### PR TITLE
feat: support testnet/mainnet switching via STELLAR_NETWORK config

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -165,12 +165,16 @@ app.get('/health', async (req, res) => {
     const retryQueueStatus = await getSystemStatus();
     res.json({
       status: 'ok',
+      network: config.STELLAR_NETWORK,
+      horizonUrl: config.HORIZON_URL,
       retryQueue: retryQueueStatus,
       timestamp: new Date().toISOString(),
     });
   } catch (error) {
     res.json({
       status: 'ok',
+      network: config.STELLAR_NETWORK,
+      horizonUrl: config.HORIZON_URL,
       retryQueue: { error: error.message },
       timestamp: new Date().toISOString(),
     });

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -138,7 +138,7 @@ async function submitTransaction(req, res, next) {
     }
 
     // Decode the transaction from the base64 XDR string
-    const tx = new StellarSdk.Transaction(xdr, StellarSdk.Networks.TESTNET); // or networkPassphrase
+    const tx = new StellarSdk.Transaction(xdr, require('../config/stellarConfig').networkPassphrase);
     const transactionHash = tx.hash().toString('hex');
     const memo = tx.memo.value ? tx.memo.value.toString() : null;
 


### PR DESCRIPTION
Title: feat: support testnet and mainnet switching

Description:

Completes the testnet/mainnet toggle so the system runs correctly on both Stellar networks.

Changes:

- paymentController.js — fixed submitTransaction which hardcoded StellarSdk.Networks.TESTNET when decoding XDR. Now 
uses networkPassphrase from stellarConfig, which resolves to the correct passphrase based on STELLAR_NETWORK
- app.js — /health endpoint now includes network and horizonUrl fields so the active network is observable at runtime

Usage:

bash
STELLAR_NETWORK=testnet   # default — uses horizon-testnet.stellar.org
STELLAR_NETWORK=mainnet   # production — uses horizon.stellar.org

closes #56