### PR TITLE
feat: added rate limiter globally

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -51,6 +51,9 @@ const concurrentMiddleware = createConcurrentRequestMiddleware({
   deduplicationTtlMs: 60000
 });
 
+// Apply rate limiting globally (throttle by IP: 100 req / 60 s)
+app.use(concurrentMiddleware.rateLimiter((req) => req.ip));
+
 // Apply request queue middleware globally
 app.use(concurrentMiddleware.requestQueue());
 


### PR DESCRIPTION
**Summary**
- Applies the existing rateLimiter middleware globally in app.js, throttling all API endpoints to 100 requests per 60 seconds per IP
- Rate limiter runs before the request queue, so excess requests are rejected early without consuming queue capacity
- Returns 429 Too Many Requests with a Retry-After header when the limit is exceeded
- Sets X-RateLimit-Limit, X-RateLimit-Remaining, and X-RateLimit-Reset headers on every response

**Changes**
- backend/src/app.js — one line added to wire concurrentMiddleware.rateLimiter() globally

**Notes**
The rate limiter implementation already existed in concurrentRequestHandler.js and was used only for the createConcurrentPaymentRoutes helper. This PR promotes it to global middleware so all routes (schools, students, payments, fees, reports) are protected without duplicating any logic.

Limits are driven by the existing rateLimit config passed to createConcurrentRequestMiddleware (windowMs: 60000, maxRequests: 100) and can be tuned via that config or environment variables.

closes #60 