### PR TITLE
fix: enforce non-negative feeAmount and harden transaction/audit/dispute integrity (#406 #407 #408 #409)

### DIFF
--- a/backend/src/models/feeStructureModel.js
+++ b/backend/src/models/feeStructureModel.js
@@ -6,7 +6,7 @@ const feeStructureSchema = new mongoose.Schema(
   {
     schoolId:     { type: String, required: true, index: true },
     className:    { type: String, required: true },
-    feeAmount:    { type: Number, required: true },
+    feeAmount:    { type: Number, required: true, min: [0, 'Fee amount cannot be negative'] },
     description:  { type: String, default: '' },
     academicYear: { type: String, default: () => new Date().getUTCFullYear().toString() },
     isActive:        { type: Boolean, default: true, index: true },


### PR DESCRIPTION
Summary                                                                                  
                                                                                           
  This PR addresses four issues identified during the StellarEduPay codebase review. One   
  required a direct code fix; the other three were confirmed already implemented and are   
  documented here for traceability.                                                        
                                                                                           
  ─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
  Issues Addressed                                                                         
                                                                                           
  #406 — `feeStructureModel.js`: `feeAmount` can be set to negative values ✅ Fixed        
                                                                                           
  Root cause: feeStructureModel.js had no min constraint on feeAmount, allowing negative   
  values to be persisted via the API. Since feeAmount from the fee structure is copied to  
  students on registration, a negative fee would cause every payment to appear as overpaid 
  during validation.                                                                       
                                                                                           
  Fix: Added min: [0, 'Fee amount cannot be negative'] to feeAmount in                     
  backend/src/models/feeStructureModel.js. Mongoose now rejects any create or update       
  supplying a negative value before the document is written.                               
                                                                                           
  Note: studentModel.js already carried this constraint on its own feeAmount — this closes 
  the gap at the source.                                                                   
                                                                                           
  closes #406 

─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
  #407 — `transactionParser.js`: no handling for failed Stellar transactions ✅ Confirmed  
  present                                                                                  
                                                                                           
  parseTransaction() already checks tx.successful === false immediately after validating   
  the transaction object and throws TransactionParseError('TRANSACTION_FAILED') before any 
  memo extraction or student matching occurs. Failed on-chain transactions are never       
  matched to students.                                                                     
                                 
closes #407                                                           
  ─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
  #408 — `auditController.js`: audit log endpoint has no pagination ✅ Confirmed present   
                                                                                           
  GET /api/audit-logs already accepts page and limit query params (default 50, max 200).   
  auditService.getAuditLogs() applies skip/limit to the MongoDB query and returns { logs,  
  total, page, pages }, preventing unbounded result sets.                                  
                                                                                           
closes #408 
  ─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
  #409 — `disputeModel.js`: no index on `status` field ✅ Confirmed present                
                                                                                           
  disputeModel.js already carries index: true on status plus a compound { schoolId: 1,     
  status: 1 } index covering the primary query pattern in dispute.controller.js. Full      
  collection scans on status queries are not an issue.                                     
                                                                                           
closes #409 
  ─────────────────────────────────────────────────────────────────────────────────────────
                                                                                           
  Files Changed                                                                            
                                                                                           
  ┌───────────────────────────────────────────┬────────────────────────────────────────────
  ──────────────────────┐                                                                  
  │ File                                      │ Change                                     
                                                             │                             
  ├───────────────────────────────────────────┼────────────────────────────────────────────
  ──────────────────────┤                                                                  
  │ `backend/src/models/feeStructureModel.js` │ Added `min: [0, 'Fee amount cannot be      
  negative']` to `feeAmount` │                                                             
  └───────────────────────────────────────────┴────────────────────────────────────────────
  ──────────────────────┘               