### PR TITLE
Feature/sync idempotency lock

### DIFF
--- a/.kiro/specs/audit-log-pagination/.config.kiro
+++ b/.kiro/specs/audit-log-pagination/.config.kiro
@@ -1,0 +1,1 @@
+{"generationMode": "requirements-first"}

--- a/.kiro/specs/audit-log-pagination/design.md
+++ b/.kiro/specs/audit-log-pagination/design.md
@@ -1,0 +1,192 @@
+# Design Document: Audit Log Pagination
+
+## Overview
+
+The audit log page currently fetches all payment records in one unbounded query. This design adds a paginated `GET /api/audit-logs` endpoint backed by the existing `Payment` MongoDB model, and replaces the single-fetch frontend with an incremental "load more" pattern. Entries are served in pages of 50, the URL reflects the current page for shareability, and a count summary keeps the user oriented.
+
+No new data model is needed — the `Payment` model already contains all audit-relevant fields (`txHash`, `studentId`, `amount`, `status`, `confirmedAt`, `verifiedAt`, etc.).
+
+---
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant AuditLogPage
+    participant ApiService
+    participant AuditLogController
+    participant PaymentModel
+
+    Browser->>AuditLogPage: navigate to /audit-logs[?page=N]
+    AuditLogPage->>ApiService: getAuditLogs({ page: 1..N, limit: 50 })
+    ApiService->>AuditLogController: GET /api/audit-logs?page=P&limit=50
+    AuditLogController->>PaymentModel: countDocuments()
+    AuditLogController->>PaymentModel: find().sort().skip().limit()
+    PaymentModel-->>AuditLogController: [Payment]
+    AuditLogController-->>ApiService: { data, total, page, limit, totalPages }
+    ApiService-->>AuditLogPage: response envelope
+    AuditLogPage-->>Browser: render entries + "Showing X of Y" + Load More button
+
+    Browser->>AuditLogPage: click "Load More"
+    AuditLogPage->>ApiService: getAuditLogs({ page: currentPage+1, limit: 50 })
+    AuditLogController-->>AuditLogPage: next page envelope
+    AuditLogPage-->>Browser: append entries, update URL ?page=N+1
+```
+
+---
+
+## Components and Interfaces
+
+### Backend
+
+#### `backend/src/controllers/auditLogController.js` (new)
+
+```js
+// GET /api/audit-logs?page=1&limit=50
+async function getAuditLogs(req, res, next)
+```
+
+- Parses and validates `page` (default 1) and `limit` (default 50, max 100) from `req.query`.
+- Returns `400 VALIDATION_ERROR` for non-positive-integer values.
+- Runs `Payment.countDocuments()` and `Payment.find().sort({ confirmedAt: -1 }).skip(skip).limit(limit)` in parallel via `Promise.all`.
+- Returns the envelope: `{ data, total, page, limit, totalPages }`.
+
+#### `backend/src/routes/auditLogRoutes.js` (new)
+
+```js
+router.get('/', getAuditLogs);
+```
+
+Mounted at `/api/audit-logs` in `backend/src/app.js`.
+
+### Frontend
+
+#### `frontend/src/services/api.js` (modified)
+
+```js
+export const getAuditLogs = ({ page = 1, limit = 50 } = {}) =>
+  api.get('/audit-logs', { params: { page, limit } });
+```
+
+#### `frontend/src/pages/audit-logs.jsx` (new)
+
+State:
+- `entries` — accumulated array of loaded Payment records
+- `page` — highest page fetched so far
+- `total` — Total_Count from last response
+- `totalPages` — from last response
+- `loading` — boolean, true while any fetch is in flight
+- `initialLoading` — boolean, true only during the very first fetch
+- `error` — error message string or null
+
+Behaviour:
+- On mount: read `?page` from URL (default 1). If `?page=N`, sequentially fetch pages 1..N and accumulate entries.
+- "Load More" click: fetch `page + 1`, append to `entries`, push `?page=N+1` to router.
+- URL updates use `router.push` with `shallow: true` to avoid full navigation.
+
+---
+
+## Data Models
+
+No new models. The existing `Payment` model fields used for the audit log display:
+
+| Field | Type | Notes |
+|---|---|---|
+| `txHash` | String | Unique on-chain reference |
+| `studentId` | String | Student identifier |
+| `amount` | Number | Payment amount |
+| `status` | String | `pending` / `confirmed` / `failed` |
+| `feeValidationStatus` | String | `valid` / `underpaid` / `overpaid` / `unknown` |
+| `confirmedAt` | Date | Sort key (descending) |
+| `verifiedAt` | Date | When verified via API |
+| `createdAt` | Date | Auto-managed by Mongoose |
+
+The `confirmedAt` field already has a MongoDB index (defined in `paymentModel.js`), so the sort + skip + limit query is efficient.
+
+---
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Pagination envelope invariant
+
+*For any* valid `page` and `limit` values and any dataset size, the API response SHALL always contain all five envelope fields (`data`, `total`, `page`, `limit`, `totalPages`), the `data` array length SHALL be at most `limit`, and `totalPages` SHALL equal `Math.ceil(total / limit)`.
+
+**Validates: Requirements 1.2, 1.3**
+
+### Property 2: Invalid parameters always rejected
+
+*For any* `page` or `limit` value that is not a positive integer (zero, negative, non-numeric string, float), the API SHALL return HTTP 400 with `code: "VALIDATION_ERROR"`.
+
+**Validates: Requirements 1.5**
+
+### Property 3: Load more appends, never replaces
+
+*For any* loaded state where `entries.length < total`, clicking Load More SHALL result in `entries.length` increasing by the number of entries in the next page, and all previously loaded entries SHALL remain in the list at their original positions.
+
+**Validates: Requirements 2.2**
+
+### Property 4: Load More button hidden when fully loaded
+
+*For any* state where `entries.length >= total` and `total > 0`, the Load More button SHALL NOT be present in the rendered output.
+
+**Validates: Requirements 2.4**
+
+### Property 5: Summary string format
+
+*For any* combination of loaded entry count X and total Y where Y > 0, the summary string SHALL match `"Showing X of Y entries"`. When Y = 0, the summary SHALL be `"No entries found"`.
+
+**Validates: Requirements 3.1, 3.2**
+
+---
+
+## Error Handling
+
+| Scenario | Backend behaviour | Frontend behaviour |
+|---|---|---|
+| Invalid `page`/`limit` params | 400 + `VALIDATION_ERROR` | Display error message, re-enable Load More |
+| MongoDB query failure | 500 via global error handler | Display error message, re-enable Load More |
+| Network timeout / 5xx | — | Display error message, re-enable Load More |
+| `page` beyond `totalPages` | 200 with empty `data` array | Load More hidden (no more pages) |
+
+The global Express error handler in `backend/src/app.js` already maps errors with a `code` property to structured JSON responses, so `auditLogController` only needs to attach `err.code = 'VALIDATION_ERROR'` before calling `next(err)`.
+
+---
+
+## Testing Strategy
+
+### Dual approach
+
+Both unit/example tests and property-based tests are used. Unit tests cover specific examples, edge cases, and integration points. Property tests verify universal correctness across many generated inputs.
+
+### Property-based testing library
+
+**Backend**: [`fast-check`](https://github.com/dubzzz/fast-check) (already available in the JS ecosystem, no Stellar/network dependency).  
+**Frontend**: [`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro/) with Jest for component example tests (property tests for pure functions use `fast-check`).
+
+Each property test runs a minimum of **100 iterations**.
+
+Tag format: `// Feature: audit-log-pagination, Property N: <property_text>`
+
+### Unit / example tests (`tests/auditLog.test.js`)
+
+- Controller returns correct envelope shape for a known dataset
+- Controller returns 400 for `page=0`, `page=-1`, `page=abc`, `limit=0`, `limit=101`
+- Controller returns empty `data` when `page > totalPages`
+- `getAuditLogs()` API service defaults to `page=1, limit=50`
+- Audit log page renders "No entries found" when total is 0
+- Audit log page shows loading indicator during fetch, removes it after
+- Audit log page shows error message and re-enables Load More on fetch failure
+- Audit log page pre-fetches pages 1..N when `?page=N` is in the URL
+
+### Property tests (`tests/auditLog.property.test.js`)
+
+- **Property 1** — Pagination envelope invariant: generate random `(page, limit, datasetSize)` triples, assert envelope fields and `data.length <= limit` and `totalPages == ceil(total/limit)`.
+- **Property 2** — Invalid params always rejected: generate invalid `page`/`limit` values, assert 400 + `VALIDATION_ERROR`.
+- **Property 3** — Load more appends: generate random initial state + next-page response, assert entries grow and existing entries are unchanged.
+- **Property 4** — Load More hidden when fully loaded: generate states where `entries.length >= total`, assert button absent.
+- **Property 5** — Summary string format: generate random `(loaded, total)` pairs, assert string matches expected format.
+
+All tests mock MongoDB and do not require real network connections to Stellar or external services, consistent with the existing test suite pattern in `tests/payment.test.js`.

--- a/.kiro/specs/audit-log-pagination/requirements.md
+++ b/.kiro/specs/audit-log-pagination/requirements.md
@@ -1,0 +1,82 @@
+# Requirements Document
+
+## Introduction
+
+The audit log page (`frontend/src/pages/audit-logs.jsx`) currently fetches all payment audit log entries in a single API call. With thousands of entries this causes slow page loads and high browser memory usage. This feature adds server-side pagination to the audit log API endpoint and updates the frontend to load entries in batches of 50, with a "Load more" button, a total count display, loading state feedback, and URL-reflected page state for shareable links.
+
+## Glossary
+
+- **Audit_Log_Page**: The Next.js page at `frontend/src/pages/audit-logs.jsx` that displays payment audit log entries.
+- **Audit_Log_API**: The Express endpoint `GET /api/audit-logs` that returns paginated payment records from MongoDB.
+- **Page**: A discrete batch of 50 audit log entries returned by a single API call.
+- **Cursor**: The page number (1-based integer) identifying which batch of entries to fetch.
+- **Total_Count**: The total number of audit log entries matching the current query, returned alongside each page.
+- **Load_More_Button**: The UI control that triggers fetching the next page of entries and appending them to the current list.
+- **Loading_State**: A visual indicator shown while an API request is in flight.
+
+---
+
+## Requirements
+
+### Requirement 1: Paginated Audit Log API Endpoint
+
+**User Story:** As a school administrator, I want the audit log API to return entries in pages, so that the server does not send thousands of records in a single response.
+
+#### Acceptance Criteria
+
+1. THE Audit_Log_API SHALL accept a `page` query parameter (positive integer, default `1`) and a `limit` query parameter (positive integer, default `50`, maximum `100`).
+2. WHEN a valid `page` and `limit` are provided, THE Audit_Log_API SHALL return exactly `limit` entries (or fewer on the last page), sorted by `confirmedAt` descending.
+3. THE Audit_Log_API SHALL return a response envelope containing `{ data: [...], total: <integer>, page: <integer>, limit: <integer>, totalPages: <integer> }`.
+4. WHEN `page` exceeds `totalPages`, THE Audit_Log_API SHALL return an empty `data` array with the correct `total` and `totalPages` values.
+5. IF the `page` or `limit` query parameter is not a positive integer, THEN THE Audit_Log_API SHALL return HTTP 400 with an error message and code `VALIDATION_ERROR`.
+
+### Requirement 2: Frontend Paginated Data Fetching
+
+**User Story:** As a school administrator, I want the audit log page to load entries in batches, so that the page loads quickly even when thousands of entries exist.
+
+#### Acceptance Criteria
+
+1. WHEN the Audit_Log_Page loads, THE Audit_Log_Page SHALL fetch only the first page (50 entries) from the Audit_Log_API.
+2. WHEN the user clicks the Load_More_Button, THE Audit_Log_Page SHALL fetch the next page and append the new entries to the existing list without replacing previously loaded entries.
+3. WHILE a page fetch is in progress, THE Audit_Log_Page SHALL display a Loading_State indicator and disable the Load_More_Button.
+4. WHEN all entries have been loaded (current count equals Total_Count), THE Audit_Log_Page SHALL hide the Load_More_Button.
+5. IF an API request fails, THEN THE Audit_Log_Page SHALL display an error message and re-enable the Load_More_Button so the user can retry.
+
+### Requirement 3: Total Count Display
+
+**User Story:** As a school administrator, I want to see how many entries are loaded versus the total, so that I know how much data exists and how much I have viewed.
+
+#### Acceptance Criteria
+
+1. WHEN entries are displayed, THE Audit_Log_Page SHALL show a summary string in the format `"Showing X of Y entries"` where X is the number of currently loaded entries and Y is the Total_Count.
+2. WHEN the Total_Count is zero, THE Audit_Log_Page SHALL display `"No entries found"` instead of the summary string.
+3. WHEN additional entries are loaded via the Load_More_Button, THE Audit_Log_Page SHALL update the summary string to reflect the new loaded count.
+
+### Requirement 4: URL-Reflected Page State
+
+**User Story:** As a school administrator, I want the current page number to be reflected in the URL, so that I can share or bookmark a link that restores the same view.
+
+#### Acceptance Criteria
+
+1. WHEN the Audit_Log_Page loads with a `?page=N` query parameter, THE Audit_Log_Page SHALL pre-fetch all pages from 1 through N and display the combined entries.
+2. WHEN the user loads more entries, THE Audit_Log_Page SHALL update the URL query parameter `page` to reflect the highest page loaded, without triggering a full page navigation.
+3. WHEN the `?page` parameter is absent or invalid, THE Audit_Log_Page SHALL default to page 1 and display the first 50 entries.
+
+### Requirement 5: Loading State
+
+**User Story:** As a school administrator, I want visual feedback while entries are loading, so that I know the application is working and not frozen.
+
+#### Acceptance Criteria
+
+1. WHEN the initial page load fetch is in progress, THE Audit_Log_Page SHALL display a full-page loading indicator in place of the entry list.
+2. WHEN a subsequent "load more" fetch is in progress, THE Audit_Log_Page SHALL display an inline loading indicator near the Load_More_Button.
+3. WHEN a fetch completes (success or error), THE Audit_Log_Page SHALL remove the loading indicator.
+
+### Requirement 6: API Service Integration
+
+**User Story:** As a frontend developer, I want a typed API service function for the paginated audit log endpoint, so that all pages and components call the API consistently.
+
+#### Acceptance Criteria
+
+1. THE Audit_Log_API service function SHALL accept `{ page, limit }` parameters and return the full response envelope.
+2. WHEN called without parameters, THE Audit_Log_API service function SHALL default to `page=1` and `limit=50`.

--- a/.kiro/specs/audit-log-pagination/tasks.md
+++ b/.kiro/specs/audit-log-pagination/tasks.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Audit Log Pagination
+
+## Overview
+
+Add a paginated `GET /api/audit-logs` backend endpoint, wire it into the Express app, create the `getAuditLogs` API service function, and build the `audit-logs.jsx` page with load-more, count summary, loading states, and URL-reflected page state.
+
+## Tasks
+
+- [ ] 1. Add paginated audit log controller and route
+  - Create `backend/src/controllers/auditLogController.js` with `getAuditLogs(req, res, next)`
+  - Parse and validate `page` (default 1) and `limit` (default 50, max 100) from `req.query`; call `next(err)` with `err.code = 'VALIDATION_ERROR'` for invalid values
+  - Run `Payment.countDocuments()` and `Payment.find().sort({ confirmedAt: -1 }).skip((page-1)*limit).limit(limit)` in parallel
+  - Return `{ data, total, page, limit, totalPages }` envelope
+  - Create `backend/src/routes/auditLogRoutes.js` with `router.get('/', getAuditLogs)`
+  - Mount the router at `/api/audit-logs` in `backend/src/app.js`
+  - _Requirements: 1.1, 1.2, 1.3, 1.4, 1.5_
+
+  - [ ]* 1.1 Write property test for pagination envelope invariant
+    - **Property 1: Pagination envelope invariant**
+    - **Validates: Requirements 1.2, 1.3**
+    - Use `fast-check` to generate random `(page, limit, datasetSize)` triples; mock `Payment` model; assert `data.length <= limit`, all five envelope fields present, `totalPages === Math.ceil(total / limit)`
+    - Include edge case: `page > totalPages` returns empty `data` with correct `total`
+    - `// Feature: audit-log-pagination, Property 1: pagination envelope invariant`
+
+  - [ ]* 1.2 Write property test for invalid parameter rejection
+    - **Property 2: Invalid parameters always rejected**
+    - **Validates: Requirements 1.5**
+    - Use `fast-check` to generate invalid `page`/`limit` values (zero, negative, non-numeric, float); assert HTTP 400 and `code: "VALIDATION_ERROR"` for each
+    - `// Feature: audit-log-pagination, Property 2: invalid parameters always rejected`
+
+- [ ] 2. Add `getAuditLogs` to the frontend API service
+  - Add `export const getAuditLogs = ({ page = 1, limit = 50 } = {}) => api.get('/audit-logs', { params: { page, limit } });` to `frontend/src/services/api.js`
+  - _Requirements: 6.1, 6.2_
+
+  - [ ]* 2.1 Write unit test for API service defaults
+    - Verify `getAuditLogs()` calls `/audit-logs?page=1&limit=50`
+    - Verify `getAuditLogs({ page: 3, limit: 25 })` calls `/audit-logs?page=3&limit=25`
+    - _Requirements: 6.1, 6.2_
+
+- [ ] 3. Checkpoint — ensure backend tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 4. Build the `audit-logs.jsx` page
+  - Create `frontend/src/pages/audit-logs.jsx`
+  - Manage state: `entries`, `page`, `total`, `totalPages`, `loading`, `initialLoading`, `error`
+  - On mount: read `?page=N` from Next.js router (default 1); sequentially fetch pages 1..N via `getAuditLogs` and accumulate entries into state
+  - Render a full-page loading indicator while `initialLoading` is true
+  - Render the entry list as a table with columns: Date, Student ID, Tx Hash, Amount, Status, Fee Validation
+  - Render the summary string: `"Showing X of Y entries"` or `"No entries found"` when total is 0
+  - Render the Load More button when `entries.length < total`; disable it while `loading` is true; show an inline loading indicator beside it during subsequent fetches
+  - On Load More click: fetch `page + 1`, append entries, update URL with `router.push({ query: { page: page + 1 } }, undefined, { shallow: true })`
+  - On fetch error: set `error` message, re-enable Load More button
+  - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 3.1, 3.2, 3.3, 4.1, 4.2, 4.3, 5.1, 5.2, 5.3_
+
+  - [ ]* 4.1 Write property test for load-more append behaviour
+    - **Property 3: Load more appends, never replaces**
+    - **Validates: Requirements 2.2**
+    - Use `fast-check` to generate random initial `entries` arrays and a next-page response; simulate the append reducer; assert all original entries remain at original indices and total length increases by the new page size
+    - `// Feature: audit-log-pagination, Property 3: load more appends never replaces`
+
+  - [ ]* 4.2 Write property test for Load More button visibility
+    - **Property 4: Load More button hidden when fully loaded**
+    - **Validates: Requirements 2.4**
+    - Use `fast-check` to generate states where `entries.length >= total > 0`; render component with mocked API; assert Load More button is not in the document
+    - `// Feature: audit-log-pagination, Property 4: load more button hidden when fully loaded`
+
+  - [ ]* 4.3 Write property test for summary string format
+    - **Property 5: Summary string format**
+    - **Validates: Requirements 3.1, 3.2**
+    - Use `fast-check` to generate random `(loaded, total)` pairs; assert rendered summary matches `"Showing X of Y entries"` for `total > 0` and `"No entries found"` for `total === 0`
+    - `// Feature: audit-log-pagination, Property 5: summary string format`
+
+  - [ ]* 4.4 Write example tests for loading state and error handling
+    - Test: initial load shows full-page loading indicator; resolves to entry list
+    - Test: Load More click disables button and shows inline indicator; resolves to appended list
+    - Test: fetch failure shows error message and re-enables Load More button
+    - Test: `?page=3` in URL causes pages 1, 2, 3 to be fetched and combined
+    - Test: missing/invalid `?page` param defaults to page 1
+    - _Requirements: 2.3, 2.5, 4.1, 4.3, 5.3_
+
+- [ ] 5. Update documentation and environment files
+  - Add the new endpoint to `docs/api-spec.md` under a new `## Audit Logs` section documenting `GET /api/audit-logs`, query params, and response envelope
+  - Confirm no new environment variables are required (the endpoint uses the existing `NEXT_PUBLIC_API_URL`); add a comment to `frontend/.env.example` noting the audit log endpoint is served from the same base URL
+  - _Requirements: 1.1, 1.3_
+
+- [ ] 6. Final checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- All tests mock MongoDB and do not require real Stellar or external network connections
+- The `confirmedAt` field already has a MongoDB index, so skip + limit queries are efficient
+- `fast-check` must be added as a dev dependency if not already present: `npm install --save-dev fast-check`

--- a/.kiro/specs/sync-idempotency-lock/.config.kiro
+++ b/.kiro/specs/sync-idempotency-lock/.config.kiro
@@ -1,0 +1,1 @@
+{"generationMode": "requirements-first"}

--- a/.kiro/specs/sync-idempotency-lock/design.md
+++ b/.kiro/specs/sync-idempotency-lock/design.md
@@ -1,0 +1,162 @@
+# Design Document: sync-idempotency-lock
+
+## Overview
+
+`POST /api/payments/sync` (and the background poller) both call `syncPayments()` in `stellarService.js`. Because the function fetches a batch of transactions and processes each one sequentially, two concurrent invocations can race: both read the same `txHash` from Horizon before either has written a `Payment` document, so both proceed through fee validation and student-status updates before the second one hits the `txHash` unique-index error.
+
+The fix introduces a **MongoDB-backed per-transaction lock** (`SyncLock` collection). Before processing any transaction, `syncPayments()` attempts an atomic upsert on a `SyncLock` document keyed by `txHash`. Only the caller that wins the upsert proceeds; all others skip that transaction. A TTL index on `expiresAt` ensures stale locks are cleaned up automatically if a process crashes mid-flight.
+
+No new infrastructure is required — the lock collection lives in the same MongoDB instance already used by the application.
+
+## Architecture
+
+```mermaid
+sequenceDiagram
+    participant PollerA as Background Poller
+    participant PollerB as Manual Trigger
+    participant SS as stellarService.syncPayments()
+    participant SL as SyncLock (MongoDB)
+    participant DB as Payment / Student / PaymentIntent
+
+    PollerA->>SS: syncPayments()
+    PollerB->>SS: syncPayments() [concurrent]
+
+    SS->>SL: findOneAndUpdate({txHash}, $setOnInsert, upsert:true) [PollerA]
+    SS->>SL: findOneAndUpdate({txHash}, $setOnInsert, upsert:true) [PollerB]
+
+    SL-->>SS: inserted (lock acquired) [PollerA]
+    SL-->>SS: existing doc returned (lock NOT acquired) [PollerB]
+
+    SS->>DB: Payment.create + Student.update + Intent.update [PollerA only]
+    Note over SS: PollerB skips — lock already held
+```
+
+## Components and Interfaces
+
+### SyncLockModel (`backend/src/models/syncLockModel.js`)
+
+New Mongoose model. Responsible for the lock collection and TTL index.
+
+```js
+const syncLockSchema = new mongoose.Schema({
+  txHash:    { type: String, required: true, unique: true, index: true },
+  lockedAt:  { type: Date, default: Date.now },
+  expiresAt: { type: Date, required: true },
+});
+syncLockSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+```
+
+### `acquireLock(txHash, ttlMs)` — helper in `syncLockModel.js`
+
+Performs the atomic upsert. Returns `true` if the lock was acquired (document was inserted), `false` if it already existed.
+
+```js
+async function acquireLock(txHash, ttlMs) {
+  const expiresAt = new Date(Date.now() + ttlMs);
+  const result = await SyncLock.findOneAndUpdate(
+    { txHash },
+    { $setOnInsert: { txHash, lockedAt: new Date(), expiresAt } },
+    { upsert: true, new: false, rawResult: true }
+  );
+  // upserted.n === 1 means a new document was inserted → lock acquired
+  return result.lastErrorObject?.upserted != null;
+}
+```
+
+### `syncPayments()` changes (`backend/src/services/stellarService.js`)
+
+The per-transaction loop gains a lock-acquisition step before the existing `Payment.findOne` existence check:
+
+```
+for each tx in transactions:
+  acquired = await acquireLock(tx.hash, SYNC_LOCK_TTL_MS)
+  if not acquired → continue          // another worker holds the lock
+  exists = await Payment.findOne(...)
+  if exists → continue                // already recorded (defence-in-depth)
+  ... existing processing logic ...
+  catch DuplicateKeyError → log + continue   // last-resort guard
+```
+
+### Config changes (`backend/src/config/index.js`)
+
+```js
+const SYNC_LOCK_TTL_MS = parseInt(process.env.SYNC_LOCK_TTL_MS || '30000', 10);
+```
+
+Exported alongside existing values.
+
+## Data Models
+
+### SyncLock document
+
+| Field       | Type   | Description                                              |
+|-------------|--------|----------------------------------------------------------|
+| `txHash`    | String | Stellar transaction hash — unique idempotency key        |
+| `lockedAt`  | Date   | When the lock was acquired                               |
+| `expiresAt` | Date   | `lockedAt + SYNC_LOCK_TTL_MS` — TTL index target field   |
+
+MongoDB TTL index: `{ expiresAt: 1 }, { expireAfterSeconds: 0 }`
+
+The TTL monitor runs approximately every 60 seconds, so actual deletion may lag up to 60 s beyond `expiresAt`. This is acceptable — the lock only needs to outlive the processing window (typically < 1 s).
+
+### No changes to existing models
+
+`Payment`, `Student`, `PaymentIntent`, and `PendingVerification` schemas are unchanged. The `txHash` unique index on `Payment` is preserved as a defence-in-depth guard.
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+Property 1: Lock acquisition is mutually exclusive
+*For any* `txHash`, if two concurrent calls to `acquireLock(txHash, ttl)` are made, exactly one SHALL return `true` and the other SHALL return `false`.
+**Validates: Requirements 1.1, 1.2**
+
+Property 2: Concurrent sync produces exactly one Payment record
+*For any* `txHash` that has not been previously processed, if `syncPayments()` is called concurrently N times with that transaction in the batch, exactly one `Payment` document SHALL be created for that `txHash`.
+**Validates: Requirements 1.3, 1.4, 4.2**
+
+Property 3: Lock skip leaves Payment collection unchanged
+*For any* `txHash` for which a lock already exists, calling `syncPayments()` SHALL result in zero new `Payment` documents for that `txHash`.
+**Validates: Requirements 1.4, 4.3**
+
+Property 4: TTL expiry allows reprocessing after crash
+*For any* lock document whose `expiresAt` is in the past, a subsequent call to `acquireLock(txHash, ttl)` SHALL return `true` (lock re-acquired), because MongoDB's TTL monitor will have removed the stale document.
+**Validates: Requirements 2.4**
+
+Property 5: Duplicate-key error is non-fatal
+*For any* scenario where `Payment.create` throws error code `11000`, `syncPayments()` SHALL NOT propagate the error and SHALL continue processing subsequent transactions in the batch.
+**Validates: Requirements 3.2**
+
+## Error Handling
+
+| Scenario | Behaviour |
+|---|---|
+| Lock already held by another worker | Skip transaction silently, continue batch |
+| `Payment.create` throws `11000` (duplicate key) | Catch, log warning, continue batch |
+| MongoDB connection error during lock acquisition | Propagate error — sync fails fast, poller retries on next interval |
+| Process crash while lock is held | TTL index removes lock after `SYNC_LOCK_TTL_MS` ms; next sync reprocesses |
+| `SYNC_LOCK_TTL_MS` not set | Default to `30000` ms |
+
+## Testing Strategy
+
+### Unit / Integration tests (Jest)
+
+All tests mock MongoDB models and the Stellar SDK, consistent with `tests/stellar.test.js`.
+
+- **Specific examples**: verify that a single sync call with one new transaction creates exactly one `Payment` document.
+- **Edge cases**: verify that a transaction already in `Payment` is skipped even without a lock (defence-in-depth path).
+- **Error conditions**: verify that a `11000` duplicate-key error from `Payment.create` does not abort the batch.
+
+### Property-based tests (fast-check)
+
+Each correctness property above is implemented as a property-based test using [fast-check](https://github.com/dubzzz/fast-check), configured to run a minimum of 100 iterations.
+
+Tag format: `Feature: sync-idempotency-lock, Property {N}: {property_text}`
+
+- **Property 1** — generate random `txHash` strings; simulate two concurrent `acquireLock` calls; assert exactly one returns `true`.
+- **Property 2** — generate random transaction batches; simulate N concurrent `syncPayments()` calls; assert `Payment.create` is called exactly once per unique `txHash`.
+- **Property 3** — pre-seed a lock document; call `syncPayments()`; assert `Payment.create` is never called for that `txHash`.
+- **Property 4** — generate an expired lock document (`expiresAt` in the past); call `acquireLock`; assert it returns `true`.
+- **Property 5** — simulate `Payment.create` throwing `11000`; assert `syncPayments()` resolves without throwing and processes remaining transactions.
+
+Each property test MUST be a single `fc.assert(fc.asyncProperty(...))` block referencing its property number in a comment.

--- a/.kiro/specs/sync-idempotency-lock/requirements.md
+++ b/.kiro/specs/sync-idempotency-lock/requirements.md
@@ -1,0 +1,71 @@
+# Requirements Document
+
+## Introduction
+
+`POST /api/payments/sync` currently has no idempotency protection. When two sync requests arrive simultaneously — for example, from the background poller (`transactionService.js`) and a manual trigger — both can fetch the same transactions from Horizon and begin processing them concurrently. The `txHash` unique index on the `Payment` collection prevents duplicate documents from being persisted, but the processing side-effects (fee validation, student status update, `PaymentIntent` status change) may execute twice before the duplicate-key error is thrown.
+
+This feature introduces a per-transaction distributed lock backed by MongoDB so that each Stellar transaction is processed exactly once, regardless of how many concurrent sync calls arrive. No new infrastructure dependency (e.g. Redis) is introduced; the lock collection reuses the existing MongoDB connection.
+
+## Glossary
+
+- **SyncLock**: A MongoDB document that represents an in-progress or recently-completed processing lock for a single Stellar transaction, keyed by `txHash`.
+- **Lock TTL**: The maximum duration a `SyncLock` document is allowed to exist before MongoDB automatically removes it, preventing deadlocks caused by a crashed process.
+- **txHash**: The unique 64-character hexadecimal Stellar transaction hash used as the idempotency key.
+- **Sync**: The operation performed by `syncPayments()` in `stellarService.js` that fetches recent Stellar transactions and records new payments.
+- **Background Poller**: The `setInterval`-based loop in `transactionService.js` that calls `syncPayments()` on a configurable interval.
+- **Processing Side-Effects**: The sequence of writes that occur when a new payment is recorded: `Payment.create`, `Student.findOneAndUpdate`, and `PaymentIntent.findByIdAndUpdate`.
+- **SyncLockModel**: The Mongoose model that manages `SyncLock` documents in MongoDB.
+
+## Requirements
+
+### Requirement 1: Per-Transaction Idempotency Lock
+
+**User Story:** As a system operator, I want each Stellar transaction to be processed by at most one sync worker at a time, so that concurrent sync calls cannot trigger duplicate fee validation or student status updates.
+
+#### Acceptance Criteria
+
+1. WHEN `syncPayments()` begins processing a transaction, THE SyncLockModel SHALL attempt to acquire a lock document keyed by `txHash` using an atomic `findOneAndUpdate` with `upsert: true` and `setOnInsert`.
+2. WHEN a lock document for a given `txHash` already exists, THE SyncLockModel SHALL return the existing document without overwriting it, causing the competing worker to skip that transaction.
+3. WHEN a lock is successfully acquired for a `txHash`, THE Sync SHALL proceed to execute all processing side-effects for that transaction exactly once.
+4. WHEN a lock acquisition attempt fails because the document already exists, THE Sync SHALL skip that transaction without error and continue processing the remaining transactions in the batch.
+5. THE SyncLockModel SHALL enforce a TTL index on the `expiresAt` field so that MongoDB automatically removes stale lock documents after the configured lock duration elapses.
+
+### Requirement 2: Lock TTL Configuration
+
+**User Story:** As a system operator, I want the lock TTL to be configurable via an environment variable, so that I can tune deadlock recovery time without redeploying code.
+
+#### Acceptance Criteria
+
+1. THE Config SHALL read a `SYNC_LOCK_TTL_MS` environment variable and default to `30000` (30 seconds) when the variable is absent.
+2. WHEN `SYNC_LOCK_TTL_MS` is set to a positive integer, THE SyncLockModel SHALL set the `expiresAt` field on each new lock document to `Date.now() + SYNC_LOCK_TTL_MS`.
+3. THE SyncLockModel SHALL define a MongoDB TTL index on `expiresAt` with `expireAfterSeconds: 0` so that the database removes expired documents automatically.
+4. WHEN a process crashes while holding a lock, THE SyncLockModel SHALL allow the lock to expire naturally via the TTL index, enabling subsequent sync calls to reprocess the transaction after the TTL elapses.
+
+### Requirement 3: Existing Duplicate-Key Guard Preserved
+
+**User Story:** As a developer, I want the existing `txHash` unique index on the `Payment` collection to remain as a last-resort guard, so that the system has defence-in-depth against duplicate payment records even if the lock layer is bypassed.
+
+#### Acceptance Criteria
+
+1. THE Payment collection SHALL retain the unique index on `txHash` as a secondary idempotency guard.
+2. WHEN `Payment.create` throws a duplicate-key error (MongoDB error code `11000`), THE Sync SHALL catch the error, log it, and continue processing remaining transactions without propagating the error.
+3. WHEN both the lock layer and the unique index are present, THE Sync SHALL rely on the lock as the primary guard and treat the unique index error as a non-fatal fallback.
+
+### Requirement 4: Testability Without Real Stellar Network
+
+**User Story:** As a developer, I want the idempotency lock logic to be testable with mocked dependencies, so that CI can verify concurrent-sync behaviour without connecting to the Stellar testnet.
+
+#### Acceptance Criteria
+
+1. THE SyncLockModel SHALL be injectable as a dependency or mockable via Jest's module mocking system, consistent with how `Payment`, `Student`, and `PaymentIntent` are mocked in existing tests.
+2. WHEN tests simulate two concurrent calls to `syncPayments()` for the same `txHash`, THE Sync SHALL invoke the processing side-effects exactly once across both calls.
+3. WHEN tests simulate a lock that has already been acquired, THE Sync SHALL skip processing for that transaction and produce no additional writes to the `Payment` collection.
+
+### Requirement 5: Environment Variable Documentation
+
+**User Story:** As a developer onboarding to the project, I want all new environment variables documented in `backend/.env.example`, so that I can configure the service correctly from the start.
+
+#### Acceptance Criteria
+
+1. THE `backend/.env.example` file SHALL include an entry for `SYNC_LOCK_TTL_MS` with a comment explaining its purpose and the default value.
+2. THE `backend/src/config/index.js` file SHALL export `SYNC_LOCK_TTL_MS` alongside the existing configuration values.

--- a/.kiro/specs/sync-idempotency-lock/tasks.md
+++ b/.kiro/specs/sync-idempotency-lock/tasks.md
@@ -1,0 +1,92 @@
+# Implementation Plan: sync-idempotency-lock
+
+## Overview
+
+Introduce a MongoDB-backed per-transaction idempotency lock into `syncPayments()` so that concurrent sync calls process each Stellar transaction exactly once. The work is split into: (1) the new `SyncLock` model and `acquireLock` helper, (2) wiring the lock into `syncPayments()`, (3) config + env-var plumbing, and (4) tests.
+
+## Tasks
+
+- [ ] 1. Create the SyncLock Mongoose model
+  - Create `backend/src/models/syncLockModel.js` with a schema containing `txHash` (String, unique), `lockedAt` (Date), and `expiresAt` (Date)
+  - Add a TTL index: `syncLockSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 })`
+  - Export an `acquireLock(txHash, ttlMs)` function that performs `SyncLock.findOneAndUpdate({ txHash }, { $setOnInsert: { txHash, lockedAt, expiresAt } }, { upsert: true, new: false, rawResult: true })` and returns `true` when `result.lastErrorObject?.upserted != null`, `false` otherwise
+  - _Requirements: 1.1, 1.2, 1.5, 2.2, 2.3_
+
+  - [ ]* 1.1 Write unit tests for acquireLock
+    - Test that the first call for a new `txHash` returns `true`
+    - Test that a second call for the same `txHash` returns `false`
+    - Test that `expiresAt` is set to approximately `Date.now() + ttlMs`
+    - Test that the TTL index is declared on the schema
+    - _Requirements: 1.1, 1.2, 2.2, 2.3_
+
+  - [ ]* 1.2 Write property test for lock mutual exclusion
+    - **Property 1: Lock acquisition is mutually exclusive**
+    - **Validates: Requirements 1.1, 1.2**
+    - Use `fast-check` to generate random `txHash` strings; simulate two concurrent `acquireLock` calls; assert exactly one returns `true`
+    - Tag: `Feature: sync-idempotency-lock, Property 1: Lock acquisition is mutually exclusive`
+
+- [ ] 2. Add SYNC_LOCK_TTL_MS to config
+  - In `backend/src/config/index.js`, read `process.env.SYNC_LOCK_TTL_MS` and parse it as an integer, defaulting to `30000`
+  - Export `SYNC_LOCK_TTL_MS` in the frozen config object
+  - Add an entry to `backend/.env.example`:
+    ```
+    # Lock TTL for per-transaction sync idempotency (ms, default: 30000)
+    SYNC_LOCK_TTL_MS=30000
+    ```
+  - _Requirements: 2.1, 5.1, 5.2_
+
+  - [ ]* 2.1 Write unit tests for config
+    - Test that `SYNC_LOCK_TTL_MS` defaults to `30000` when the env var is absent
+    - Test that it reads the env var value when set
+    - _Requirements: 2.1_
+
+- [ ] 3. Wire acquireLock into syncPayments()
+  - In `backend/src/services/stellarService.js`, import `acquireLock` from `syncLockModel` and `SYNC_LOCK_TTL_MS` from config
+  - At the top of the per-transaction loop (before the existing `Payment.findOne` existence check), call `acquireLock(tx.hash, SYNC_LOCK_TTL_MS)`; if it returns `false`, `continue` to the next transaction
+  - Wrap the `Payment.create` call in a try/catch that catches `err.code === 11000`, logs a warning, and `continue`s — preserving the existing defence-in-depth guard
+  - _Requirements: 1.1, 1.3, 1.4, 3.2, 3.3_
+
+  - [ ]* 3.1 Write property test for concurrent sync deduplication
+    - **Property 2: Concurrent sync produces exactly one Payment record**
+    - **Validates: Requirements 1.3, 1.4, 4.2**
+    - Use `fast-check` to generate random transaction batches; simulate N concurrent `syncPayments()` calls; assert `Payment.create` is called exactly once per unique `txHash`
+    - Tag: `Feature: sync-idempotency-lock, Property 2: Concurrent sync produces exactly one Payment record`
+
+  - [ ]* 3.2 Write property test for lock-skip behaviour
+    - **Property 3: Lock skip leaves Payment collection unchanged**
+    - **Validates: Requirements 1.4, 4.3**
+    - Pre-seed a `SyncLock` document for a `txHash`; call `syncPayments()` with that transaction in the batch; assert `Payment.create` is never called for that `txHash`
+    - Tag: `Feature: sync-idempotency-lock, Property 3: Lock skip leaves Payment collection unchanged`
+
+  - [ ]* 3.3 Write property test for duplicate-key non-fatal handling
+    - **Property 5: Duplicate-key error is non-fatal**
+    - **Validates: Requirements 3.2**
+    - Simulate `Payment.create` throwing `{ code: 11000 }`; assert `syncPayments()` resolves without throwing and continues processing subsequent transactions
+    - Tag: `Feature: sync-idempotency-lock, Property 5: Duplicate-key error is non-fatal`
+
+- [ ] 4. Checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [ ] 5. Write integration test for concurrent sync
+  - In `tests/stellar.test.js` (or a new `tests/syncLock.test.js`), add a test that:
+    - Mocks `SyncLock.findOneAndUpdate` to simulate the first call inserting (lock acquired) and the second call returning an existing document (lock not acquired)
+    - Calls `syncPayments()` twice concurrently via `Promise.all`
+    - Asserts `Payment.create` was called exactly once
+  - _Requirements: 4.2, 1.3_
+
+  - [ ]* 5.1 Write property test for TTL expiry re-acquisition
+    - **Property 4: TTL expiry allows reprocessing after crash**
+    - **Validates: Requirements 2.4**
+    - Generate an expired lock document (`expiresAt` in the past, simulated by having `findOneAndUpdate` return no upserted doc on first call then behave as if absent); assert `acquireLock` returns `true` on the subsequent call
+    - Tag: `Feature: sync-idempotency-lock, Property 4: TTL expiry allows reprocessing after crash`
+
+- [ ] 6. Final checkpoint — ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for a faster MVP
+- `fast-check` should be added as a dev dependency: `npm install --save-dev fast-check`
+- Each property test must run a minimum of 100 iterations (`fc.assert(..., { numRuns: 100 })`)
+- The `SyncLock` collection does not need to be pre-created; Mongoose will create it on first write
+- No changes to existing API routes or response shapes are required


### PR DESCRIPTION
### Problem
\`POST /api/payments/sync\` had no idempotency protection. When the background poller and a manual trigger fired simultaneously, both would fetch the same transactions from Horizon and race through the processing logic — running fee validation and student status updates twice before the \`txHash\` unique index finally blocked the second insert.

### Spec Created
Three spec files were added under \`.kiro/specs/sync-idempotency-lock/\`:

- **requirements.md** — 5 EARS-compliant requirements covering the per-transaction lock, TTL configuration, defence-in-depth guard, testability without a real Stellar network, and env-var documentation.
- **design.md** — MongoDB-backed \`SyncLock\` collection with an \`acquireLock(txHash, ttlMs)\` atomic upsert helper wired into \`syncPayments()\`. Includes 5 correctness properties and a Jest + fast-check testing strategy.
- **tasks.md** — 6 implementation tasks with optional property-based test sub-tasks.

### Proposed Fix (to be implemented)
- New \`SyncLock\` Mongoose model with a TTL index on \`expiresAt\`
- \`acquireLock(txHash, ttlMs)\` uses \`findOneAndUpdate\` with \`upsert: true\` + \`\$setOnInsert\` — only the first caller wins, all others skip
- \`syncPayments()\` calls \`acquireLock\` before processing each transaction
- \`SYNC_LOCK_TTL_MS\` env var (default 30s) controls deadlock recovery time
- No Redis or new infrastructure — reuses the existing MongoDB connection
- Existing \`txHash\` unique index on \`Payment\` is preserved as a defence-in-depth fallback

### Git History
- Branch: \`feature/sync-idempotency-lock\`
- Commit: \`356bcdf\` — spec: add sync-idempotency-lock requirements, design, and tasks"
closes #417 

 