### PR TITLE
feat: add CRUD API endpoints for fee adjustment rules

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -15,6 +15,7 @@ const schoolRoutes = require('./routes/schoolRoutes');
 const reminderRoutes = require('./routes/reminderRoutes');
 const disputeRoutes = require('./routes/disputeRoutes');
 const sourceValidationRuleRoutes = require('./routes/sourceValidationRuleRoutes');
+const feeAdjustmentRoutes = require('./routes/feeAdjustmentRoutes');
 
 const { startPolling, stopPolling } = require('./services/transactionPollingService');
 const { startRetryWorker, stopRetryWorker, isRetryWorkerRunning } = require('./services/retryService');
@@ -81,6 +82,7 @@ app.use('/api/reports', reportRoutes);
 app.use('/api/reminders', reminderRoutes);
 app.use('/api/disputes', disputeRoutes);
 app.use('/api/source-rules', sourceValidationRuleRoutes);
+app.use('/api/fee-adjustments', feeAdjustmentRoutes);
 app.get('/api/consistency', runConsistencyCheck);
 app.get('/health', healthCheck);
 

--- a/backend/src/controllers/feeAdjustmentController.js
+++ b/backend/src/controllers/feeAdjustmentController.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const FeeAdjustmentRule = require('../models/feeAdjustmentRuleModel');
+
+const VALID_TYPES = ['discount_percentage', 'discount_fixed', 'penalty_percentage', 'penalty_fixed', 'waiver'];
+
+function validateBody(body) {
+  const { name, type, value } = body;
+  if (!name || typeof name !== 'string' || !name.trim()) return 'name is required';
+  if (!VALID_TYPES.includes(type)) return `type must be one of: ${VALID_TYPES.join(', ')}`;
+  if (value == null || typeof value !== 'number' || value < 0) return 'value must be a non-negative number';
+  return null;
+}
+
+// POST /api/fee-adjustments
+async function createRule(req, res, next) {
+  try {
+    const validationError = validateBody(req.body);
+    if (validationError) {
+      const err = new Error(validationError);
+      err.code = 'VALIDATION_ERROR';
+      err.status = 400;
+      return next(err);
+    }
+
+    const { name, type, value, conditions, priority, description } = req.body;
+    const rule = await FeeAdjustmentRule.create({
+      schoolId: req.schoolId,
+      name: name.trim(),
+      type,
+      value,
+      conditions: conditions || {},
+      priority: priority ?? 10,
+      description,
+      isActive: true,
+    });
+
+    res.status(201).json(rule);
+  } catch (err) {
+    if (err.code === 11000) {
+      err.message = `A rule named "${req.body.name}" already exists for this school`;
+      err.code = 'DUPLICATE_RULE';
+      err.status = 409;
+    }
+    next(err);
+  }
+}
+
+// GET /api/fee-adjustments
+async function listRules(req, res, next) {
+  try {
+    const rules = await FeeAdjustmentRule.find({ schoolId: req.schoolId }).sort({ priority: 1, name: 1 });
+    res.json(rules);
+  } catch (err) {
+    next(err);
+  }
+}
+
+// PUT /api/fee-adjustments/:id
+async function updateRule(req, res, next) {
+  try {
+    const validationError = validateBody(req.body);
+    if (validationError) {
+      const err = new Error(validationError);
+      err.code = 'VALIDATION_ERROR';
+      err.status = 400;
+      return next(err);
+    }
+
+    const { name, type, value, conditions, priority, description, isActive } = req.body;
+    const rule = await FeeAdjustmentRule.findOneAndUpdate(
+      { _id: req.params.id, schoolId: req.schoolId },
+      { name: name.trim(), type, value, conditions, priority, description, isActive },
+      { new: true, runValidators: true }
+    );
+
+    if (!rule) {
+      const err = new Error('Fee adjustment rule not found');
+      err.code = 'NOT_FOUND';
+      err.status = 404;
+      return next(err);
+    }
+
+    res.json(rule);
+  } catch (err) {
+    if (err.code === 11000) {
+      err.message = `A rule named "${req.body.name}" already exists for this school`;
+      err.code = 'DUPLICATE_RULE';
+      err.status = 409;
+    }
+    next(err);
+  }
+}
+
+// DELETE /api/fee-adjustments/:id  — soft delete (deactivate)
+async function deleteRule(req, res, next) {
+  try {
+    const rule = await FeeAdjustmentRule.findOneAndUpdate(
+      { _id: req.params.id, schoolId: req.schoolId },
+      { isActive: false },
+      { new: true }
+    );
+
+    if (!rule) {
+      const err = new Error('Fee adjustment rule not found');
+      err.code = 'NOT_FOUND';
+      err.status = 404;
+      return next(err);
+    }
+
+    res.json({ message: `Rule "${rule.name}" deactivated` });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { createRule, listRules, updateRule, deleteRule };

--- a/backend/src/models/feeAdjustmentRuleModel.js
+++ b/backend/src/models/feeAdjustmentRuleModel.js
@@ -1,7 +1,8 @@
 const mongoose = require('mongoose');
 
 const feeAdjustmentRuleSchema = new mongoose.Schema({
-  name: { type: String, required: true, unique: true }, // e.g., "Early Bird Discount", "Late Penalty"
+  schoolId: { type: String, required: true, index: true },
+  name: { type: String, required: true }, // e.g., "Early Bird Discount", "Late Penalty"
   type: { 
     type: String, 
     enum: ['discount_percentage', 'discount_fixed', 'penalty_percentage', 'penalty_fixed', 'waiver'], 
@@ -21,5 +22,7 @@ const feeAdjustmentRuleSchema = new mongoose.Schema({
   priority: { type: Number, default: 10 },      // higher priority applied first
   description: { type: String }
 }, { timestamps: true });
+
+feeAdjustmentRuleSchema.index({ schoolId: 1, name: 1 }, { unique: true });
 
 module.exports = mongoose.model('FeeAdjustmentRule', feeAdjustmentRuleSchema);

--- a/backend/src/routes/feeAdjustmentRoutes.js
+++ b/backend/src/routes/feeAdjustmentRoutes.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const { createRule, listRules, updateRule, deleteRule } = require('../controllers/feeAdjustmentController');
+const { resolveSchool } = require('../middleware/schoolContext');
+const { requireAdminAuth } = require('../middleware/auth');
+
+router.use(resolveSchool);
+
+router.post('/',     requireAdminAuth, createRule);
+router.get('/',      listRules);
+router.put('/:id',   requireAdminAuth, updateRule);
+router.delete('/:id', requireAdminAuth, deleteRule);
+
+module.exports = router;

--- a/backend/src/services/feeAdjustmentService.js
+++ b/backend/src/services/feeAdjustmentService.js
@@ -12,7 +12,7 @@ class FeeAdjustmentService {
     let finalFee = feeStructure.feeAmount;
     const adjustmentsApplied = [];
 
-    const rules = await FeeAdjustmentRule.find({ isActive: true })
+    const rules = await FeeAdjustmentRule.find({ isActive: true, ...(paymentContext.schoolId ? { schoolId: paymentContext.schoolId } : {}) })
       .sort({ priority: 1 }); // lower number = higher priority
 
     for (const rule of rules) {

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -21,6 +21,7 @@ All error responses follow the [Error Responses](#error-responses) format.
 - [Retry Queue](#retry-queue)
 - [Health Check](#health-check)
 - [Error Responses](#error-responses)
+- [Fee Adjustment Rules](#fee-adjustment-rules)
 
 ---
 
@@ -1080,3 +1081,155 @@ Permanently delete a source validation rule by its MongoDB `_id`.
 | 403 | `INSUFFICIENT_ROLE` | Token does not have admin role |
 | 404 | `NOT_FOUND` | No rule found with the given id |
 
+
+## Fee Adjustment Rules
+
+Manage dynamic fee adjustment rules (discounts, penalties, waivers) scoped to a school.  
+All write endpoints require admin authentication and a school context header.
+
+### Rule Types
+
+| Type | Effect |
+|------|--------|
+| `discount_percentage` | Reduce fee by `value`% |
+| `discount_fixed` | Reduce fee by a fixed `value` amount |
+| `penalty_percentage` | Increase fee by `value`% |
+| `penalty_fixed` | Increase fee by a fixed `value` amount |
+| `waiver` | Waive the full fee (set to 0) |
+
+---
+
+#### POST /api/fee-adjustments
+
+Create a new fee adjustment rule for the school.
+
+**Headers:** `Authorization: Bearer <admin-token>`, `X-School-ID` or `X-School-Slug`
+
+**Request body:**
+
+```json
+{
+  "name": "Early Bird Discount",
+  "type": "discount_percentage",
+  "value": 10,
+  "conditions": {
+    "studentClass": ["JSS1", "JSS2"],
+    "paymentBefore": "2026-09-01T00:00:00.000Z"
+  },
+  "priority": 5,
+  "description": "10% discount for early payment"
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | ✅ | Unique rule name within the school |
+| `type` | ✅ | One of the rule types above |
+| `value` | ✅ | Non-negative number (percentage or fixed amount) |
+| `conditions` | No | Object with optional `studentClass[]`, `academicYear`, `paymentBefore`, `paymentAfter`, `minAmount`, `maxAmount` |
+| `priority` | No | Lower number = applied first (default: 10) |
+| `description` | No | Human-readable description |
+
+**Response `201`:**
+
+```json
+{
+  "_id": "507f1f77bcf86cd799439011",
+  "schoolId": "SCH001",
+  "name": "Early Bird Discount",
+  "type": "discount_percentage",
+  "value": 10,
+  "conditions": { "studentClass": ["JSS1", "JSS2"], "paymentBefore": "2026-09-01T00:00:00.000Z" },
+  "priority": 5,
+  "isActive": true,
+  "description": "10% discount for early payment",
+  "createdAt": "2026-04-23T15:00:00.000Z",
+  "updatedAt": "2026-04-23T15:00:00.000Z"
+}
+```
+
+**Error responses:**
+
+| Status | Code | Reason |
+|--------|------|--------|
+| 400 | `VALIDATION_ERROR` | Missing or invalid fields |
+| 401 | `MISSING_AUTH_TOKEN` | No Bearer token provided |
+| 403 | `INSUFFICIENT_ROLE` | Token does not have admin role |
+| 409 | `DUPLICATE_RULE` | A rule with this name already exists for the school |
+
+---
+
+#### GET /api/fee-adjustments
+
+List all fee adjustment rules for the school (active and inactive).
+
+**Headers:** `X-School-ID` or `X-School-Slug`
+
+**Response `200`:**
+
+```json
+[
+  {
+    "_id": "507f1f77bcf86cd799439011",
+    "schoolId": "SCH001",
+    "name": "Early Bird Discount",
+    "type": "discount_percentage",
+    "value": 10,
+    "conditions": {},
+    "priority": 5,
+    "isActive": true,
+    "description": "10% discount for early payment"
+  }
+]
+```
+
+**Error responses:**
+
+| Status | Code | Reason |
+|--------|------|--------|
+| 400 | `MISSING_SCHOOL_CONTEXT` | No school header provided |
+| 404 | `SCHOOL_NOT_FOUND` | School not found or inactive |
+
+---
+
+#### PUT /api/fee-adjustments/:id
+
+Update an existing fee adjustment rule.
+
+**Headers:** `Authorization: Bearer <admin-token>`, `X-School-ID` or `X-School-Slug`
+
+**Request body:** Same fields as POST.
+
+**Response `200`:** Updated rule object.
+
+**Error responses:**
+
+| Status | Code | Reason |
+|--------|------|--------|
+| 400 | `VALIDATION_ERROR` | Missing or invalid fields |
+| 401 | `MISSING_AUTH_TOKEN` | No Bearer token provided |
+| 403 | `INSUFFICIENT_ROLE` | Token does not have admin role |
+| 404 | `NOT_FOUND` | No rule found with the given id for this school |
+| 409 | `DUPLICATE_RULE` | Another rule with this name already exists |
+
+---
+
+#### DELETE /api/fee-adjustments/:id
+
+Deactivate a fee adjustment rule (soft delete — sets `isActive: false`).
+
+**Headers:** `Authorization: Bearer <admin-token>`, `X-School-ID` or `X-School-Slug`
+
+**Response `200`:**
+
+```json
+{ "message": "Rule \"Early Bird Discount\" deactivated" }
+```
+
+**Error responses:**
+
+| Status | Code | Reason |
+|--------|------|--------|
+| 401 | `MISSING_AUTH_TOKEN` | No Bearer token provided |
+| 403 | `INSUFFICIENT_ROLE` | Token does not have admin role |
+| 404 | `NOT_FOUND` | No rule found with the given id for this school |

--- a/tests/feeAdjustmentRules.test.js
+++ b/tests/feeAdjustmentRules.test.js
@@ -1,0 +1,366 @@
+'use strict';
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.SCHOOL_WALLET_ADDRESS = 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B';
+process.env.JWT_SECRET = 'test-secret';
+
+const request = require('supertest');
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  Schema: class {
+    constructor() { this.index = jest.fn(); }
+  },
+  model: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../backend/src/models/feeAdjustmentRuleModel', () => ({
+  create:            jest.fn(),
+  find:              jest.fn(),
+  findOneAndUpdate:  jest.fn(),
+}));
+
+// Minimal stubs for models loaded transitively by app.js
+jest.mock('../backend/src/models/studentModel', () => ({
+  create: jest.fn(), find: jest.fn().mockReturnValue({ sort: jest.fn().mockReturnValue({ skip: jest.fn().mockReturnValue({ limit: jest.fn().mockResolvedValue([]) }) }) }),
+  findOne: jest.fn().mockResolvedValue(null), findOneAndUpdate: jest.fn().mockResolvedValue({}), countDocuments: jest.fn().mockResolvedValue(0),
+}));
+jest.mock('../backend/src/models/paymentModel', () => ({
+  find: jest.fn().mockReturnValue({ sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue([]) }) }),
+  findOne: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({}),
+  aggregate: jest.fn().mockResolvedValue([]), countDocuments: jest.fn().mockResolvedValue(0),
+}));
+jest.mock('../backend/src/models/paymentIntentModel', () => ({
+  create: jest.fn().mockResolvedValue({}), findOne: jest.fn().mockResolvedValue(null), findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/models/idempotencyKeyModel', () => ({
+  findOne: jest.fn().mockResolvedValue(null), create: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/models/feeStructureModel', () => ({
+  create: jest.fn().mockResolvedValue({}), find: jest.fn().mockReturnValue({ sort: jest.fn().mockResolvedValue([]) }),
+  findOne: jest.fn().mockResolvedValue(null), findOneAndUpdate: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/models/pendingVerificationModel', () => ({
+  find: jest.fn().mockReturnValue({ sort: jest.fn().mockReturnValue({ limit: jest.fn().mockResolvedValue([]) }) }),
+  findOne: jest.fn().mockResolvedValue(null), findOneAndUpdate: jest.fn().mockResolvedValue({}), findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/models/schoolModel', () => ({
+  findOne: jest.fn().mockReturnValue({
+    lean: jest.fn().mockResolvedValue({
+      schoolId: 'SCH001', name: 'Test School', slug: 'test-school',
+      stellarAddress: 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B',
+      localCurrency: 'USD', isActive: true,
+    }),
+  }),
+  create: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/models/disputeModel', () => ({
+  create: jest.fn(), find: jest.fn(), findOne: jest.fn(), findOneAndUpdate: jest.fn(), countDocuments: jest.fn(),
+}));
+jest.mock('../backend/src/config/retryQueueSetup', () => ({
+  initializeRetryQueue: jest.fn(), setupMonitoring: jest.fn(),
+}));
+jest.mock('../backend/src/services/retryService', () => ({
+  queueForRetry: jest.fn().mockResolvedValue(undefined),
+  startRetryWorker: jest.fn(), stopRetryWorker: jest.fn(), isRetryWorkerRunning: jest.fn().mockReturnValue(false),
+}));
+jest.mock('../backend/src/services/transactionService', () => ({
+  startPolling: jest.fn(), stopPolling: jest.fn(),
+}));
+jest.mock('../backend/src/services/consistencyScheduler', () => ({
+  startConsistencyScheduler: jest.fn(),
+}));
+jest.mock('../backend/src/services/reminderService', () => ({
+  startReminderScheduler: jest.fn(), stopReminderScheduler: jest.fn(),
+  processReminders: jest.fn().mockResolvedValue({ schools: 0, eligible: 0, sent: 0, failed: 0, skipped: 0 }),
+}));
+jest.mock('../backend/src/services/stellarService', () => ({
+  syncPayments: jest.fn().mockResolvedValue(undefined),
+  syncPaymentsForSchool: jest.fn().mockResolvedValue(undefined),
+  verifyTransaction: jest.fn().mockResolvedValue({}),
+  recordPayment: jest.fn().mockResolvedValue({}),
+  finalizeConfirmedPayments: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../backend/src/services/currencyConversionService', () => ({
+  convertToLocalCurrency: jest.fn().mockResolvedValue({ available: false }),
+  enrichPaymentWithConversion: jest.fn().mockImplementation((p) => Promise.resolve(p)),
+  _getRates: jest.fn().mockResolvedValue(null),
+}));
+
+const app = require('../backend/src/app');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const jwt = require('jsonwebtoken');
+const ADMIN_TOKEN = jwt.sign({ role: 'admin', sub: 'admin-1' }, 'test-secret', { expiresIn: '1h' });
+const USER_TOKEN  = jwt.sign({ role: 'user',  sub: 'user-1'  }, 'test-secret', { expiresIn: '1h' });
+
+const SCHOOL_HEADERS = { 'X-School-ID': 'SCH001' };
+
+function adminApi(method, path) {
+  return request(app)[method](path)
+    .set('Authorization', `Bearer ${ADMIN_TOKEN}`)
+    .set(SCHOOL_HEADERS);
+}
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const MOCK_RULE = {
+  _id:       '507f1f77bcf86cd799439011',
+  schoolId:  'SCH001',
+  name:      'Early Bird Discount',
+  type:      'discount_percentage',
+  value:     10,
+  conditions: { studentClass: ['JSS1'], paymentBefore: '2026-09-01T00:00:00.000Z' },
+  isActive:  true,
+  priority:  5,
+  description: '10% discount for early payment',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+};
+
+// ─── POST /api/fee-adjustments ────────────────────────────────────────────────
+
+describe('POST /api/fee-adjustments — create a rule', () => {
+  let FeeAdjustmentRule;
+
+  beforeEach(() => {
+    FeeAdjustmentRule = require('../backend/src/models/feeAdjustmentRuleModel');
+    jest.clearAllMocks();
+  });
+
+  test('201 — creates a discount_percentage rule', async () => {
+    FeeAdjustmentRule.create.mockResolvedValueOnce(MOCK_RULE);
+
+    const res = await adminApi('post', '/api/fee-adjustments').send({
+      name: 'Early Bird Discount',
+      type: 'discount_percentage',
+      value: 10,
+      conditions: { studentClass: ['JSS1'] },
+      priority: 5,
+      description: '10% discount for early payment',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ name: 'Early Bird Discount', type: 'discount_percentage', value: 10 });
+  });
+
+  test('201 — creates a waiver rule', async () => {
+    const waiverRule = { ...MOCK_RULE, name: 'Full Waiver', type: 'waiver', value: 0 };
+    FeeAdjustmentRule.create.mockResolvedValueOnce(waiverRule);
+
+    const res = await adminApi('post', '/api/fee-adjustments').send({
+      name: 'Full Waiver', type: 'waiver', value: 0,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.type).toBe('waiver');
+  });
+
+  test('400 — missing name', async () => {
+    const res = await adminApi('post', '/api/fee-adjustments').send({ type: 'discount_percentage', value: 10 });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('code', 'VALIDATION_ERROR');
+  });
+
+  test('400 — missing type', async () => {
+    const res = await adminApi('post', '/api/fee-adjustments').send({ name: 'Test', value: 10 });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('code', 'VALIDATION_ERROR');
+  });
+
+  test('400 — invalid type value', async () => {
+    const res = await adminApi('post', '/api/fee-adjustments').send({ name: 'Test', type: 'invalid_type', value: 10 });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('code', 'VALIDATION_ERROR');
+  });
+
+  test('400 — negative value', async () => {
+    const res = await adminApi('post', '/api/fee-adjustments').send({ name: 'Test', type: 'discount_fixed', value: -5 });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('code', 'VALIDATION_ERROR');
+  });
+
+  test('409 — duplicate rule name for same school', async () => {
+    const dupError = new Error('duplicate key');
+    dupError.code = 11000;
+    FeeAdjustmentRule.create.mockRejectedValueOnce(dupError);
+
+    const res = await adminApi('post', '/api/fee-adjustments').send({
+      name: 'Early Bird Discount', type: 'discount_percentage', value: 10,
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toHaveProperty('code', 'DUPLICATE_RULE');
+  });
+
+  test('401 — unauthenticated request is rejected', async () => {
+    const res = await request(app).post('/api/fee-adjustments')
+      .set(SCHOOL_HEADERS)
+      .send({ name: 'Test', type: 'discount_percentage', value: 10 });
+    expect(res.status).toBe(401);
+  });
+
+  test('403 — non-admin token is rejected', async () => {
+    const res = await request(app).post('/api/fee-adjustments')
+      .set('Authorization', `Bearer ${USER_TOKEN}`)
+      .set(SCHOOL_HEADERS)
+      .send({ name: 'Test', type: 'discount_percentage', value: 10 });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── GET /api/fee-adjustments ─────────────────────────────────────────────────
+
+describe('GET /api/fee-adjustments — list rules', () => {
+  let FeeAdjustmentRule;
+
+  beforeEach(() => {
+    FeeAdjustmentRule = require('../backend/src/models/feeAdjustmentRuleModel');
+    jest.clearAllMocks();
+  });
+
+  test('200 — returns all rules for the school', async () => {
+    FeeAdjustmentRule.find.mockReturnValueOnce({
+      sort: jest.fn().mockResolvedValueOnce([MOCK_RULE]),
+    });
+
+    const res = await request(app).get('/api/fee-adjustments').set(SCHOOL_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body[0]).toMatchObject({ name: 'Early Bird Discount', schoolId: 'SCH001' });
+  });
+
+  test('200 — returns empty array when no rules exist', async () => {
+    FeeAdjustmentRule.find.mockReturnValueOnce({
+      sort: jest.fn().mockResolvedValueOnce([]),
+    });
+
+    const res = await request(app).get('/api/fee-adjustments').set(SCHOOL_HEADERS);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(0);
+  });
+
+  test('200 — scopes query to the resolved school', async () => {
+    FeeAdjustmentRule.find.mockReturnValueOnce({
+      sort: jest.fn().mockResolvedValueOnce([MOCK_RULE]),
+    });
+
+    await request(app).get('/api/fee-adjustments').set(SCHOOL_HEADERS);
+
+    expect(FeeAdjustmentRule.find).toHaveBeenCalledWith(expect.objectContaining({ schoolId: 'SCH001' }));
+  });
+
+  test('400 — missing school context header', async () => {
+    const res = await request(app).get('/api/fee-adjustments');
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('code', 'MISSING_SCHOOL_CONTEXT');
+  });
+});
+
+// ─── PUT /api/fee-adjustments/:id ─────────────────────────────────────────────
+
+describe('PUT /api/fee-adjustments/:id — update a rule', () => {
+  let FeeAdjustmentRule;
+
+  beforeEach(() => {
+    FeeAdjustmentRule = require('../backend/src/models/feeAdjustmentRuleModel');
+    jest.clearAllMocks();
+  });
+
+  test('200 — updates an existing rule', async () => {
+    const updated = { ...MOCK_RULE, value: 15, description: 'Updated discount' };
+    FeeAdjustmentRule.findOneAndUpdate.mockResolvedValueOnce(updated);
+
+    const res = await adminApi('put', `/api/fee-adjustments/${MOCK_RULE._id}`).send({
+      name: 'Early Bird Discount', type: 'discount_percentage', value: 15, description: 'Updated discount',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.value).toBe(15);
+  });
+
+  test('404 — rule not found', async () => {
+    FeeAdjustmentRule.findOneAndUpdate.mockResolvedValueOnce(null);
+
+    const res = await adminApi('put', '/api/fee-adjustments/000000000000000000000000').send({
+      name: 'Nonexistent', type: 'discount_fixed', value: 50,
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('code', 'NOT_FOUND');
+  });
+
+  test('400 — invalid body on update', async () => {
+    const res = await adminApi('put', `/api/fee-adjustments/${MOCK_RULE._id}`).send({
+      name: 'Test', type: 'bad_type', value: 10,
+    });
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('code', 'VALIDATION_ERROR');
+  });
+
+  test('401 — unauthenticated request is rejected', async () => {
+    const res = await request(app).put(`/api/fee-adjustments/${MOCK_RULE._id}`)
+      .set(SCHOOL_HEADERS)
+      .send({ name: 'Test', type: 'discount_percentage', value: 10 });
+    expect(res.status).toBe(401);
+  });
+
+  test('403 — non-admin token is rejected', async () => {
+    const res = await request(app).put(`/api/fee-adjustments/${MOCK_RULE._id}`)
+      .set('Authorization', `Bearer ${USER_TOKEN}`)
+      .set(SCHOOL_HEADERS)
+      .send({ name: 'Test', type: 'discount_percentage', value: 10 });
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─── DELETE /api/fee-adjustments/:id ─────────────────────────────────────────
+
+describe('DELETE /api/fee-adjustments/:id — deactivate a rule', () => {
+  let FeeAdjustmentRule;
+
+  beforeEach(() => {
+    FeeAdjustmentRule = require('../backend/src/models/feeAdjustmentRuleModel');
+    jest.clearAllMocks();
+  });
+
+  test('200 — deactivates an existing rule', async () => {
+    FeeAdjustmentRule.findOneAndUpdate.mockResolvedValueOnce({ ...MOCK_RULE, isActive: false });
+
+    const res = await adminApi('delete', `/api/fee-adjustments/${MOCK_RULE._id}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toContain('Early Bird Discount');
+    expect(FeeAdjustmentRule.findOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: MOCK_RULE._id }),
+      { isActive: false },
+      { new: true }
+    );
+  });
+
+  test('404 — rule not found', async () => {
+    FeeAdjustmentRule.findOneAndUpdate.mockResolvedValueOnce(null);
+
+    const res = await adminApi('delete', '/api/fee-adjustments/000000000000000000000000');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toHaveProperty('code', 'NOT_FOUND');
+  });
+
+  test('401 — unauthenticated request is rejected', async () => {
+    const res = await request(app).delete(`/api/fee-adjustments/${MOCK_RULE._id}`).set(SCHOOL_HEADERS);
+    expect(res.status).toBe(401);
+  });
+
+  test('403 — non-admin token is rejected', async () => {
+    const res = await request(app).delete(`/api/fee-adjustments/${MOCK_RULE._id}`)
+      .set('Authorization', `Bearer ${USER_TOKEN}`)
+      .set(SCHOOL_HEADERS);
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
Closes #419

---

## Summary

Implements the missing CRUD endpoints for fee adjustment rules, resolving the issue where administrators had no way to manage rules without direct database access.

## Changes

- **Model** (`feeAdjustmentRuleModel.js`): Added `schoolId` field for multi-school isolation; replaced global unique index on `name` with compound `{ schoolId, name }` index.
- **Service** (`feeAdjustmentService.js`): Scoped rule queries by `schoolId` when present in payment context.
- **Controller** (`feeAdjustmentController.js`): New file with `createRule`, `listRules`, `updateRule`, `deleteRule` handlers.
- **Routes** (`feeAdjustmentRoutes.js`): New file mounting routes at `/api/fee-adjustments` with `resolveSchool` and `requireAdminAuth` middleware.
- **App** (`app.js`): Mounted new routes.
- **Tests** (`tests/feeAdjustmentRules.test.js`): 20 tests covering all CRUD operations, auth enforcement, validation, and error cases.
- **Docs** (`docs/api-spec.md`): Added `Fee Adjustment Rules` section.

## Endpoints

| Method | Path | Auth |
|--------|------|------|
| `POST` | `/api/fee-adjustments` | Admin |
| `GET` | `/api/fee-adjustments` | Public |
| `PUT` | `/api/fee-adjustments/:id` | Admin |
| `DELETE` | `/api/fee-adjustments/:id` | Admin (soft delete) |

## Tested

- All four endpoints covered with happy path, validation errors, 401/403 auth, 404 not found, 409 duplicate, and school context scoping tests.