### PR TITLE
Feat/fee validation

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -189,6 +189,7 @@ app.use((err, req, res, next) => { // eslint-disable-line no-unused-vars
     INVALID_DESTINATION:    400,
     UNSUPPORTED_ASSET:      400,
     VALIDATION_ERROR:       400,
+    UNDERPAID:              400,
     MISSING_SCHOOL_CONTEXT: 400,
     MISSING_IDEMPOTENCY_KEY:400,
     DUPLICATE_TX:           409,

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -31,7 +31,7 @@ const { getPaymentLimits } = require('../utils/paymentLimits');
 const crypto = require('crypto');
 
 // Permanent error codes that should NOT be retried
-const PERMANENT_FAIL_CODES = ['TX_FAILED', 'MISSING_MEMO', 'INVALID_DESTINATION', 'UNSUPPORTED_ASSET', 'AMOUNT_TOO_LOW', 'AMOUNT_TOO_HIGH'];
+const PERMANENT_FAIL_CODES = ['TX_FAILED', 'MISSING_MEMO', 'INVALID_DESTINATION', 'UNSUPPORTED_ASSET', 'AMOUNT_TOO_LOW', 'AMOUNT_TOO_HIGH', 'UNDERPAID'];
 const { ACCEPTED_ASSETS } = require('../config/stellarConfig');
 const { getPaymentLimits } = require('../utils/paymentLimits');
 const {
@@ -39,7 +39,7 @@ const {
   enrichPaymentWithConversion,
 } = require('../services/currencyConversionService');
 
-const PERMANENT_FAIL_CODES = ['TX_FAILED', 'MISSING_MEMO', 'INVALID_DESTINATION', 'UNSUPPORTED_ASSET', 'AMOUNT_TOO_LOW', 'AMOUNT_TOO_HIGH'];
+const PERMANENT_FAIL_CODES = ['TX_FAILED', 'MISSING_MEMO', 'INVALID_DESTINATION', 'UNSUPPORTED_ASSET', 'AMOUNT_TOO_LOW', 'AMOUNT_TOO_HIGH', 'UNDERPAID'];
 
 function wrapStellarError(err) {
   if (!err.code) {
@@ -295,6 +295,20 @@ async function verifyPayment(req, res, next) {
       studentId: studentObj._id,
     // Persist the verified payment
     const now = new Date();
+
+    // Reject underpaid transactions — do not record as SUCCESS
+    if (result.feeValidation.status === 'underpaid') {
+      const err = new Error(result.feeValidation.message);
+      err.code = 'UNDERPAID';
+      err.status = 400;
+      err.details = {
+        paid: result.amount,
+        required: result.feeAmount,
+        shortfall: parseFloat((result.feeAmount - result.amount).toFixed(7)),
+      };
+      return next(err);
+    }
+
     await recordPayment({
       schoolId,
       studentId: result.studentId || result.memo,

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -496,6 +496,32 @@ async function syncPaymentsForSchool(school) {
 
     const feeValidation = validatePaymentAgainstFee(paymentAmount, intent.amount);
 
+    // Skip underpaid single payments — record them as flagged but do not credit
+    if (feeValidation.status === 'underpaid') {
+      logger.warn('Underpaid transaction skipped', {
+        txHash: tx.hash, schoolId, studentId: intent.studentId,
+        paid: paymentAmount, required: intent.amount,
+      });
+      await Payment.create({
+        schoolId,
+        studentId: intent.studentId,
+        txHash: tx.hash,
+        amount: paymentAmount,
+        feeAmount: intent.amount,
+        feeValidationStatus: 'underpaid',
+        excessAmount: 0,
+        status: 'FAILED',
+        memo,
+        senderAddress,
+        isSuspicious: true,
+        suspicionReason: feeValidation.message,
+        ledger: txLedger,
+        confirmationStatus: 'failed',
+        confirmedAt: txDate,
+      });
+      continue;
+    }
+
     await Payment.create({
       schoolId,
       studentId: intent.studentId,
@@ -514,6 +540,16 @@ async function syncPaymentsForSchool(school) {
       confirmedAt: txDate,
     });
 
+    logger.info('Transaction recorded', {
+      txHash: tx.hash,
+      schoolId,
+      studentId: intent.studentId,
+      amount: paymentAmount,
+      feeValidationStatus: cumulativeStatus,
+      isSuspicious: collision.suspicious,
+      confirmationStatus,
+    });
+
     if (isConfirmed && !collision.suspicious && typeof Student.findOneAndUpdate === 'function') {
       await Student.findOneAndUpdate(
         { schoolId, studentId: intent.studentId },
@@ -526,10 +562,6 @@ async function syncPaymentsForSchool(school) {
     }
 
     await PaymentIntent.findByIdAndUpdate(intent._id, { status: 'completed' });
-
-    if (feeValidation.status === 'valid' || feeValidation.status === 'overpaid') {
-      await Student.findOneAndUpdate({ studentId: intent.studentId }, { feePaid: true });
-    }
   }
 }
 


### PR DESCRIPTION

Title: feat: reject and flag underpaid transactions

Description:

Enforces correct fee payment by comparing the actual paid amount against the expected fee and blocking underpaid 
transactions from being credited.

Root cause: verifyPayment and syncPaymentsForSchool both called validatePaymentAgainstFee but never acted on an 
underpaid result — the payment was recorded as SUCCESS regardless.

Changes:

- paymentController.js — verifyPayment now returns 400 UNDERPAID (with paid, required, shortfall details) before 
calling recordPayment when feeValidation.status === 'underpaid'. Added UNDERPAID to PERMANENT_FAIL_CODES so it is 
never queued for retry.

- stellarService.js — syncPaymentsForSchool now skips underpaid transactions: records them as status: FAILED, 
feeValidationStatus: underpaid, isSuspicious: true for audit trail, then continues without updating the student's 
feePaid or totalPaid. Removed the stale non-school-scoped feePaid update.

- app.js — added UNDERPAID: 400 to the global error status map.

Behaviour after this change:

| Scenario | Result |
|---|---|
| Paid = required fee | valid — recorded, feePaid: true |
| Paid > required fee | overpaid — recorded, feePaid: true |
| Paid < required fee | underpaid — rejected (400) / flagged (FAILED) in sync, feePaid unchanged |
closes #57