### PR TITLE
feat: audit log pagination spec

### DIFF
--- a/.kiro/specs/audit-log-pagination/.config.kiro
+++ b/.kiro/specs/audit-log-pagination/.config.kiro
@@ -1,0 +1,1 @@
+{"generationMode": "requirements-first"}

--- a/.kiro/specs/audit-log-pagination/design.md
+++ b/.kiro/specs/audit-log-pagination/design.md
@@ -1,0 +1,192 @@
+# Design Document: Audit Log Pagination
+
+## Overview
+
+The audit log page currently fetches all payment records in one unbounded query. This design adds a paginated `GET /api/audit-logs` endpoint backed by the existing `Payment` MongoDB model, and replaces the single-fetch frontend with an incremental "load more" pattern. Entries are served in pages of 50, the URL reflects the current page for shareability, and a count summary keeps the user oriented.
+
+No new data model is needed — the `Payment` model already contains all audit-relevant fields (`txHash`, `studentId`, `amount`, `status`, `confirmedAt`, `verifiedAt`, etc.).
+
+---
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant AuditLogPage
+    participant ApiService
+    participant AuditLogController
+    participant PaymentModel
+
+    Browser->>AuditLogPage: navigate to /audit-logs[?page=N]
+    AuditLogPage->>ApiService: getAuditLogs({ page: 1..N, limit: 50 })
+    ApiService->>AuditLogController: GET /api/audit-logs?page=P&limit=50
+    AuditLogController->>PaymentModel: countDocuments()
+    AuditLogController->>PaymentModel: find().sort().skip().limit()
+    PaymentModel-->>AuditLogController: [Payment]
+    AuditLogController-->>ApiService: { data, total, page, limit, totalPages }
+    ApiService-->>AuditLogPage: response envelope
+    AuditLogPage-->>Browser: render entries + "Showing X of Y" + Load More button
+
+    Browser->>AuditLogPage: click "Load More"
+    AuditLogPage->>ApiService: getAuditLogs({ page: currentPage+1, limit: 50 })
+    AuditLogController-->>AuditLogPage: next page envelope
+    AuditLogPage-->>Browser: append entries, update URL ?page=N+1
+```
+
+---
+
+## Components and Interfaces
+
+### Backend
+
+#### `backend/src/controllers/auditLogController.js` (new)
+
+```js
+// GET /api/audit-logs?page=1&limit=50
+async function getAuditLogs(req, res, next)
+```
+
+- Parses and validates `page` (default 1) and `limit` (default 50, max 100) from `req.query`.
+- Returns `400 VALIDATION_ERROR` for non-positive-integer values.
+- Runs `Payment.countDocuments()` and `Payment.find().sort({ confirmedAt: -1 }).skip(skip).limit(limit)` in parallel via `Promise.all`.
+- Returns the envelope: `{ data, total, page, limit, totalPages }`.
+
+#### `backend/src/routes/auditLogRoutes.js` (new)
+
+```js
+router.get('/', getAuditLogs);
+```
+
+Mounted at `/api/audit-logs` in `backend/src/app.js`.
+
+### Frontend
+
+#### `frontend/src/services/api.js` (modified)
+
+```js
+export const getAuditLogs = ({ page = 1, limit = 50 } = {}) =>
+  api.get('/audit-logs', { params: { page, limit } });
+```
+
+#### `frontend/src/pages/audit-logs.jsx` (new)
+
+State:
+- `entries` — accumulated array of loaded Payment records
+- `page` — highest page fetched so far
+- `total` — Total_Count from last response
+- `totalPages` — from last response
+- `loading` — boolean, true while any fetch is in flight
+- `initialLoading` — boolean, true only during the very first fetch
+- `error` — error message string or null
+
+Behaviour:
+- On mount: read `?page` from URL (default 1). If `?page=N`, sequentially fetch pages 1..N and accumulate entries.
+- "Load More" click: fetch `page + 1`, append to `entries`, push `?page=N+1` to router.
+- URL updates use `router.push` with `shallow: true` to avoid full navigation.
+
+---
+
+## Data Models
+
+No new models. The existing `Payment` model fields used for the audit log display:
+
+| Field | Type | Notes |
+|---|---|---|
+| `txHash` | String | Unique on-chain reference |
+| `studentId` | String | Student identifier |
+| `amount` | Number | Payment amount |
+| `status` | String | `pending` / `confirmed` / `failed` |
+| `feeValidationStatus` | String | `valid` / `underpaid` / `overpaid` / `unknown` |
+| `confirmedAt` | Date | Sort key (descending) |
+| `verifiedAt` | Date | When verified via API |
+| `createdAt` | Date | Auto-managed by Mongoose |
+
+The `confirmedAt` field already has a MongoDB index (defined in `paymentModel.js`), so the sort + skip + limit query is efficient.
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Pagination envelope invariant
+
+*For any* valid `page` and `limit` values and any dataset size, the API response SHALL always contain all five envelope fields (`data`, `total`, `page`, `limit`, `totalPages`), the `data` array length SHALL be at most `limit`, and `totalPages` SHALL equal `Math.ceil(total / limit)`.
+
+**Validates: Requirements 1.2, 1.3**
+
+### Property 2: Invalid parameters always rejected
+
+*For any* `page` or `limit` value that is not a positive integer (zero, negative, non-numeric string, float), the API SHALL return HTTP 400 with `code: "VALIDATION_ERROR"`.
+
+**Validates: Requirements 1.5**
+
+### Property 3: Load more appends, never replaces
+
+*For any* loaded state where `entries.length < total`, clicking Load More SHALL result in `entries.length` increasing by the number of entries in the next page, and all previously loaded entries SHALL remain in the list at their original positions.
+
+**Validates: Requirements 2.2**
+
+### Property 4: Load More button hidden when fully loaded
+
+*For any* state where `entries.length >= total` and `total > 0`, the Load More button SHALL NOT be present in the rendered output.
+
+**Validates: Requirements 2.4**
+
+### Property 5: Summary string format
+
+*For any* combination of loaded entry count X and total Y where Y > 0, the summary string SHALL match `"Showing X of Y entries"`. When Y = 0, the summary SHALL be `"No entries found"`.
+
+**Validates: Requirements 3.1, 3.2**
+
+---
+
+## Error Handling
+
+| Scenario | Backend behaviour | Frontend behaviour |
+|---|---|---|
+| Invalid `page`/`limit` params | 400 + `VALIDATION_ERROR` | Display error message, re-enable Load More |
+| MongoDB query failure | 500 via global error handler | Display error message, re-enable Load More |
+| Network timeout / 5xx | — | Display error message, re-enable Load More |
+| `page` beyond `totalPages` | 200 with empty `data` array | Load More hidden (no more pages) |
+
+The global Express error handler in `backend/src/app.js` already maps errors with a `code` property to structured JSON responses, so `auditLogController` only needs to attach `err.code = 'VALIDATION_ERROR'` before calling `next(err)`.
+
+---
+
+## Testing Strategy
+
+### Dual approach
+
+Both unit/example tests and property-based tests are used. Unit tests cover specific examples, edge cases, and integration points. Property tests verify universal correctness across many generated inputs.
+
+### Property-based testing library
+
+**Backend**: [`fast-check`](https://github.com/dubzzz/fast-check) (already available in the JS ecosystem, no Stellar/network dependency).  
+**Frontend**: [`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro/) with Jest for component example tests (property tests for pure functions use `fast-check`).
+
+Each property test runs a minimum of **100 iterations**.
+
+Tag format: `// Feature: audit-log-pagination, Property N: <property_text>`
+
+### Unit / example tests (`tests/auditLog.test.js`)
+
+- Controller returns correct envelope shape for a known dataset
+- Controller returns 400 for `page=0`, `page=-1`, `page=abc`, `limit=0`, `limit=101`
+- Controller returns empty `data` when `page > totalPages`
+- `getAuditLogs()` API service defaults to `page=1, limit=50`
+- Audit log page renders "No entries found" when total is 0
+- Audit log page shows loading indicator during fetch, removes it after
+- Audit log page shows error message and re-enables Load More on fetch failure
+- Audit log page pre-fetches pages 1..N when `?page=N` is in the URL
+
+### Property tests (`tests/auditLog.property.test.js`)
+
+- **Property 1** — Pagination envelope invariant: generate random `(page, limit, datasetSize)` triples, assert envelope fields and `data.length <= limit` and `totalPages == ceil(total/limit)`.
+- **Property 2** — Invalid params always rejected: generate invalid `page`/`limit` values, assert 400 + `VALIDATION_ERROR`.
+- **Property 3** — Load more appends: generate random initial state + next-page response, assert entries grow and existing entries are unchanged.
+- **Property 4** — Load More hidden when fully loaded: generate states where `entries.length >= total`, assert button absent.
+- **Property 5** — Summary string format: generate random `(loaded, total)` pairs, assert string matches expected format.
+
+All tests mock MongoDB and do not require real network connections to Stellar or external services, consistent with the existing test suite pattern in `tests/payment.test.js`.

--- a/.kiro/specs/audit-log-pagination/requirements.md
+++ b/.kiro/specs/audit-log-pagination/requirements.md
@@ -1,0 +1,82 @@
+# Requirements Document
+
+## Introduction
+
+The audit log page (`frontend/src/pages/audit-logs.jsx`) currently fetches all payment audit log entries in a single API call. With thousands of entries this causes slow page loads and high browser memory usage. This feature adds server-side pagination to the audit log API endpoint and updates the frontend to load entries in batches of 50, with a "Load more" button, a total count display, loading state feedback, and URL-reflected page state for shareable links.
+
+## Glossary
+
+- **Audit_Log_Page**: The Next.js page at `frontend/src/pages/audit-logs.jsx` that displays payment audit log entries.
+- **Audit_Log_API**: The Express endpoint `GET /api/audit-logs` that returns paginated payment records from MongoDB.
+- **Page**: A discrete batch of 50 audit log entries returned by a single API call.
+- **Cursor**: The page number (1-based integer) identifying which batch of entries to fetch.
+- **Total_Count**: The total number of audit log entries matching the current query, returned alongside each page.
+- **Load_More_Button**: The UI control that triggers fetching the next page of entries and appending them to the current list.
+- **Loading_State**: A visual indicator shown while an API request is in flight.
+
+---
+
+## Requirements
+
+### Requirement 1: Paginated Audit Log API Endpoint
+
+**User Story:** As a school administrator, I want the audit log API to return entries in pages, so that the server does not send thousands of records in a single response.
+
+#### Acceptance Criteria
+
+1. THE Audit_Log_API SHALL accept a `page` query parameter (positive integer, default `1`) and a `limit` query parameter (positive integer, default `50`, maximum `100`).
+2. WHEN a valid `page` and `limit` are provided, THE Audit_Log_API SHALL return exactly `limit` entries (or fewer on the last page), sorted by `confirmedAt` descending.
+3. THE Audit_Log_API SHALL return a response envelope containing `{ data: [...], total: <integer>, page: <integer>, limit: <integer>, totalPages: <integer> }`.
+4. WHEN `page` exceeds `totalPages`, THE Audit_Log_API SHALL return an empty `data` array with the correct `total` and `totalPages` values.
+5. IF the `page` or `limit` query parameter is not a positive integer, THEN THE Audit_Log_API SHALL return HTTP 400 with an error message and code `VALIDATION_ERROR`.
+
+### Requirement 2: Frontend Paginated Data Fetching
+
+**User Story:** As a school administrator, I want the audit log page to load entries in batches, so that the page loads quickly even when thousands of entries exist.
+
+#### Acceptance Criteria
+
+1. WHEN the Audit_Log_Page loads, THE Audit_Log_Page SHALL fetch only the first page (50 entries) from the Audit_Log_API.
+2. WHEN the user clicks the Load_More_Button, THE Audit_Log_Page SHALL fetch the next page and append the new entries to the existing list without replacing previously loaded entries.
+3. WHILE a page fetch is in progress, THE Audit_Log_Page SHALL display a Loading_State indicator and disable the Load_More_Button.
+4. WHEN all entries have been loaded (current count equals Total_Count), THE Audit_Log_Page SHALL hide the Load_More_Button.
+5. IF an API request fails, THEN THE Audit_Log_Page SHALL display an error message and re-enable the Load_More_Button so the user can retry.
+
+### Requirement 3: Total Count Display
+
+**User Story:** As a school administrator, I want to see how many entries are loaded versus the total, so that I know how much data exists and how much I have viewed.
+
+#### Acceptance Criteria
+
+1. WHEN entries are displayed, THE Audit_Log_Page SHALL show a summary string in the format `"Showing X of Y entries"` where X is the number of currently loaded entries and Y is the Total_Count.
+2. WHEN the Total_Count is zero, THE Audit_Log_Page SHALL display `"No entries found"` instead of the summary string.
+3. WHEN additional entries are loaded via the Load_More_Button, THE Audit_Log_Page SHALL update the summary string to reflect the new loaded count.
+
+### Requirement 4: URL-Reflected Page State
+
+**User Story:** As a school administrator, I want the current page number to be reflected in the URL, so that I can share or bookmark a link that restores the same view.
+
+#### Acceptance Criteria
+
+1. WHEN the Audit_Log_Page loads with a `?page=N` query parameter, THE Audit_Log_Page SHALL pre-fetch all pages from 1 through N and display the combined entries.
+2. WHEN the user loads more entries, THE Audit_Log_Page SHALL update the URL query parameter `page` to reflect the highest page loaded, without triggering a full page navigation.
+3. WHEN the `?page` parameter is absent or invalid, THE Audit_Log_Page SHALL default to page 1 and display the first 50 entries.
+
+### Requirement 5: Loading State
+
+**User Story:** As a school administrator, I want visual feedback while entries are loading, so that I know the application is working and not frozen.
+
+#### Acceptance Criteria
+
+1. WHEN the initial page load fetch is in progress, THE Audit_Log_Page SHALL display a full-page loading indicator in place of the entry list.
+2. WHEN a subsequent "load more" fetch is in progress, THE Audit_Log_Page SHALL display an inline loading indicator near the Load_More_Button.
+3. WHEN a fetch completes (success or error), THE Audit_Log_Page SHALL remove the loading indicator.
+
+### Requirement 6: API Service Integration
+
+**User Story:** As a frontend developer, I want a typed API service function for the paginated audit log endpoint, so that all pages and components call the API consistently.
+
+#### Acceptance Criteria
+
+1. THE Audit_Log_API service function SHALL accept `{ page, limit }` parameters and return the full response envelope.
+2. WHEN called without parameters, THE Audit_Log_API service function SHALL default to `page=1` and `limit=50`.

--- a/.kiro/specs/audit-log-pagination/tasks.md
+++ b/.kiro/specs/audit-log-pagination/tasks.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Audit Log Pagination
+
+## Overview
+
+Add a paginated `GET /api/audit-logs` backend endpoint, wire it into the Express app, create the `getAuditLogs` API service function, and build the `audit-logs.jsx` page with load-more, count summary, loading states, and URL-reflected page state.
+
+## Tasks
+
+- [ ] 1. Add paginated audit log controller and route
+  - Create `backend/src/controllers/auditLogController.js` with `getAuditLogs(req, res, next)`
+  - Parse and validate `page` (default 1) and `limit` (default 50, max 100) from `req.query`; call `next(err)` with `err.code = 'VALIDATION_ERROR'` for invalid values
+  - Run `Payment.countDocuments()` and `Payment.find().sort({ confirmedAt: -1 }).skip((page-1)*limit).limit(limit)` in parallel
+  - Return `{ data, total, page, limit, totalPages }` envelope
+  - Create `backend/src/routes/auditLogRoutes.js` with `router.get('/', getAuditLogs)`
+  - Mount the router at `/api/audit-logs` in `backend/src/app.js`
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+  - [ ]* 1.1 Write property test for pagination envelope invariant
+    - **Property 1: Pagination envelope invariant**
+    - **Validates: Requirements 1.2, 1.3**
+    - Use `fast-check` to generate random `(page, limit, datasetSize)` triples; mock `Payment` model; assert `data.length <= limit`, all five envelope fields present, `totalPages === Math.ceil(total / limit)`
+    - Include edge case: `page > totalPages` returns empty `data` with correct `total`
+    - `// Feature: audit-log-pagination, Property 1: pagination envelope invariant`
+
+  - [ ]* 1.2 Write property test for invalid parameter rejection
+    - **Property 2: Invalid parameters always rejected**
+    - **Validates: Requirements 1.5**
+    - Use `fast-check` to generate invalid `page`/`limit` values (zero, negative, non-numeric, float); assert HTTP 400 and `code: "VALIDATION_ERROR"` for each
+    - `// Feature: audit-log-pagination, Property 2: invalid parameters always rejected`
+
+- [ ] 2. Add `getAuditLogs` to the frontend API service
+  - Add `export const getAuditLogs = ({ page = 1, limit = 50 } = {}) => api.get('/audit-logs', { params: { page, limit } });` to `frontend/src/services/api.js`
+  - _Requirements: 6.1, 6.2_
+
+  - [ ]* 2.1 Write unit test for API service defaults
+    - Verify `getAuditLogs()` calls `/audit-logs?page=1&limit=50`
+    - Verify `getAuditLogs({ page: 3, limit: 25 })` calls `/audit-logs?page=3&limit=25`
+    - _Requirements: 6.1, 6.2_
+
+- [ ] 3. Checkpoint — ensure backend tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Build the `audit-logs.jsx` page
+  - Create `frontend/src/pages/audit-logs.jsx`
+  - Manage state: `entries`, `page`, `total`, `totalPages`, `loading`, `initialLoading`, `error`
+  - On mount: read `?page=N` from Next.js router (default 1); sequentially fetch pages 1..N via `getAuditLogs` and accumulate entries into state
+  - Render a full-page loading indicator while `initialLoading` is true
+  - Render the entry list as a table with columns: Date, Student ID, Tx Hash, Amount, Status, Fee Validation
+  - Render the summary string: `"Showing X of Y entries"` or `"No entries found"` when total is 0
+  - Render the Load More button when `entries.length < total`; disable it while `loading` is true; show an inline loading indicator beside it during subsequent fetches
+  - On Load More click: fetch `page + 1`, append entries, update URL with `router.push({ query: { page: page + 1 } }, undefined, { shallow: true })`
+  - On fetch error: set `error` message, re-enable Load More button
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3_
+
+  - [ ]* 4.1 Write property test for load-more append behaviour
+    - **Property 3: Load more appends, never replaces**
+    - **Validates: Requirements 2.2**
+    - Use `fast-check` to generate random initial `entries` arrays and a next-page response; simulate the append reducer; assert all original entries remain at original indices and total length increases by the new page size
+    - `// Feature: audit-log-pagination, Property 3: load more appends never replaces`
+
+  - [ ]* 4.2 Write property test for Load More button visibility
+    - **Property 4: Load More button hidden when fully loaded**
+    - **Validates: Requirements 2.4**
+    - Use `fast-check` to generate states where `entries.length >= total > 0`; render component with mocked API; assert Load More button is not in the document
+    - `// Feature: audit-log-pagination, Property 4: load more button hidden when fully loaded`
+
+  - [ ]* 4.3 Write property test for summary string format
+    - **Property 5: Summary string format**
+    - **Validates: Requirements 3.1, 3.2**
+    - Use `fast-check` to generate random `(loaded, total)` pairs; assert rendered summary matches `"Showing X of Y entries"` for `total > 0` and `"No entries found"` for `total === 0`
+    - `// Feature: audit-log-pagination, Property 5: summary string format`
+
+  - [ ]* 4.4 Write example tests for loading state and error handling
+    - Test: initial load shows full-page loading indicator; resolves to entry list
+    - Test: Load More click disables button and shows inline indicator; resolves to appended list
+    - Test: fetch failure shows error message and re-enables Load More button
+    - Test: `?page=3` in URL causes pages 1, 2, 3 to be fetched and combined
+    - Test: missing/invalid `?page` param defaults to page 1
+    - _Requirements: 2.3, 2.5, 4.1, 4.3, 5.3_
+
+- [ ] 5. Update documentation and environment files
+  - Add the new endpoint to `docs/api-spec.md` under a new `## Audit Logs` section documenting `GET /api/audit-logs`, query params, and response envelope
+  - Confirm no new environment variables are required (the endpoint uses the existing `NEXT_PUBLIC_API_URL`); add a comment to `frontend/.env.example` noting the audit log endpoint is served from the same base URL
+  - _Requirements: 1.1, 1.3_
+
+- [ ] 6. Final checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- All tests mock MongoDB and do not require real Stellar or external network connections
+- The `confirmedAt` field already has a MongoDB index, so skip + limit queries are efficient
+- `fast-check` must be added as a dev dependency if not already present: `npm install --save-dev fast-check`


### PR DESCRIPTION
## Summary

Adds spec for paginated audit log page to fix the issue where `frontend/src/pages/audit-logs.jsx` fetches all entries in a single API call.

## Changes
- `.kiro/specs/audit-log-pagination/requirements.md` — 6 EARS-compliant requirements
- `.kiro/specs/audit-log-pagination/design.md` — architecture, correctness properties, testing strategy
- `.kiro/specs/audit-log-pagination/tasks.md` — 6 incremental implementation tasks

## Acceptance Criteria Addressed
- Audit logs loaded in pages of 50
- Load more button triggers next page fetch
- Total count displayed (Showing X of Y entries)
- Loading state shown while fetching
- URL reflects current page for shareable links

closes #415 