### PR TITLE
Add MAX_QUEUE_DEPTH backpressure to ConcurrentPaymentProcessor

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -245,6 +245,12 @@ MIN_PAYMENT_AMOUNT=0.01
 # Maximum payment amount in XLM/USDC (default: 100000)
 MAX_PAYMENT_AMOUNT=100000
 
+# ── Concurrent Payment Processor ───────────────────────────────
+# Maximum number of payments that can be in-flight simultaneously.
+# When this limit is reached, new payments return QUEUE_FULL and
+# are retried automatically by the batch processor. (default: 1000)
+MAX_QUEUE_DEPTH=1000
+
 # ── Fee Reminders ───────────────────────────────────────────────
 # How often the reminder scheduler runs in milliseconds (default: 86400000 = 24h)
 REMINDER_INTERVAL_MS=86400000

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -69,6 +69,9 @@ const MAX_PAYMENT_AMOUNT = parseFloat(
   process.env.MAX_PAYMENT_AMOUNT || "100000",
 );
 
+// ── Concurrent Payment Processor ─────────────────────────────────────────────
+const MAX_QUEUE_DEPTH = parseInt(process.env.MAX_QUEUE_DEPTH || "1000", 10);
+
 if (MIN_PAYMENT_AMOUNT < 0) {
   throw new Error("[Config] MIN_PAYMENT_AMOUNT must be a positive number");
 }
@@ -132,6 +135,7 @@ const config = Object.freeze({
   RETRY_MAX_ATTEMPTS,
   MIN_PAYMENT_AMOUNT,
   MAX_PAYMENT_AMOUNT,
+  MAX_QUEUE_DEPTH,
   REQUEST_TIMEOUT_MS,
   STELLAR_TIMEOUT_MS,
   JWT_SECRET,

--- a/backend/src/controllers/healthController.js
+++ b/backend/src/controllers/healthController.js
@@ -3,6 +3,7 @@
 const database = require('../config/database');
 const { server } = require('../config/stellarConfig');
 const config = require('../config');
+const { concurrentPaymentProcessor } = require('../services/concurrentPaymentProcessor');
 
 const STELLAR_CHECK_TIMEOUT_MS = Math.min(config.STELLAR_TIMEOUT_MS, 5000);
 
@@ -41,6 +42,8 @@ async function healthCheck(req, res) {
 
   const allHealthy = db.healthy === true && stellar.status === 'healthy';
 
+  const { queueDepth, maxQueueDepth } = concurrentPaymentProcessor.getStats();
+
   const body = {
     status: allHealthy ? 'healthy' : 'degraded',
     timestamp: new Date().toISOString(),
@@ -55,6 +58,10 @@ async function healthCheck(req, res) {
         ...stellar,
         network: config.STELLAR_NETWORK,
         horizonUrl: config.HORIZON_URL,
+      },
+      paymentProcessor: {
+        queueDepth,
+        maxQueueDepth,
       },
     },
   };

--- a/backend/src/services/concurrentPaymentProcessor.js
+++ b/backend/src/services/concurrentPaymentProcessor.js
@@ -123,6 +123,8 @@ class ConcurrentPaymentProcessor {
       options.lockStrategy || CONCURRENCY_STRATEGY.OPTIMISTIC;
     this.lockTimeoutMs = options.lockTimeoutMs || 30000;
     this.maxRetries = options.maxRetries || 3;
+    this.maxQueueDepth = options.maxQueueDepth || 1000;
+    this.activeCount = 0;
   }
 
   // ── Process Payment ───────────────────────────────────────────────────────
@@ -134,6 +136,15 @@ class ConcurrentPaymentProcessor {
       amount,
       txHash,
     } = options;
+
+    // Queue depth check
+    if (this.activeCount >= this.maxQueueDepth) {
+      return new PaymentProcessingResult(
+        false,
+        {},
+        { message: "Queue is full", code: "QUEUE_FULL" }
+      );
+    }
 
     // Idempotency check
     if (idempotencyKey && this.idempotencyCache.has(idempotencyKey)) {
@@ -157,6 +168,7 @@ class ConcurrentPaymentProcessor {
       );
     }
 
+    this.activeCount++;
     try {
       // Duplicate transaction
       const existingPayment = await Payment.findOne({ txHash });
@@ -219,6 +231,8 @@ class ConcurrentPaymentProcessor {
         {},
         { message: err.message, code: "PROCESSING_ERROR" }
       );
+    } finally {
+      this.activeCount--;
     }
   }
 
@@ -490,11 +504,24 @@ class ConcurrentPaymentProcessor {
   async processBatch(payments, options = {}) {
     const results = [];
     const concurrencyLimit = options.concurrencyLimit || 10;
+    const queueFullRetryDelayMs = options.queueFullRetryDelayMs || 500;
 
     for (let i = 0; i < payments.length; i += concurrencyLimit) {
       const batch = payments.slice(i, i + concurrencyLimit);
       const batchResults = await Promise.allSettled(
-        batch.map((p) => this.processPayment(p, options))
+        batch.map(async (p) => {
+          let result = await this.processPayment(p, options);
+          while (result && result.error && result.error.code === "QUEUE_FULL") {
+            logger.warn("[PaymentProcessor] Queue full, retrying after delay", {
+              retryDelayMs: queueFullRetryDelayMs,
+            });
+            await new Promise((resolve) =>
+              setTimeout(resolve, queueFullRetryDelayMs)
+            );
+            result = await this.processPayment(p, options);
+          }
+          return result;
+        })
       );
 
       for (const res of batchResults) {
@@ -520,9 +547,13 @@ class ConcurrentPaymentProcessor {
       transactionManagerStats: {
         activeTransactions: transactionManager.getActiveTransactionCount(),
       },
+      queueDepth: this.activeCount,
+      maxQueueDepth: this.maxQueueDepth,
     };
   }
 }
+
+const config = require("../config");
 
 // ── Singleton Instance ─────────────────────────────────────────────────────
 const concurrentPaymentProcessor = new ConcurrentPaymentProcessor({
@@ -531,6 +562,7 @@ const concurrentPaymentProcessor = new ConcurrentPaymentProcessor({
   lockStrategy: CONCURRENCY_STRATEGY.OPTIMISTIC,
   lockTimeoutMs: 30000,
   maxRetries: 3,
+  maxQueueDepth: config.MAX_QUEUE_DEPTH,
 });
 
 module.exports = {

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -869,8 +869,18 @@ Simple liveness probe. No auth or school context required.
 
 **Response `200`**
 ```json
-{ "status": "ok" }
+{
+  "status": "healthy",
+  "timestamp": "2026-04-23T15:00:00.000Z",
+  "checks": {
+    "database": { "status": "healthy", "latency_ms": 2 },
+    "stellar": { "status": "healthy", "latency_ms": 120, "network": "testnet", "horizonUrl": "https://horizon-testnet.stellar.org" },
+    "paymentProcessor": { "queueDepth": 0, "maxQueueDepth": 1000 }
+  }
+}
 ```
+
+`checks.paymentProcessor.queueDepth` is the number of payments currently being processed. When it reaches `maxQueueDepth` (controlled by `MAX_QUEUE_DEPTH` env var), new payments return `QUEUE_FULL` and are retried automatically.
 
 ---
 
@@ -910,6 +920,7 @@ Validation middleware failures return an `errors` array:
 | `DUPLICATE_STUDENT` | 409 | Student ID already exists for this school |
 | `STELLAR_NETWORK_ERROR` | 502 | Stellar Horizon API unreachable |
 | `REQUEST_TIMEOUT` | 503 | Request exceeded server timeout |
+| `QUEUE_FULL` | 503 | Payment processor queue is at capacity; caller should retry after a delay |
 | `INTERNAL_ERROR` | 500 | Unexpected server error |
 
 ---

--- a/tests/concurrent-payment-processor-queue.test.js
+++ b/tests/concurrent-payment-processor-queue.test.js
@@ -1,0 +1,196 @@
+'use strict';
+
+/**
+ * Tests for ConcurrentPaymentProcessor queue depth / backpressure.
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('../backend/src/services/transactionManager', () => ({
+  transactionManager: {
+    getActiveTransactionCount: jest.fn().mockReturnValue(0),
+  },
+}));
+
+jest.mock('../backend/src/utils/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../backend/src/models/paymentModel', () => ({
+  findOne: jest.fn(),
+  create: jest.fn(),
+}));
+
+jest.mock('../backend/src/models/studentModel', () => ({
+  findOne: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+}));
+
+jest.mock('../backend/src/models/paymentIntentModel', () => ({
+  findOne: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/webhookService', () => ({
+  sendPaymentWebhook: jest.fn(),
+}));
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+const {
+  ConcurrentPaymentProcessor,
+  PaymentProcessingResult,
+} = require('../backend/src/services/concurrentPaymentProcessor');
+
+const Payment = require('../backend/src/models/paymentModel');
+const Student = require('../backend/src/models/studentModel');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makePaymentData(n) {
+  return { memo: `STU00${n}`, senderAddress: 'GSENDER' };
+}
+
+function makeOptions(n) {
+  return {
+    studentId: `STU00${n}`,
+    amount: 100,
+    txHash: `txhash${n}`,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ConcurrentPaymentProcessor – queue depth backpressure', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // No duplicate transactions by default
+    Payment.findOne.mockResolvedValue(null);
+  });
+
+  describe('processPayment', () => {
+    test('returns QUEUE_FULL when activeCount >= maxQueueDepth', async () => {
+      const processor = new ConcurrentPaymentProcessor({ maxQueueDepth: 1 });
+
+      // Manually saturate the queue
+      processor.activeCount = 1;
+
+      const result = await processor.processPayment(makePaymentData(1), makeOptions(1));
+
+      expect(result.success).toBe(false);
+      expect(result.error.code).toBe('QUEUE_FULL');
+    });
+
+    test('allows processing when activeCount < maxQueueDepth', async () => {
+      const processor = new ConcurrentPaymentProcessor({ maxQueueDepth: 2 });
+      processor.activeCount = 1;
+
+      // Student not found → STUDENT_NOT_FOUND, but NOT QUEUE_FULL
+      Student.findOne.mockResolvedValue(null);
+
+      const result = await processor.processPayment(makePaymentData(1), makeOptions(1));
+
+      expect(result.error.code).not.toBe('QUEUE_FULL');
+    });
+
+    test('decrements activeCount after processing (success path)', async () => {
+      const processor = new ConcurrentPaymentProcessor({ maxQueueDepth: 10 });
+
+      Student.findOne.mockResolvedValue({
+        studentId: 'STU001',
+        feeAmount: 100,
+        totalPaid: 0,
+      });
+      Student.findOneAndUpdate.mockResolvedValue({
+        studentId: 'STU001',
+        feeAmount: 100,
+        totalPaid: 100,
+        feePaid: true,
+      });
+      Payment.create.mockResolvedValue({ _id: 'pay1', txHash: 'txhash1' });
+
+      expect(processor.activeCount).toBe(0);
+      await processor.processPayment(makePaymentData(1), makeOptions(1));
+      expect(processor.activeCount).toBe(0);
+    });
+
+    test('decrements activeCount after processing (error path)', async () => {
+      const processor = new ConcurrentPaymentProcessor({ maxQueueDepth: 10 });
+
+      // Force an unexpected error
+      Payment.findOne.mockRejectedValue(new Error('DB error'));
+
+      await processor.processPayment(makePaymentData(1), makeOptions(1));
+      expect(processor.activeCount).toBe(0);
+    });
+  });
+
+  describe('getStats', () => {
+    test('exposes queueDepth and maxQueueDepth', () => {
+      const processor = new ConcurrentPaymentProcessor({ maxQueueDepth: 42 });
+      processor.activeCount = 7;
+
+      const stats = processor.getStats();
+
+      expect(stats.queueDepth).toBe(7);
+      expect(stats.maxQueueDepth).toBe(42);
+    });
+  });
+
+  describe('processBatch', () => {
+    test('retries QUEUE_FULL items until they succeed', async () => {
+      jest.useFakeTimers();
+
+      const processor = new ConcurrentPaymentProcessor({ maxQueueDepth: 10 });
+
+      // processPayment returns QUEUE_FULL on first call, succeeds on second
+      const queueFullResult = new PaymentProcessingResult(
+        false, {}, { message: 'Queue is full', code: 'QUEUE_FULL' }
+      );
+      const successResult = new PaymentProcessingResult(true, { payment: { _id: 'p1' } });
+
+      const spy = jest
+        .spyOn(processor, 'processPayment')
+        .mockResolvedValueOnce(queueFullResult)
+        .mockResolvedValueOnce(successResult);
+
+      const batchPromise = processor.processBatch(
+        [makePaymentData(1)],
+        { ...makeOptions(1), queueFullRetryDelayMs: 100 }
+      );
+
+      // Advance past the retry delay
+      await jest.runAllTimersAsync();
+
+      const batchResult = await batchPromise;
+
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(batchResult.successful).toBe(1);
+      expect(batchResult.failed).toBe(0);
+
+      jest.useRealTimers();
+    });
+
+    test('reports failure for non-QUEUE_FULL errors without retrying', async () => {
+      const processor = new ConcurrentPaymentProcessor({ maxQueueDepth: 10 });
+
+      const errorResult = new PaymentProcessingResult(
+        false, {}, { message: 'Student not found', code: 'STUDENT_NOT_FOUND' }
+      );
+
+      const spy = jest
+        .spyOn(processor, 'processPayment')
+        .mockResolvedValue(errorResult);
+
+      const batchResult = await processor.processBatch([makePaymentData(1)], makeOptions(1));
+
+      // processPayment is called exactly once — no retry for non-QUEUE_FULL errors
+      expect(spy).toHaveBeenCalledTimes(1);
+      // The result is fulfilled (not thrown), so processBatch counts it as successful
+      // at the Promise level; the caller must inspect result.data.success for details
+      expect(batchResult.total).toBe(1);
+      expect(batchResult.successful).toBe(1); // fulfilled promise
+    });
+  });
+});


### PR DESCRIPTION
fix: add MAX\_QUEUE\_DEPTH backpressure to ConcurrentPaymentProcessor                                               
                                                                                                                      
  Problem                                                                                                             
                                                                                                                      
  ConcurrentPaymentProcessor queued payment processing tasks in memory with no upper bound. During a large sync after 
  a Stellar outage, processBatch could spawn thousands of concurrent in-flight payments and exhaust available memory, 
  causing the process to crash and payments to be lost.                                                               
                                                                                                                      
  Solution                                                                                                            
                                                                                                                      
  Introduce a configurable queue depth cap. When the limit is reached, processPayment returns a QUEUE_FULL            
  backpressure signal instead of accepting more work. processBatch handles this by retrying after a short delay rather
  than dropping payments.                                                                                             
                                                                                                                      
  Changes                                                                                                             
                                                                                                                      
                                        
  │ `concurrentPaymentProcessor.js` │ Tracks `activeCount`; rejects with `QUEUE_FULL` at capacity; `processBatch`     
  retries on `QUEUE_FULL`; `getStats()` exposes `queueDepth`/`maxQueueDepth` │                                        
  │ `config/index.js`               │ Parses `MAX_QUEUE_DEPTH` env var (default `1000`)                               
                                                                                                        │             
  │ `healthController.js`           │ `GET /health` now includes `checks.paymentProcessor.queueDepth` and             
  `maxQueueDepth`                                                                    │                                
  │ `backend/.env.example`          │ Documents `MAX_QUEUE_DEPTH`                                                     
                                                                                                                      
                                                                                                                      
          │                                                                                                           
  │ `docs/api-spec.md`                                 │ Updates health endpoint response shape; adds `QUEUE_FULL` to 
  error code table                                                                          │                         
  │ `tests/concurrent-payment-processor-queue.test.js` │ 7 new tests (all acceptance criteria covered)                
                                                                                                            │         
                     
                                                                                                                      
  Testing                                                                                                             
                                                                                                                      
  npx jest tests/concurrent-payment-processor-queue.test.js                                                           
  # 7 passed                                                                                                          
                                                                                                                      
  Acceptance criteria                                                                                                 
                                                                                                                      
  - [x] MAX_QUEUE_DEPTH env var controls maximum queue size (default: 1000)                                           
  - [x] When queue is full, new items return a QUEUE_FULL error                                                       
  - [x] Caller (processBatch) handles QUEUE_FULL by retrying after a delay                                            
  - [x] Queue depth exposed as a metric in the health endpoint                                                        
  - [x] Test covers queue-full scenario
  
  closes #420 