### PR TITLE
feat: add payment intent expiry

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -113,7 +113,9 @@ async function createPaymentIntent(req, res, next) {
     }
 
     const memo = crypto.randomBytes(4).toString('hex').toUpperCase();
-    
+    const ttlMs = parseInt(process.env.PAYMENT_INTENT_TTL_MS, 10) || 24 * 60 * 60 * 1000;
+    const expiresAt = new Date(Date.now() + ttlMs);
+
     // We now use the Payment model to track the initial 'PENDING' intent.
     const payment = await Payment.create({
       studentId: student._id,
@@ -123,6 +125,7 @@ async function createPaymentIntent(req, res, next) {
       amount: student.feeAmount,
       memo,
       status: 'PENDING',
+      expiresAt,
       startedAt: new Date(),
     });
 
@@ -308,6 +311,18 @@ async function verifyPayment(req, res, next) {
     const studentObj = await Student.findOne({ studentId: studentStrId });
     if (!studentObj) {
       return res.status(404).json({ error: 'Associated student not found. Cannot record transaction.' });
+    }
+
+    // Reject if the payment intent has expired
+    const intent = await PaymentIntent.findOne({ memo: result.memo, schoolId });
+    if (intent) {
+      if (intent.expiresAt && intent.expiresAt < new Date()) {
+        await PaymentIntent.findByIdAndUpdate(intent._id, { status: 'expired' });
+        const err = new Error('Payment intent has expired. Please request new payment instructions.');
+        err.code = 'INTENT_EXPIRED';
+        err.status = 410;
+        return next(err);
+      }
     }
 
     await recordPayment({

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -115,6 +115,12 @@ async function syncPayments() {
     const intent = await PaymentIntent.findOne({ memo, status: 'pending' });
     if (!intent) continue;
 
+    // Reject expired intents
+    if (intent.expiresAt && intent.expiresAt < new Date(tx.created_at)) {
+      await PaymentIntent.findByIdAndUpdate(intent._id, { status: 'expired' });
+      continue;
+    }
+
     const student = await Student.findOne({ studentId: intent.studentId });
     if (!student) continue;
 


### PR DESCRIPTION
## Summary
Payment instructions now expire after a configurable period. Expired intents are rejected at both the sync and manual verify stages.

## Changes
- `paymentController.js` — set `expiresAt` on intent creation
- `stellarService.js` — reject expired intents during `syncPayments`
- `paymentController.js` — reject expired intents in `verifyPayment`

## How It Works

**Creation**
`expiresAt` is set when a payment intent is created:
```
expiresAt = now + PAYMENT_INTENT_TTL_MS   (default: 24 hours)
```

**Sync path (`POST /api/payments/sync`)**
If the transaction's `created_at` is after `expiresAt`, the intent is marked `expired` and the payment is skipped.

**Verify path (`POST /api/payments/verify`)**
If the intent is expired at verification time, returns:
```json
{ "error": "Payment intent has expired. Please request new payment instructions.", "code": "INTENT_EXPIRED" }
```
HTTP 410 Gone.

## Configuration
```
PAYMENT_INTENT_TTL_MS=86400000   # default: 24 hours
```

## Acceptance Criteria
- ✅ Expired payment intents are invalid and rejected
- ✅ Intent status updated to `expired` in the database
- ✅ TTL is configurable via environment variable

closes #28