### PR TITLE
fix: SSE connection cleanup and CORS origin validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -83,6 +83,14 @@ JWT_SECRET=change_me_to_a_long_random_secret
 # Token expiry (default: 8h)
 JWT_EXPIRES_IN=8h
 
+# ── CORS ─────────────────────────────────────────────────────
+# Allowed origin(s) for CORS. Supports a single URL or a comma-separated list.
+# Wildcard (*) is rejected in production (NODE_ENV=production).
+# Examples:
+#   Single:   ALLOWED_ORIGIN=https://app.school.com
+#   Multiple: ALLOWED_ORIGIN=https://app.school.com,https://admin.school.com
+ALLOWED_ORIGIN=http://localhost:3000
+
 # ── Server ───────────────────────────────────────────────────
 PORT=5000
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -29,12 +29,15 @@ const { healthCheck } = require('./controllers/healthController');
 const logger = require('./utils/logger');
 
 const morgan = require('morgan');
+const { parseAllowedOrigins } = require('./utils/corsOrigins');
+
+const allowedOrigins = parseAllowedOrigins();
 
 const app = express();
 
 app.use(morgan(process.env.NODE_ENV === 'production' ? 'combined' : 'dev'));
 app.use(cors({
-  origin: process.env.ALLOWED_ORIGIN || 'http://localhost:3000',
+  origin: allowedOrigins,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
   allowedHeaders: ['Content-Type', 'Authorization', 'X-School-ID', 'Idempotency-Key'],
 }));

--- a/backend/src/services/sseService.js
+++ b/backend/src/services/sseService.js
@@ -6,6 +6,7 @@ const clients = new Map();
 function addClient(schoolId, res) {
   if (!clients.has(schoolId)) clients.set(schoolId, new Set());
   clients.get(schoolId).add(res);
+  res.on('close', () => removeClient(schoolId, res));
 }
 
 function removeClient(schoolId, res) {
@@ -20,7 +21,11 @@ function emit(schoolId, event, data) {
   if (!set || set.size === 0) return;
   const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
   for (const res of set) {
-    res.write(payload);
+    try {
+      res.write(payload);
+    } catch {
+      removeClient(schoolId, res);
+    }
   }
 }
 

--- a/backend/src/utils/corsOrigins.js
+++ b/backend/src/utils/corsOrigins.js
@@ -1,0 +1,39 @@
+'use strict';
+
+/**
+ * Parses and validates the ALLOWED_ORIGIN environment variable.
+ *
+ * Rules:
+ *  - Supports a single URL or a comma-separated list of URLs
+ *  - Wildcard (*) is allowed in non-production environments
+ *  - Wildcard (*) is rejected when NODE_ENV === 'production'
+ *  - Each entry must be a valid URL (validated via the URL constructor)
+ *  - Whitespace around entries is trimmed
+ *  - Falls back to 'http://localhost:3000' when ALLOWED_ORIGIN is not set
+ *
+ * @returns {string|string[]} A single origin string or an array of origin strings
+ * @throws {Error} If the configuration is invalid
+ */
+function parseAllowedOrigins() {
+  const raw = process.env.ALLOWED_ORIGIN || 'http://localhost:3000';
+  const isProduction = process.env.NODE_ENV === 'production';
+
+  if (raw === '*') {
+    if (isProduction) {
+      throw new Error('ALLOWED_ORIGIN wildcard (*) is not permitted in production');
+    }
+    return '*';
+  }
+
+  const origins = raw.split(',').map((o) => o.trim()).filter(Boolean);
+  for (const origin of origins) {
+    try {
+      new URL(origin);
+    } catch {
+      throw new Error(`ALLOWED_ORIGIN contains invalid URL: "${origin}"`);
+    }
+  }
+  return origins.length === 1 ? origins[0] : origins;
+}
+
+module.exports = { parseAllowedOrigins };

--- a/tests/cors.test.js
+++ b/tests/cors.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * Tests for Issue #405 — CORS origin validation.
+ *
+ * parseAllowedOrigins() reads process.env at call time, so we set env vars
+ * before each call and restore them after.
+ */
+
+// Load the function once — it has no module-level side effects
+const { parseAllowedOrigins } = require('../backend/src/utils/corsOrigins');
+
+// Helper: call parseAllowedOrigins with specific env vars, then restore
+function parse(envOverrides = {}) {
+  const saved = {};
+  for (const [k, v] of Object.entries(envOverrides)) {
+    saved[k] = process.env[k];
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  let result, error;
+  try {
+    result = parseAllowedOrigins();
+  } catch (e) {
+    error = e;
+  }
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  if (error) throw error;
+  return result;
+}
+
+describe('Issue #405 — CORS origin validation', () => {
+  // ── Valid configurations ──────────────────────────────────────────────────
+
+  test('single valid origin — returns the origin string', () => {
+    const result = parse({ NODE_ENV: 'development', ALLOWED_ORIGIN: 'https://app.school.com' });
+    expect(result).toBe('https://app.school.com');
+  });
+
+  test('multiple comma-separated valid origins — returns an array', () => {
+    const result = parse({
+      NODE_ENV: 'development',
+      ALLOWED_ORIGIN: 'https://app.school.com,https://admin.school.com',
+    });
+    expect(result).toEqual(['https://app.school.com', 'https://admin.school.com']);
+  });
+
+  test('wildcard (*) is allowed in development — returns "*"', () => {
+    const result = parse({ NODE_ENV: 'development', ALLOWED_ORIGIN: '*' });
+    expect(result).toBe('*');
+  });
+
+  test('missing ALLOWED_ORIGIN falls back to http://localhost:3000', () => {
+    const result = parse({ NODE_ENV: 'development', ALLOWED_ORIGIN: undefined });
+    expect(result).toBe('http://localhost:3000');
+  });
+
+  test('origin with surrounding whitespace is trimmed and accepted', () => {
+    const result = parse({
+      NODE_ENV: 'development',
+      ALLOWED_ORIGIN: '  https://app.school.com  ,  https://admin.school.com  ',
+    });
+    expect(result).toEqual(['https://app.school.com', 'https://admin.school.com']);
+  });
+
+  // ── Production security ───────────────────────────────────────────────────
+
+  test('wildcard (*) is rejected in production', () => {
+    expect(() =>
+      parse({ NODE_ENV: 'production', ALLOWED_ORIGIN: '*' })
+    ).toThrow(/wildcard.*not permitted in production/i);
+  });
+
+  // ── Invalid URL rejection ─────────────────────────────────────────────────
+
+  test('invalid URL causes a descriptive error', () => {
+    expect(() =>
+      parse({ NODE_ENV: 'development', ALLOWED_ORIGIN: 'not-a-valid-url' })
+    ).toThrow(/invalid URL/i);
+  });
+
+  test('one invalid URL in a comma-separated list causes a descriptive error', () => {
+    expect(() =>
+      parse({ NODE_ENV: 'development', ALLOWED_ORIGIN: 'https://app.school.com,bad-url' })
+    ).toThrow(/invalid URL/i);
+  });
+});

--- a/tests/sse.test.js
+++ b/tests/sse.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+const { addClient, removeClient, emit } = require('../backend/src/services/sseService');
+
+// Helper: create a minimal mock SSE response object
+function makeMockRes() {
+  const listeners = {};
+  return {
+    write: jest.fn(),
+    on(event, cb) { listeners[event] = cb; },
+    // Simulate the browser closing the connection
+    simulateClose() { if (listeners['close']) listeners['close'](); },
+  };
+}
+
+// Reset the internal clients Map between tests by re-requiring the module
+// We achieve isolation by removing dead connections via the public API.
+
+describe('Issue #404 — SSE connection cleanup', () => {
+  afterEach(() => {
+    // Clean up any lingering state by removing all clients we added
+    jest.clearAllMocks();
+  });
+
+  // ── addClient / removeClient ──────────────────────────────────────────────
+
+  test('addClient registers the connection', () => {
+    const res = makeMockRes();
+    addClient('SCH001', res);
+
+    // emit should reach the registered client
+    emit('SCH001', 'ping', { ok: true });
+    expect(res.write).toHaveBeenCalledTimes(1);
+    expect(res.write).toHaveBeenCalledWith(
+      expect.stringContaining('event: ping')
+    );
+
+    removeClient('SCH001', res);
+  });
+
+  test('removeClient unregisters the connection so it no longer receives broadcasts', () => {
+    const res = makeMockRes();
+    addClient('SCH001', res);
+    removeClient('SCH001', res);
+
+    emit('SCH001', 'ping', { ok: true });
+    expect(res.write).not.toHaveBeenCalled();
+  });
+
+  // ── Disconnect cleanup (res.on('close')) ──────────────────────────────────
+
+  test('client is automatically removed when the connection closes', () => {
+    const res = makeMockRes();
+    addClient('SCH002', res);
+
+    // Simulate browser/network disconnect
+    res.simulateClose();
+
+    // After close, broadcast should not reach the disconnected client
+    emit('SCH002', 'update', { data: 1 });
+    expect(res.write).not.toHaveBeenCalled();
+  });
+
+  test('close event on one client does not affect other clients in the same school', () => {
+    const res1 = makeMockRes();
+    const res2 = makeMockRes();
+    addClient('SCH003', res1);
+    addClient('SCH003', res2);
+
+    res1.simulateClose(); // only res1 disconnects
+
+    emit('SCH003', 'update', { data: 2 });
+    expect(res1.write).not.toHaveBeenCalled(); // removed
+    expect(res2.write).toHaveBeenCalledTimes(1); // still active
+
+    removeClient('SCH003', res2);
+  });
+
+  test('close event on last client removes the school entry entirely', () => {
+    const res = makeMockRes();
+    addClient('SCH004', res);
+    res.simulateClose();
+
+    // emit to a school with no clients should be a no-op (no error thrown)
+    expect(() => emit('SCH004', 'ping', {})).not.toThrow();
+    expect(res.write).not.toHaveBeenCalled();
+  });
+
+  // ── Robust broadcast: dead connections ────────────────────────────────────
+
+  test('emit skips and removes a connection that throws on write', () => {
+    const deadRes = makeMockRes();
+    const liveRes = makeMockRes();
+
+    deadRes.write.mockImplementation(() => { throw new Error('socket hang up'); });
+
+    addClient('SCH005', deadRes);
+    addClient('SCH005', liveRes);
+
+    // Should not throw even though deadRes.write throws
+    expect(() => emit('SCH005', 'event', { x: 1 })).not.toThrow();
+
+    // Live client still received the message
+    expect(liveRes.write).toHaveBeenCalledTimes(1);
+
+    // Dead client is now removed — a second emit should not call it again
+    liveRes.write.mockClear();
+    emit('SCH005', 'event', { x: 2 });
+    expect(deadRes.write).toHaveBeenCalledTimes(1); // only the first (failed) attempt
+    expect(liveRes.write).toHaveBeenCalledTimes(1);
+
+    removeClient('SCH005', liveRes);
+  });
+
+  test('emit to a school with no clients does not throw', () => {
+    expect(() => emit('NONEXISTENT', 'ping', {})).not.toThrow();
+  });
+
+  // ── Payload format ────────────────────────────────────────────────────────
+
+  test('emit writes correct SSE payload format', () => {
+    const res = makeMockRes();
+    addClient('SCH006', res);
+
+    emit('SCH006', 'payment', { amount: 100 });
+
+    const written = res.write.mock.calls[0][0];
+    expect(written).toMatch(/^event: payment\n/);
+    expect(written).toMatch(/data: {"amount":100}\n\n$/);
+
+    removeClient('SCH006', res);
+  });
+
+  // ── Multiple schools isolation ────────────────────────────────────────────
+
+  test('emit only broadcasts to the correct school', () => {
+    const resA = makeMockRes();
+    const resB = makeMockRes();
+    addClient('SCHOOL_A', resA);
+    addClient('SCHOOL_B', resB);
+
+    emit('SCHOOL_A', 'ping', {});
+
+    expect(resA.write).toHaveBeenCalledTimes(1);
+    expect(resB.write).not.toHaveBeenCalled();
+
+    removeClient('SCHOOL_A', resA);
+    removeClient('SCHOOL_B', resB);
+  });
+});


### PR DESCRIPTION
## Summary



---

### Closes #404 — SSE Connection Cleanup

**Problem:** `sseService.js` never removed clients on disconnect, causing memory leaks and broadcast errors to dead connections.

**Changes:**
- `addClient`: added `res.on('close', () => removeClient(schoolId, res))` — fires automatically on browser close or network drop
- `emit`: wrapped `res.write()` in `try/catch` — dead connections that throw are silently removed without crashing the broadcast loop

---

### Closes #405  — CORS Origin Validation

**Problem:** `app.js` used `process.env.ALLOWED_ORIGIN` without validation — accepted wildcards in production and didn't support multiple origins.

**Changes:**
- Extracted `parseAllowedOrigins()` into `backend/src/utils/corsOrigins.js`
- Supports comma-separated origins: `https://app.school.com,https://admin.school.com`
- Rejects `*` wildcard when `NODE_ENV=production`
- Validates each entry with the `URL` constructor — throws a descriptive error at startup for invalid configs
- Updated `backend/.env.example` to document the format

---

### Tests

- `tests/sse.test.js` — 9 tests: disconnect cleanup, dead connection removal, payload format, multi-school isolation
- `tests/cors.test.js` — 8 tests: single origin, multi-origin, wildcard in dev/prod, invalid URL, fallback, whitespace trimming

All 17 new tests pass.