### PR TITLE
Handle long-running requests with timeout limits    

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -28,3 +28,10 @@ RETRY_INTERVAL_MS=60000
 
 # Maximum number of retry attempts before a transaction is dead-lettered (default: 10)
 RETRY_MAX_ATTEMPTS=10
+
+# ── Timeouts ──────────────────────────────────────────────────
+# Maximum time (ms) for an inbound HTTP request before the server returns 503 (default: 30000)
+REQUEST_TIMEOUT_MS=30000
+
+# Maximum time (ms) for a single outbound Stellar Horizon API call (default: 10000)
+STELLAR_TIMEOUT_MS=10000

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -16,6 +16,17 @@ const app = express();
 app.use(cors());
 app.use(express.json());
 
+// ── Request timeout ───────────────────────────────────────────────────────────
+// If a response has not been sent within REQUEST_TIMEOUT_MS, reply 503.
+app.use((req, res, next) => {
+  res.setTimeout(config.REQUEST_TIMEOUT_MS, () => {
+    const err = new Error(`Request timed out after ${config.REQUEST_TIMEOUT_MS}ms`);
+    err.code = 'REQUEST_TIMEOUT';
+    next(err);
+  });
+  next();
+});
+
 mongoose.connect(config.MONGO_URI)
   .then(() => {
     console.log('MongoDB connected');
@@ -42,6 +53,7 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
     NOT_FOUND: 404,
     VALIDATION_ERROR: 400,
     STELLAR_NETWORK_ERROR: 502,
+    REQUEST_TIMEOUT: 503,
   };
   const status = statusMap[err.code] || err.status || 500;
   console.error(`[${err.code || 'ERROR'}] ${err.message}`);

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -53,6 +53,14 @@ const CONFIRMATION_THRESHOLD = parseInt(process.env.CONFIRMATION_THRESHOLD || '2
 // ── Polling ───────────────────────────────────────────────────────────────────
 const POLL_INTERVAL_MS = parseInt(process.env.POLL_INTERVAL_MS || '30000', 10);
 
+// ── Timeouts ──────────────────────────────────────────────────────────────────
+// Maximum time (ms) an incoming HTTP request may remain open before the server
+// responds with 503. Covers slow Stellar/DB calls on any route.
+const REQUEST_TIMEOUT_MS = parseInt(process.env.REQUEST_TIMEOUT_MS || '30000', 10);
+
+// Maximum time (ms) allowed for a single outbound Stellar Horizon API call.
+const STELLAR_TIMEOUT_MS = parseInt(process.env.STELLAR_TIMEOUT_MS || '10000', 10);
+
 // ── Freeze to prevent accidental mutation at runtime ─────────────────────────
 const config = Object.freeze({
   PORT,
@@ -64,6 +72,8 @@ const config = Object.freeze({
   USDC_ISSUER,
   CONFIRMATION_THRESHOLD,
   POLL_INTERVAL_MS,
+  REQUEST_TIMEOUT_MS,
+  STELLAR_TIMEOUT_MS,
 });
 
 module.exports = config;

--- a/backend/src/config/stellarConfig.js
+++ b/backend/src/config/stellarConfig.js
@@ -3,7 +3,9 @@
 const StellarSdk = require('@stellar/stellar-sdk');
 const config = require('./index');
 
-const server = new StellarSdk.Horizon.Server(config.HORIZON_URL);
+const server = new StellarSdk.Horizon.Server(config.HORIZON_URL, {
+  timeout: config.STELLAR_TIMEOUT_MS,
+});
 
 const networkPassphrase = config.IS_TESTNET
   ? StellarSdk.Networks.TESTNET

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,6 +1,11 @@
 import axios from 'axios';
 
-const api = axios.create({ baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api' });
+const TIMEOUT_MS = parseInt(process.env.NEXT_PUBLIC_REQUEST_TIMEOUT_MS || '15000', 10);
+
+const api = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api',
+  timeout: TIMEOUT_MS,
+});
 
 export const getStudent = (studentId) => api.get(`/students/${studentId}`);
 export const getPaymentInstructions = (studentId) => api.get(`/payments/instructions/${studentId}`);


### PR DESCRIPTION
closes #95 
                                                                                
  Requests to the Stellar Horizon API (and slow DB queries) could hang          
  indefinitely, leaving clients waiting and server resources held open. This PR 
  adds timeout enforcement at every layer of the stack.                         
                  
  Changes

  Backend
  - app.js — Added request timeout middleware using res.setTimeout. Any inbound
  request that hasn't received a response within REQUEST_TIMEOUT_MS (default:   
  30s) is terminated with a 503 Service Unavailable error via the existing   
  global error handler.                                                         
  - config/stellarConfig.js — Passes timeout: STELLAR_TIMEOUT_MS (default: 10s)
  to the Horizon.Server constructor, so outbound Stellar API calls are aborted 
  at the SDK level if they stall.                                               
  - config/index.js — Adds REQUEST_TIMEOUT_MS and STELLAR_TIMEOUT_MS as
  configurable values read from env vars.                                       
                                                                                
  Frontend
  - services/api.js — Axios instance now sets timeout: 15000ms (configurable via
   NEXT_PUBLIC_REQUEST_TIMEOUT_MS), so UI requests fail fast rather than hanging
   indefinitely.
                                                                                
  Config / Docs   
  - backend/.env.example — Documents both new timeout env vars with their
  defaults.                                                                     
  
  Defaults                                                                      
                  
  ┌────────────────────────────────┬──────────┬────────────────────────────┐    
  │            Variable            │ Default  │           Scope            │
  ├────────────────────────────────┼──────────┼────────────────────────────┤    
  │ REQUEST_TIMEOUT_MS             │ 30,000ms │ Inbound HTTP requests      │
  ├────────────────────────────────┼──────────┼────────────────────────────┤
  │ STELLAR_TIMEOUT_MS             │ 10,000ms │ Outbound Horizon API calls │
  ├────────────────────────────────┼──────────┼────────────────────────────┤    
  │ NEXT_PUBLIC_REQUEST_TIMEOUT_MS │ 15,000ms │ Frontend axios calls       │
  └────────────────────────────────┴──────────┴────────────────────────────┘ 