### PR TITLE
feat: add unit tests for stellar service (#11)

### DIFF
--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -1,127 +1,175 @@
 const request = require('supertest');
 const app = require('../backend/src/app');
 
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockStudent = { studentId: 'STU001', name: 'Alice', class: '5A', feeAmount: 200, feePaid: false };
+const mockFee = { className: '5A', feeAmount: 200, description: 'Class 5A fees', academicYear: '2026', isActive: true };
+
 jest.mock('../backend/src/models/studentModel', () => ({
   create: jest.fn().mockResolvedValue({ studentId: 'STU001', name: 'Alice', class: '5A', feeAmount: 200, feePaid: false }),
-  find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue([]) }),
+  find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue([{ studentId: 'STU001', name: 'Alice', class: '5A', feeAmount: 200, feePaid: false }]) }),
   findOne: jest.fn().mockResolvedValue({ studentId: 'STU001', name: 'Alice', class: '5A', feeAmount: 200, feePaid: false }),
   findOneAndUpdate: jest.fn().mockResolvedValue({}),
 }));
 
 jest.mock('../backend/src/models/paymentModel', () => ({
-  find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue([]) }),
+  find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue([{ studentId: 'STU001', txHash: 'abc123', amount: 200 }]) }),
   findOne: jest.fn().mockResolvedValue(null),
   create: jest.fn().mockResolvedValue({}),
 }));
 
-jest.mock('../backend/src/models/feeStructureModel', () => {
-  const mockFees = [
+jest.mock('../backend/src/models/feeStructureModel', () => ({
+  create: jest.fn().mockResolvedValue({ className: '5A', feeAmount: 200, description: 'Class 5A fees', academicYear: '2026', isActive: true }),
+  find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue([
     { className: '5A', feeAmount: 200, description: 'Class 5A fees', academicYear: '2026', isActive: true },
     { className: '6B', feeAmount: 300, description: 'Class 6B fees', academicYear: '2026', isActive: true },
-  ];
-  return {
-    create: jest.fn().mockResolvedValue(mockFees[0]),
-    find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue(mockFees) }),
-    findOne: jest.fn().mockImplementation(({ className }) => {
-      const fee = mockFees.find(f => f.className === className);
-      return Promise.resolve(fee || null);
-    }),
-    findOneAndUpdate: jest.fn().mockImplementation((query, update, opts) => {
-      return Promise.resolve({ className: query.className, ...update });
-    }),
-  };
-});
+  ]) }),
+  findOne: jest.fn().mockImplementation(({ className }) => {
+    const fees = { '5A': { className: '5A', feeAmount: 200, isActive: true }, '6B': { className: '6B', feeAmount: 300, isActive: true } };
+    return Promise.resolve(fees[className] || null);
+  }),
+  findOneAndUpdate: jest.fn().mockImplementation((query, update) =>
+    Promise.resolve({ className: query.className, ...update })
+  ),
+}));
 
 jest.mock('mongoose', () => ({
   connect: jest.fn().mockResolvedValue(true),
-  Schema: class {
-    constructor() { this.index = jest.fn(); }
-  },
+  Schema: class { constructor() { this.index = jest.fn(); } },
   model: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('../backend/src/services/stellarService', () => ({
   syncPayments: jest.fn().mockResolvedValue(),
   verifyTransaction: jest.fn().mockResolvedValue({
-    hash: 'abc123', memo: 'STU001', amount: 200, feeAmount: 200,
+    hash: 'abc123',
+    memo: 'STU001',
+    amount: 200,
+    feeAmount: 200,
     feeValidation: { status: 'valid', message: 'Payment matches the required fee' },
     date: new Date().toISOString(),
   }),
 }));
 
-describe('Payment API', () => {
-  test('GET /api/payments/instructions/:studentId returns wallet info with accepted assets', async () => {
+// ─── Full Payment Flow ────────────────────────────────────────────────────────
+
+describe('Full payment flow', () => {
+  test('Step 1 — register student', async () => {
+    const res = await request(app).post('/api/students').send({
+      studentId: 'STU001', name: 'Alice', class: '5A', feeAmount: 200,
+    });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ studentId: 'STU001', feeAmount: 200 });
+  });
+
+  test('Step 2 — get payment instructions', async () => {
     const res = await request(app).get('/api/payments/instructions/STU001');
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('memo', 'STU001');
-    expect(res.body).toHaveProperty('acceptedAssets');
-    expect(Array.isArray(res.body.acceptedAssets)).toBe(true);
-    expect(res.body.acceptedAssets.length).toBeGreaterThanOrEqual(1);
+    expect(res.body).toHaveProperty('note');
     expect(res.body.acceptedAssets.some(a => a.code === 'XLM')).toBe(true);
   });
 
-  test('POST /api/payments/verify returns transaction with fee validation', async () => {
+  test('Step 3 — verify transaction after payment', async () => {
     const res = await request(app).post('/api/payments/verify').send({ txHash: 'abc123' });
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('hash', 'abc123');
-    expect(res.body).toHaveProperty('feeAmount', 200);
-    expect(res.body.feeValidation).toHaveProperty('status', 'valid');
+    expect(res.body).toMatchObject({ hash: 'abc123', memo: 'STU001', amount: 200 });
+    expect(res.body.feeValidation.status).toBe('valid');
   });
 
-  test('POST /api/payments/sync returns success message', async () => {
+  test('Step 4 — payment history reflects the transaction', async () => {
+    const res = await request(app).get('/api/payments/STU001');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toHaveProperty('txHash', 'abc123');
+  });
+});
+
+// ─── Student API ──────────────────────────────────────────────────────────────
+
+describe('Student API', () => {
+  test('POST /api/students — creates a student', async () => {
+    const res = await request(app).post('/api/students').send({
+      studentId: 'STU001', name: 'Alice', class: '5A', feeAmount: 200,
+    });
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('studentId', 'STU001');
+  });
+
+  test('GET /api/students — returns all students', async () => {
+    const res = await request(app).get('/api/students');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  test('GET /api/students/:studentId — returns a student', async () => {
+    const res = await request(app).get('/api/students/STU001');
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ studentId: 'STU001', feeAmount: 200 });
+  });
+
+  test('GET /api/students/:studentId — 404 for unknown student', async () => {
+    const Student = require('../backend/src/models/studentModel');
+    Student.findOne.mockResolvedValueOnce(null);
+    const res = await request(app).get('/api/students/UNKNOWN');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─── Payment API ──────────────────────────────────────────────────────────────
+
+describe('Payment API', () => {
+  test('POST /api/payments/sync — returns success', async () => {
     const res = await request(app).post('/api/payments/sync');
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty('message', 'Sync complete');
   });
 
-  test('GET /api/students/:studentId returns student with feeAmount', async () => {
-    const res = await request(app).get('/api/students/STU001');
+  test('POST /api/payments/verify — 404 when transaction not found', async () => {
+    const { verifyTransaction } = require('../backend/src/services/stellarService');
+    verifyTransaction.mockResolvedValueOnce(null);
+    const res = await request(app).post('/api/payments/verify').send({ txHash: 'bad_hash' });
+    expect(res.status).toBe(404);
+  });
+
+  test('GET /api/payments/accepted-assets — returns XLM and USDC', async () => {
+    const res = await request(app).get('/api/payments/accepted-assets');
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('studentId', 'STU001');
-    expect(res.body).toHaveProperty('feeAmount', 200);
+    expect(res.body.assets.map(a => a.code)).toEqual(expect.arrayContaining(['XLM', 'USDC']));
   });
 });
 
+// ─── Fee Structure API ────────────────────────────────────────────────────────
+
 describe('Fee Structure API', () => {
-  test('POST /api/fees creates a fee structure', async () => {
-    const res = await request(app).post('/api/fees').send({
-      className: '5A', feeAmount: 200, description: 'Class 5A fees',
-    });
+  test('POST /api/fees — creates a fee structure', async () => {
+    const res = await request(app).post('/api/fees').send({ className: '5A', feeAmount: 200 });
     expect(res.status).toBe(201);
-    expect(res.body).toHaveProperty('className', '5A');
-    expect(res.body).toHaveProperty('feeAmount', 200);
+    expect(res.body).toMatchObject({ className: '5A', feeAmount: 200 });
   });
 
-  test('GET /api/fees returns all fee structures', async () => {
+  test('POST /api/fees — 400 when required fields missing', async () => {
+    const res = await request(app).post('/api/fees').send({ description: 'No class' });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  test('GET /api/fees — returns all fee structures', async () => {
     const res = await request(app).get('/api/fees');
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
     expect(res.body.length).toBeGreaterThanOrEqual(1);
   });
 
-  test('GET /api/fees/:className returns fee for a specific class', async () => {
+  test('GET /api/fees/:className — returns fee for class', async () => {
     const res = await request(app).get('/api/fees/5A');
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('className', '5A');
-    expect(res.body).toHaveProperty('feeAmount', 200);
+    expect(res.body).toMatchObject({ className: '5A', feeAmount: 200 });
   });
 
-  test('GET /api/fees/:className returns 404 for unknown class', async () => {
+  test('GET /api/fees/:className — 404 for unknown class', async () => {
     const res = await request(app).get('/api/fees/UNKNOWN');
     expect(res.status).toBe(404);
-  });
-
-  test('POST /api/fees rejects missing required fields', async () => {
-    const res = await request(app).post('/api/fees').send({ description: 'No class' });
-    expect(res.status).toBe(400);
-    expect(res.body).toHaveProperty('error');
-  });
-
-  test('GET /api/payments/accepted-assets returns list of accepted assets', async () => {
-    const res = await request(app).get('/api/payments/accepted-assets');
-    expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty('assets');
-    expect(res.body.assets.some(a => a.code === 'XLM')).toBe(true);
-    expect(res.body.assets.some(a => a.code === 'USDC')).toBe(true);
   });
 });

--- a/tests/stellar.test.js
+++ b/tests/stellar.test.js
@@ -1,19 +1,25 @@
-const { verifyTransaction, syncPayments, validatePaymentAgainstFee } = require('../backend/src/services/stellarService');
+const {
+  verifyTransaction,
+  syncPayments,
+  validatePaymentAgainstFee,
+  detectAsset,
+  normalizeAmount,
+} = require('../backend/src/services/stellarService');
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockOperations = jest.fn();
 
 jest.mock('../backend/src/config/stellarConfig', () => ({
   SCHOOL_WALLET: 'GTEST123',
   ACCEPTED_ASSETS: {
-    XLM: { code: 'XLM', type: 'native', issuer: null, displayName: 'Stellar Lumens', decimals: 7 },
-    USDC: { code: 'USDC', type: 'credit_alphanum4', issuer: 'GISSUER', displayName: 'USD Coin', decimals: 7 },
+    XLM: { code: 'XLM', type: 'native', issuer: null },
+    USDC: { code: 'USDC', type: 'credit_alphanum4', issuer: 'GISSUER' },
   },
   isAcceptedAsset: (code, type) => {
-    const assets = {
-      XLM: { code: 'XLM', type: 'native' },
-      USDC: { code: 'USDC', type: 'credit_alphanum4' },
-    };
-    const asset = assets[code];
-    if (!asset || asset.type !== type) return { accepted: false, asset: null };
-    return { accepted: true, asset };
+    const map = { XLM: 'native', USDC: 'credit_alphanum4' };
+    if (map[code] && map[code] === type) return { accepted: true, asset: { code, type } };
+    return { accepted: false, asset: null };
   },
   server: {
     transactions: () => ({
@@ -25,95 +31,149 @@ jest.mock('../backend/src/config/stellarConfig', () => ({
           hash,
           memo: 'STU001',
           created_at: new Date().toISOString(),
-          operations: async () => ({
-<<<<<<< feature/multi-asset-payment-support
-            records: [{ type: 'payment', to: 'GTEST123', amount: '100.0000000', asset_type: 'native' }],
-=======
-            records: [{ type: 'payment', to: 'GTEST123', amount: '200.0' }],
->>>>>>> main
-          }),
+          operations: mockOperations,
         }),
       }),
     }),
   },
 }));
 
+const Payment = require('../backend/src/models/paymentModel');
+const Student = require('../backend/src/models/studentModel');
+
 jest.mock('../backend/src/models/paymentModel', () => ({
-  findOne: jest.fn().mockResolvedValue(null),
+  findOne: jest.fn(),
   create: jest.fn().mockResolvedValue({}),
-  find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue([]) }),
 }));
 
 jest.mock('../backend/src/models/studentModel', () => ({
-  findOne: jest.fn().mockResolvedValue({ studentId: 'STU001', feeAmount: 200 }),
+  findOne: jest.fn(),
   findOneAndUpdate: jest.fn().mockResolvedValue({}),
 }));
 
-describe('stellarService', () => {
-  test('syncPayments runs without error', async () => {
-    await expect(syncPayments()).resolves.toBeUndefined();
+// ─── validatePaymentAgainstFee ────────────────────────────────────────────────
+
+describe('validatePaymentAgainstFee', () => {
+  test('valid when payment equals fee', () => {
+    expect(validatePaymentAgainstFee(200, 200).status).toBe('valid');
   });
 
-<<<<<<< feature/multi-asset-payment-support
-  test('verifyTransaction returns payment details with asset info', async () => {
-=======
-  test('verifyTransaction returns payment details with fee validation', async () => {
->>>>>>> main
-    const result = await verifyTransaction('abc123');
-    expect(result).toMatchObject({
-      hash: 'abc123',
-      memo: 'STU001',
-<<<<<<< feature/multi-asset-payment-support
-      amount: 100,
-      assetCode: 'XLM',
-      assetType: 'native',
-    });
+  test('underpaid when payment is less than fee', () => {
+    expect(validatePaymentAgainstFee(150, 200).status).toBe('underpaid');
   });
 
-  test('detectAsset returns null for unsupported asset', () => {
-    const payOp = { asset_type: 'credit_alphanum4', asset_code: 'SHIB', asset_issuer: 'GRANDOM' };
-    const result = detectAsset(payOp);
-    expect(result).toBeNull();
+  test('overpaid when payment exceeds fee', () => {
+    expect(validatePaymentAgainstFee(250, 200).status).toBe('overpaid');
   });
 
-  test('detectAsset recognizes native XLM', () => {
-    const payOp = { asset_type: 'native' };
-    const result = detectAsset(payOp);
-    expect(result).toEqual({ assetCode: 'XLM', assetType: 'native', assetIssuer: null });
-  });
-
-  test('detectAsset recognizes USDC', () => {
-    const payOp = { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: 'GISSUER' };
-    const result = detectAsset(payOp);
-    expect(result).toEqual({ assetCode: 'USDC', assetType: 'credit_alphanum4', assetIssuer: 'GISSUER' });
-  });
-
-  test('normalizeAmount formats amounts consistently', () => {
-    expect(normalizeAmount('100.123456789')).toBe(100.1234568);
-    expect(normalizeAmount('200')).toBe(200.0);
-    expect(normalizeAmount('0.0000001')).toBe(0.0000001);
-=======
-      amount: 200,
-      feeAmount: 200,
-    });
-    expect(result.feeValidation).toHaveProperty('status', 'valid');
+  test('messages include the amounts', () => {
+    expect(validatePaymentAgainstFee(50, 200).message).toContain('50');
+    expect(validatePaymentAgainstFee(50, 200).message).toContain('200');
   });
 });
 
-describe('validatePaymentAgainstFee', () => {
-  test('returns valid when payment matches fee', () => {
-    const result = validatePaymentAgainstFee(200, 200);
-    expect(result.status).toBe('valid');
+// ─── detectAsset ─────────────────────────────────────────────────────────────
+
+describe('detectAsset', () => {
+  test('recognizes native XLM', () => {
+    expect(detectAsset({ asset_type: 'native' })).toEqual({
+      assetCode: 'XLM',
+      assetType: 'native',
+      assetIssuer: null,
+    });
   });
 
-  test('returns underpaid when payment is less than fee', () => {
-    const result = validatePaymentAgainstFee(150, 200);
-    expect(result.status).toBe('underpaid');
+  test('recognizes USDC', () => {
+    expect(detectAsset({ asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: 'GISSUER' })).toEqual({
+      assetCode: 'USDC',
+      assetType: 'credit_alphanum4',
+      assetIssuer: 'GISSUER',
+    });
   });
 
-  test('returns overpaid when payment exceeds fee', () => {
-    const result = validatePaymentAgainstFee(250, 200);
-    expect(result.status).toBe('overpaid');
->>>>>>> main
+  test('returns null for unsupported asset', () => {
+    expect(detectAsset({ asset_type: 'credit_alphanum4', asset_code: 'SHIB', asset_issuer: 'GRANDOM' })).toBeNull();
+  });
+
+  test('returns null when asset type does not match', () => {
+    // XLM code but wrong type
+    expect(detectAsset({ asset_type: 'credit_alphanum4', asset_code: 'XLM', asset_issuer: 'GISSUER' })).toBeNull();
+  });
+});
+
+// ─── normalizeAmount ──────────────────────────────────────────────────────────
+
+describe('normalizeAmount', () => {
+  test('rounds to 7 decimal places', () => {
+    expect(normalizeAmount('100.123456789')).toBe(100.1234568);
+  });
+
+  test('handles whole numbers', () => {
+    expect(normalizeAmount('200')).toBe(200.0);
+  });
+
+  test('handles smallest XLM unit', () => {
+    expect(normalizeAmount('0.0000001')).toBe(0.0000001);
+  });
+});
+
+// ─── verifyTransaction ────────────────────────────────────────────────────────
+
+describe('verifyTransaction', () => {
+  beforeEach(() => {
+    Student.findOne.mockResolvedValue({ studentId: 'STU001', feeAmount: 100 });
+  });
+
+  test('returns payment details for a valid XLM transaction', async () => {
+    mockOperations.mockResolvedValue({
+      records: [{ type: 'payment', to: 'GTEST123', amount: '100.0000000', asset_type: 'native' }],
+    });
+
+    const result = await verifyTransaction('abc123');
+    expect(result).toMatchObject({ hash: 'abc123', memo: 'STU001', amount: 100 });
+    expect(result.feeValidation.status).toBe('valid');
+  });
+
+  test('returns null when no matching payment operation exists', async () => {
+    mockOperations.mockResolvedValue({ records: [] });
+    const result = await verifyTransaction('abc123');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when payment is to a different wallet', async () => {
+    mockOperations.mockResolvedValue({
+      records: [{ type: 'payment', to: 'GOTHER999', amount: '100.0', asset_type: 'native' }],
+    });
+    const result = await verifyTransaction('abc123');
+    expect(result).toBeNull();
+  });
+
+  test('feeValidation status is unknown when student not found', async () => {
+    Student.findOne.mockResolvedValue(null);
+    mockOperations.mockResolvedValue({
+      records: [{ type: 'payment', to: 'GTEST123', amount: '100.0', asset_type: 'native' }],
+    });
+
+    const result = await verifyTransaction('abc123');
+    expect(result.feeValidation.status).toBe('unknown');
+  });
+
+  test('still returns details for unsupported asset (verifyTransaction does not filter by asset)', async () => {
+    // verifyTransaction does not call detectAsset — it returns details regardless of asset type.
+    // Asset filtering only happens in syncPayments. This test documents that behaviour.
+    mockOperations.mockResolvedValue({
+      records: [{ type: 'payment', to: 'GTEST123', amount: '100.0', asset_type: 'credit_alphanum4', asset_code: 'SHIB', asset_issuer: 'GRANDOM' }],
+    });
+    const result = await verifyTransaction('abc123');
+    expect(result).not.toBeNull();
+    expect(result.amount).toBe(100);
+  });
+});
+
+// ─── syncPayments ─────────────────────────────────────────────────────────────
+
+describe('syncPayments', () => {
+  test('resolves without error when no transactions exist', async () => {
+    await expect(syncPayments()).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION

Replaces the conflict-ridden stellar.test.js with clean, fully passing tests.

Coverage:
- validatePaymentAgainstFee — valid, underpaid, overpaid
- detectAsset — XLM, USDC, unsupported, type mismatch
- normalizeAmount — rounding, edge values
- verifyTransaction — happy path, no ops, wrong wallet, missing student
- syncPayments — empty ledger

All Stellar SDK and DB calls are mocked. No real network calls. 17/17 tests pass.

closes #11 