### PR TITLE
fix(#410,#411,#412,#413): email templates, system config seed, explorer link

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -116,6 +116,21 @@ mongoose.connection.on('error', (err) =>
 );
 
 connectWithRetry().then(async () => {
+  // Seed default system config entries on first run
+  const SystemConfig = require('./models/systemConfigModel');
+  const DEFAULTS = [
+    { key: 'maintenanceMode',    value: false },
+    { key: 'maxSyncBatchSize',   value: 20 },
+    { key: 'reminderEnabled',    value: true },
+    { key: 'reminderIntervalMs', value: 86400000 },
+  ];
+  await Promise.all(
+    DEFAULTS.map(({ key, value }) =>
+      SystemConfig.findOneAndUpdate({ key }, { $setOnInsert: { key, value } }, { upsert: true })
+    )
+  );
+  logger.info('System config defaults ensured');
+
   startPolling();
   startConsistencyScheduler();
   startRetryWorker();

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -6,10 +6,35 @@
  * Sends fee reminder emails to parents via SMTP (nodemailer).
  * Falls back to console logging when SMTP is not configured — useful
  * for development and environments without email infrastructure.
+ *
+ * Email bodies are loaded from:
+ *   backend/src/templates/reminderEmail.txt  (plain-text)
+ *   backend/src/templates/reminderEmail.html (HTML)
+ *
+ * Supported placeholders: {{studentName}}, {{studentId}}, {{className}},
+ * {{schoolName}}, {{feeAmount}}, {{outstanding}}, {{reminderNote}}
+ * The {{#if reminderNote}}…{{/if}} block is stripped when reminderNote is empty.
  */
 
+const fs = require('fs');
+const path = require('path');
 const config = require('../config');
 const logger = require('../utils/logger').child('NotificationService');
+
+const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
+
+function loadTemplate(filename) {
+  return fs.readFileSync(path.join(TEMPLATES_DIR, filename), 'utf8');
+}
+
+function renderTemplate(template, vars) {
+  // Replace {{#if key}}…{{/if}} blocks — include content only when key is truthy
+  let out = template.replace(/\{\{#if (\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_, key, inner) =>
+    vars[key] ? inner : ''
+  );
+  // Replace {{key}} placeholders
+  return out.replace(/\{\{(\w+)\}\}/g, (_, key) => (vars[key] != null ? vars[key] : ''));
+}
 
 let _transporter = null;
 
@@ -49,41 +74,19 @@ function getTransporter() {
 }
 
 /**
- * Build the reminder email body.
+ * Build the reminder email body from external template files.
  */
 function buildReminderEmail({ studentName, studentId, className, feeAmount, remainingBalance, schoolName, reminderCount }) {
   const outstanding = remainingBalance != null ? remainingBalance : feeAmount;
   const subject = `[${schoolName}] Fee Payment Reminder — ${studentName}`;
+  const reminderNote = reminderCount > 1
+    ? `Note: This is reminder #${reminderCount}. If you have already paid, please disregard this message.`
+    : '';
 
-  const text = [
-    `Dear Parent/Guardian,`,
-    ``,
-    `This is a reminder that school fees for ${studentName} (ID: ${studentId}, Class: ${className}) are outstanding.`,
-    ``,
-    `  School       : ${schoolName}`,
-    `  Fee Amount   : ${feeAmount}`,
-    `  Amount Due   : ${outstanding}`,
-    ``,
-    `Please arrange payment at your earliest convenience to avoid any disruption to your child's education.`,
-    ``,
-    reminderCount > 1 ? `Note: This is reminder #${reminderCount}. If you have already paid, please disregard this message.` : '',
-    ``,
-    `Thank you,`,
-    `${schoolName} Administration`,
-  ].filter(line => line !== undefined).join('\n');
+  const vars = { studentName, studentId, className, feeAmount, outstanding, schoolName, reminderNote };
 
-  const html = `
-    <p>Dear Parent/Guardian,</p>
-    <p>This is a reminder that school fees for <strong>${studentName}</strong> (ID: <code>${studentId}</code>, Class: <strong>${className}</strong>) are outstanding.</p>
-    <table style="border-collapse:collapse;margin:16px 0;">
-      <tr><td style="padding:4px 12px 4px 0;color:#555;">School</td><td><strong>${schoolName}</strong></td></tr>
-      <tr><td style="padding:4px 12px 4px 0;color:#555;">Fee Amount</td><td>${feeAmount}</td></tr>
-      <tr><td style="padding:4px 12px 4px 0;color:#555;">Amount Due</td><td><strong>${outstanding}</strong></td></tr>
-    </table>
-    <p>Please arrange payment at your earliest convenience to avoid any disruption to your child's education.</p>
-    ${reminderCount > 1 ? `<p><em>Note: This is reminder #${reminderCount}. If you have already paid, please disregard this message.</em></p>` : ''}
-    <p>Thank you,<br/><strong>${schoolName} Administration</strong></p>
-  `;
+  const text = renderTemplate(loadTemplate('reminderEmail.txt'), vars);
+  const html = renderTemplate(loadTemplate('reminderEmail.html'), vars);
 
   return { subject, text, html };
 }

--- a/backend/src/templates/reminderEmail.html
+++ b/backend/src/templates/reminderEmail.html
@@ -1,0 +1,10 @@
+<p>Dear Parent/Guardian,</p>
+<p>This is a reminder that school fees for <strong>{{studentName}}</strong> (ID: <code>{{studentId}}</code>, Class: <strong>{{className}}</strong>) are outstanding.</p>
+<table style="border-collapse:collapse;margin:16px 0;">
+  <tr><td style="padding:4px 12px 4px 0;color:#555;">School</td><td><strong>{{schoolName}}</strong></td></tr>
+  <tr><td style="padding:4px 12px 4px 0;color:#555;">Fee Amount</td><td>{{feeAmount}}</td></tr>
+  <tr><td style="padding:4px 12px 4px 0;color:#555;">Amount Due</td><td><strong>{{outstanding}}</strong></td></tr>
+</table>
+<p>Please arrange payment at your earliest convenience to avoid any disruption to your child's education.</p>
+{{#if reminderNote}}<p><em>{{reminderNote}}</em></p>{{/if}}
+<p>Thank you,<br/><strong>{{schoolName}} Administration</strong></p>

--- a/backend/src/templates/reminderEmail.txt
+++ b/backend/src/templates/reminderEmail.txt
@@ -1,0 +1,14 @@
+Dear Parent/Guardian,
+
+This is a reminder that school fees for {{studentName}} (ID: {{studentId}}, Class: {{className}}) are outstanding.
+
+  School       : {{schoolName}}
+  Fee Amount   : {{feeAmount}}
+  Amount Due   : {{outstanding}}
+
+Please arrange payment at your earliest convenience to avoid any disruption to your child's education.
+
+{{#if reminderNote}}{{reminderNote}}
+
+{{/if}}Thank you,
+{{schoolName}} Administration

--- a/frontend/src/components/TransactionCard.jsx
+++ b/frontend/src/components/TransactionCard.jsx
@@ -121,7 +121,7 @@ export default function TransactionCard({
         <span style={{ color: "#888" }}>Tx: </span>
         {tx ? (
           <a
-            href={transactionExplorerUrl}
+            href={explorerUrl}
             target="_blank"
             rel="noopener noreferrer"
             title={tx}


### PR DESCRIPTION
## Summary

### #410 — Extract hardcoded email templates into separate files

**Problem:** `notificationService.js` built email bodies with inline string concatenation, making it impossible to customise branding without editing source code.

**Fix:**
- Added `backend/src/templates/reminderEmail.txt` (plain-text template)
- Added `backend/src/templates/reminderEmail.html` (HTML template)
- Updated `buildReminderEmail()` to load templates from disk via `fs.readFileSync` and render them with a minimal `{{key}}` / `{{#if key}}…{{/if}}` renderer
- School administrators can now customise email content by editing the template files without touching application code

closes #410 
---

### #411 — Seed system config defaults on first run

**Problem:** `systemConfigModel.js` defines a key/value config schema, but nothing ever creates default documents. On a fresh install, any code reading system config finds an empty collection and either crashes or falls back inconsistently.

**Fix:**
- In `app.js`, after `connectWithRetry()` resolves, upsert four default `SystemConfig` documents using `$setOnInsert`:
  - `maintenanceMode` → `false`
  - `maxSyncBatchSize` → `20`
  - `reminderEnabled` → `true`
  - `reminderIntervalMs` → `86400000`
- `$setOnInsert` ensures existing values are never overwritten on subsequent restarts

closes #411 

---

### #412 — SyncButton.jsx loading state (no code change required)

**Problem reported:** Sync button provides no visual feedback during the sync operation, potentially causing duplicate requests.

**Finding:** The component already fully implements the required behaviour:
- `syncing` state tracked via `useState`
- Button is `disabled={syncing}` during the request
- Button label switches to `"Syncing…"` while in-flight
- Confirm button inside the modal mirrors the same disabled/label logic

No code change was needed; the issue is already satisfied by the existing implementation.

closes #412 

---

### #413 — Fix broken Stellar Explorer link in TransactionCard.jsx

**Problem:** The transaction hash anchor used `href={transactionExplorerUrl}`, which is never defined, rendering every explorer link broken (`href="undefined"`).

**Fix:**
- `explorerUrl` is already correctly derived earlier in the component: `payment?.explorerUrl ?? (tx ? `${EXPLORER_BASE}${tx}` : null)`
- Changed `href={transactionExplorerUrl}` → `href={explorerUrl}`
- Transaction hashes now link correctly to the Stellar Explorer (testnet or mainnet based on `NODE_ENV`)

closes #413 

---

## Files changed

| File | Change |
|------|--------|
| `backend/src/templates/reminderEmail.txt` | New — plain-text email template |
| `backend/src/templates/reminderEmail.html` | New — HTML email template |
| `backend/src/services/notificationService.js` | Load & render templates from files |
| `backend/src/app.js` | Seed SystemConfig defaults on startup |
| `frontend/src/components/TransactionCard.jsx` | Fix `transactionExplorerUrl` → `explorerUrl` |

