### PR TITLE
feat: add fee configuration per student or class

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -5,6 +5,7 @@ const mongoose = require('mongoose');
 
 const studentRoutes = require('./routes/studentRoutes');
 const paymentRoutes = require('./routes/paymentRoutes');
+const feeRoutes = require('./routes/feeRoutes');
 
 const app = express();
 
@@ -17,6 +18,7 @@ mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost:27017/stellaredup
 
 app.use('/api/students', studentRoutes);
 app.use('/api/payments', paymentRoutes);
+app.use('/api/fees', feeRoutes);
 
 app.get('/health', (req, res) => res.json({ status: 'ok' }));
 

--- a/backend/src/controllers/feeController.js
+++ b/backend/src/controllers/feeController.js
@@ -1,0 +1,57 @@
+const FeeStructure = require('../models/feeStructureModel');
+
+// POST /api/fees — create or update a fee structure for a class
+async function createFeeStructure(req, res) {
+  try {
+    const { className, feeAmount, description, academicYear } = req.body;
+    if (!className || feeAmount == null) {
+      return res.status(400).json({ error: 'className and feeAmount are required' });
+    }
+    const fee = await FeeStructure.findOneAndUpdate(
+      { className },
+      { feeAmount, description, academicYear, isActive: true },
+      { upsert: true, new: true, runValidators: true }
+    );
+    res.status(201).json(fee);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+}
+
+// GET /api/fees — list all fee structures
+async function getAllFeeStructures(req, res) {
+  try {
+    const fees = await FeeStructure.find({ isActive: true }).sort({ className: 1 });
+    res.json(fees);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+// GET /api/fees/:className — get fee structure for a specific class
+async function getFeeByClass(req, res) {
+  try {
+    const fee = await FeeStructure.findOne({ className: req.params.className, isActive: true });
+    if (!fee) return res.status(404).json({ error: `No fee structure found for class ${req.params.className}` });
+    res.json(fee);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+// DELETE /api/fees/:className — deactivate a fee structure
+async function deleteFeeStructure(req, res) {
+  try {
+    const fee = await FeeStructure.findOneAndUpdate(
+      { className: req.params.className },
+      { isActive: false },
+      { new: true }
+    );
+    if (!fee) return res.status(404).json({ error: 'Fee structure not found' });
+    res.json({ message: `Fee structure for class ${req.params.className} deactivated` });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+}
+
+module.exports = { createFeeStructure, getAllFeeStructures, getFeeByClass, deleteFeeStructure };

--- a/backend/src/controllers/studentController.js
+++ b/backend/src/controllers/studentController.js
@@ -1,9 +1,32 @@
 const Student = require('../models/studentModel');
+const FeeStructure = require('../models/feeStructureModel');
 
-// POST /api/students
+// POST /api/students — register a new student, auto-assign fee from fee structure
 async function registerStudent(req, res) {
   try {
-    const student = await Student.create(req.body);
+    const { studentId, name, class: className, feeAmount } = req.body;
+
+    // If feeAmount is not explicitly provided, look up the fee structure for the class
+    let assignedFee = feeAmount;
+    if (assignedFee == null && className) {
+      const feeStructure = await FeeStructure.findOne({ className, isActive: true });
+      if (feeStructure) {
+        assignedFee = feeStructure.feeAmount;
+      }
+    }
+
+    if (assignedFee == null) {
+      return res.status(400).json({
+        error: `No fee amount provided and no fee structure found for class "${className}". Please create a fee structure first or provide feeAmount.`,
+      });
+    }
+
+    const student = await Student.create({
+      studentId,
+      name,
+      class: className,
+      feeAmount: assignedFee,
+    });
     res.status(201).json(student);
   } catch (err) {
     res.status(400).json({ error: err.message });

--- a/backend/src/models/feeStructureModel.js
+++ b/backend/src/models/feeStructureModel.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const feeStructureSchema = new mongoose.Schema({
+  className: { type: String, required: true, unique: true },
+  feeAmount: { type: Number, required: true },
+  description: { type: String, default: '' },
+  academicYear: { type: String, default: () => new Date().getFullYear().toString() },
+  isActive: { type: Boolean, default: true },
+}, { timestamps: true });
+
+module.exports = mongoose.model('FeeStructure', feeStructureSchema);

--- a/backend/src/models/paymentModel.js
+++ b/backend/src/models/paymentModel.js
@@ -4,6 +4,8 @@ const paymentSchema = new mongoose.Schema({
   studentId: { type: String, required: true },
   txHash: { type: String, required: true, unique: true },
   amount: { type: Number, required: true },
+  feeAmount: { type: Number, default: null },
+  feeValidationStatus: { type: String, enum: ['valid', 'underpaid', 'overpaid', 'unknown'], default: 'unknown' },
   memo: { type: String },
   confirmedAt: { type: Date, default: Date.now },
 }, { timestamps: true });

--- a/backend/src/routes/feeRoutes.js
+++ b/backend/src/routes/feeRoutes.js
@@ -1,0 +1,10 @@
+const express = require('express');
+const router = express.Router();
+const { createFeeStructure, getAllFeeStructures, getFeeByClass, deleteFeeStructure } = require('../controllers/feeController');
+
+router.post('/', createFeeStructure);
+router.get('/', getAllFeeStructures);
+router.get('/:className', getFeeByClass);
+router.delete('/:className', deleteFeeStructure);
+
+module.exports = router;

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -25,15 +25,25 @@ async function syncPayments() {
     const student = await Student.findOne({ studentId: memo });
     if (!student) continue;
 
+    const paymentAmount = parseFloat(payOp.amount);
+
+    // Validate payment amount against the student's defined fee
+    const feeValidation = validatePaymentAgainstFee(paymentAmount, student.feeAmount);
+
     await Payment.create({
       studentId: memo,
       txHash: tx.hash,
-      amount: parseFloat(payOp.amount),
+      amount: paymentAmount,
+      feeAmount: student.feeAmount,
+      feeValidationStatus: feeValidation.status,
       memo,
       confirmedAt: new Date(tx.created_at),
     });
 
-    await Student.findOneAndUpdate({ studentId: memo }, { feePaid: true });
+    // Only mark as paid if the payment meets or exceeds the required fee
+    if (feeValidation.status === 'valid' || feeValidation.status === 'overpaid') {
+      await Student.findOneAndUpdate({ studentId: memo }, { feePaid: true });
+    }
   }
 }
 
@@ -43,7 +53,49 @@ async function verifyTransaction(txHash) {
   const ops = await tx.operations();
   const payOp = ops.records.find(op => op.type === 'payment' && op.to === SCHOOL_WALLET);
   if (!payOp) return null;
-  return { hash: tx.hash, memo: tx.memo, amount: parseFloat(payOp.amount), date: tx.created_at };
+
+  const amount = parseFloat(payOp.amount);
+
+  // Look up the student to validate against their fee
+  const student = await Student.findOne({ studentId: tx.memo });
+  const feeAmount = student ? student.feeAmount : null;
+  const feeValidation = feeAmount != null
+    ? validatePaymentAgainstFee(amount, feeAmount)
+    : { status: 'unknown', message: 'Student not found, cannot validate fee' };
+
+  return {
+    hash: tx.hash,
+    memo: tx.memo,
+    amount,
+    feeAmount,
+    feeValidation,
+    date: tx.created_at,
+  };
 }
 
-module.exports = { syncPayments, verifyTransaction };
+/**
+ * Validate a payment amount against the expected fee.
+ * @param {number} paymentAmount — the amount actually paid
+ * @param {number} expectedFee — the fee the student owes
+ * @returns {{ status: string, message: string }}
+ */
+function validatePaymentAgainstFee(paymentAmount, expectedFee) {
+  if (paymentAmount < expectedFee) {
+    return {
+      status: 'underpaid',
+      message: `Payment of ${paymentAmount} is less than the required fee of ${expectedFee}`,
+    };
+  }
+  if (paymentAmount > expectedFee) {
+    return {
+      status: 'overpaid',
+      message: `Payment of ${paymentAmount} exceeds the required fee of ${expectedFee}`,
+    };
+  }
+  return {
+    status: 'valid',
+    message: 'Payment matches the required fee',
+  };
+}
+
+module.exports = { syncPayments, verifyTransaction, validatePaymentAgainstFee };

--- a/frontend/src/components/PaymentForm.jsx
+++ b/frontend/src/components/PaymentForm.jsx
@@ -47,8 +47,8 @@ export default function PaymentForm() {
 
       {student && instructions && (
         <div style={{ marginTop: '1.5rem', background: '#f5f5f5', padding: '1rem', borderRadius: 8 }}>
-          <p><strong>Student:</strong> {student.name} — {student.class}</p>
-          <p><strong>Fee Amount:</strong> {student.feeAmount} XLM</p>
+          <p><strong>Student:</strong> {student.name} — Class {student.class}</p>
+          <p><strong>Required Fee:</strong> {student.feeAmount} XLM <span style={{ fontSize: '0.8rem', color: '#888' }}>(class fee)</span></p>
           <p><strong>Status:</strong> {student.feePaid ? '✅ Paid' : '❌ Unpaid'}</p>
           <hr />
           <p><strong>Send payment to:</strong></p>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -7,3 +7,7 @@ export const getPaymentInstructions = (studentId) => api.get(`/payments/instruct
 export const getStudentPayments = (studentId) => api.get(`/payments/${studentId}`);
 export const verifyPayment = (txHash) => api.post('/payments/verify', { txHash });
 export const syncPayments = () => api.post('/payments/sync');
+export const getFeeStructures = () => api.get('/fees');
+export const createFeeStructure = (data) => api.post('/fees', data);
+export const getFeeByClass = (className) => api.get(`/fees/${className}`);
+

--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -14,6 +14,24 @@ jest.mock('../backend/src/models/paymentModel', () => ({
   create: jest.fn().mockResolvedValue({}),
 }));
 
+jest.mock('../backend/src/models/feeStructureModel', () => {
+  const mockFees = [
+    { className: '5A', feeAmount: 200, description: 'Class 5A fees', academicYear: '2026', isActive: true },
+    { className: '6B', feeAmount: 300, description: 'Class 6B fees', academicYear: '2026', isActive: true },
+  ];
+  return {
+    create: jest.fn().mockResolvedValue(mockFees[0]),
+    find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue(mockFees) }),
+    findOne: jest.fn().mockImplementation(({ className }) => {
+      const fee = mockFees.find(f => f.className === className);
+      return Promise.resolve(fee || null);
+    }),
+    findOneAndUpdate: jest.fn().mockImplementation((query, update, opts) => {
+      return Promise.resolve({ className: query.className, ...update });
+    }),
+  };
+});
+
 jest.mock('mongoose', () => ({
   connect: jest.fn().mockResolvedValue(true),
   Schema: class {
@@ -25,7 +43,9 @@ jest.mock('mongoose', () => ({
 jest.mock('../backend/src/services/stellarService', () => ({
   syncPayments: jest.fn().mockResolvedValue(),
   verifyTransaction: jest.fn().mockResolvedValue({
-    hash: 'abc123', memo: 'STU001', amount: 200, date: new Date().toISOString(),
+    hash: 'abc123', memo: 'STU001', amount: 200, feeAmount: 200,
+    feeValidation: { status: 'valid', message: 'Payment matches the required fee' },
+    date: new Date().toISOString(),
   }),
 }));
 
@@ -36,10 +56,12 @@ describe('Payment API', () => {
     expect(res.body).toHaveProperty('memo', 'STU001');
   });
 
-  test('POST /api/payments/verify returns transaction details', async () => {
+  test('POST /api/payments/verify returns transaction with fee validation', async () => {
     const res = await request(app).post('/api/payments/verify').send({ txHash: 'abc123' });
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('hash', 'abc123');
+    expect(res.body).toHaveProperty('feeAmount', 200);
+    expect(res.body.feeValidation).toHaveProperty('status', 'valid');
   });
 
   test('POST /api/payments/sync returns success message', async () => {
@@ -48,9 +70,46 @@ describe('Payment API', () => {
     expect(res.body).toHaveProperty('message', 'Sync complete');
   });
 
-  test('GET /api/students/:studentId returns student', async () => {
+  test('GET /api/students/:studentId returns student with feeAmount', async () => {
     const res = await request(app).get('/api/students/STU001');
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('studentId', 'STU001');
+    expect(res.body).toHaveProperty('feeAmount', 200);
+  });
+});
+
+describe('Fee Structure API', () => {
+  test('POST /api/fees creates a fee structure', async () => {
+    const res = await request(app).post('/api/fees').send({
+      className: '5A', feeAmount: 200, description: 'Class 5A fees',
+    });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('className', '5A');
+    expect(res.body).toHaveProperty('feeAmount', 200);
+  });
+
+  test('GET /api/fees returns all fee structures', async () => {
+    const res = await request(app).get('/api/fees');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('GET /api/fees/:className returns fee for a specific class', async () => {
+    const res = await request(app).get('/api/fees/5A');
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('className', '5A');
+    expect(res.body).toHaveProperty('feeAmount', 200);
+  });
+
+  test('GET /api/fees/:className returns 404 for unknown class', async () => {
+    const res = await request(app).get('/api/fees/UNKNOWN');
+    expect(res.status).toBe(404);
+  });
+
+  test('POST /api/fees rejects missing required fields', async () => {
+    const res = await request(app).post('/api/fees').send({ description: 'No class' });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
   });
 });

--- a/tests/stellar.test.js
+++ b/tests/stellar.test.js
@@ -1,4 +1,4 @@
-const { verifyTransaction, syncPayments } = require('../backend/src/services/stellarService');
+const { verifyTransaction, syncPayments, validatePaymentAgainstFee } = require('../backend/src/services/stellarService');
 
 jest.mock('../backend/src/config/stellarConfig', () => ({
   SCHOOL_WALLET: 'GTEST123',
@@ -13,7 +13,7 @@ jest.mock('../backend/src/config/stellarConfig', () => ({
           memo: 'STU001',
           created_at: new Date().toISOString(),
           operations: async () => ({
-            records: [{ type: 'payment', to: 'GTEST123', amount: '100.0' }],
+            records: [{ type: 'payment', to: 'GTEST123', amount: '200.0' }],
           }),
         }),
       }),
@@ -28,7 +28,7 @@ jest.mock('../backend/src/models/paymentModel', () => ({
 }));
 
 jest.mock('../backend/src/models/studentModel', () => ({
-  findOne: jest.fn().mockResolvedValue({ studentId: 'STU001' }),
+  findOne: jest.fn().mockResolvedValue({ studentId: 'STU001', feeAmount: 200 }),
   findOneAndUpdate: jest.fn().mockResolvedValue({}),
 }));
 
@@ -37,8 +37,31 @@ describe('stellarService', () => {
     await expect(syncPayments()).resolves.toBeUndefined();
   });
 
-  test('verifyTransaction returns payment details', async () => {
+  test('verifyTransaction returns payment details with fee validation', async () => {
     const result = await verifyTransaction('abc123');
-    expect(result).toMatchObject({ hash: 'abc123', memo: 'STU001', amount: 100 });
+    expect(result).toMatchObject({
+      hash: 'abc123',
+      memo: 'STU001',
+      amount: 200,
+      feeAmount: 200,
+    });
+    expect(result.feeValidation).toHaveProperty('status', 'valid');
+  });
+});
+
+describe('validatePaymentAgainstFee', () => {
+  test('returns valid when payment matches fee', () => {
+    const result = validatePaymentAgainstFee(200, 200);
+    expect(result.status).toBe('valid');
+  });
+
+  test('returns underpaid when payment is less than fee', () => {
+    const result = validatePaymentAgainstFee(150, 200);
+    expect(result.status).toBe('underpaid');
+  });
+
+  test('returns overpaid when payment exceeds fee', () => {
+    const result = validatePaymentAgainstFee(250, 200);
+    expect(result.status).toBe('overpaid');
   });
 });


### PR DESCRIPTION
- Add FeeStructure model (class-based fee amounts with academic year)
- Add fee CRUD API (POST/GET/DELETE /api/fees)
- Auto-assign fee to students from class fee structure on registration
- Validate payments against student's defined fee (valid/underpaid/overpaid)
- Only mark student as paid when payment meets or exceeds required fee
- Add feeAmount and feeValidationStatus fields to payment model
- Update frontend to show class-based fee info
- Add fee structure API calls to frontend service
- Comprehensive test coverage (14 tests, all passing)

resolves #19 