### PR TITLE
fix: resolve issues #425, #426, #427, #428 — indexes, scheduler guard, and 401 interceptor  

### DIFF
--- a/backend/migrations/007_add_payment_student_confirmedAt_index.js
+++ b/backend/migrations/007_add_payment_student_confirmedAt_index.js
@@ -1,0 +1,31 @@
+'use strict';
+
+/**
+ * Migration 007 — Add compound index { studentId: 1, confirmedAt: -1 } to payments
+ *
+ * GET /api/payments/:studentId sorts by confirmedAt descending. Without this
+ * index MongoDB performs a full collection scan + in-memory sort on every
+ * payment-history request.
+ *
+ * Also ensures { schoolId: 1, confirmedAt: -1 } exists for school-level queries.
+ */
+
+const mongoose = require('mongoose');
+
+const VERSION = '007_add_payment_student_confirmedAt_index';
+
+async function up() {
+  const collection = mongoose.connection.collection('payments');
+  await collection.createIndex({ studentId: 1, confirmedAt: -1 }, { background: true });
+  console.log('[007] Created index { studentId: 1, confirmedAt: -1 } on payments');
+  await collection.createIndex({ schoolId: 1, confirmedAt: -1 }, { background: true });
+  console.log('[007] Ensured index { schoolId: 1, confirmedAt: -1 } on payments');
+}
+
+async function down() {
+  const collection = mongoose.connection.collection('payments');
+  await collection.dropIndex({ studentId: 1, confirmedAt: -1 });
+  console.log('[007] Dropped index { studentId: 1, confirmedAt: -1 } from payments');
+}
+
+module.exports = { version: VERSION, up, down };

--- a/backend/migrations/008_add_school_slug_unique_index.js
+++ b/backend/migrations/008_add_school_slug_unique_index.js
@@ -1,0 +1,43 @@
+'use strict';
+
+/**
+ * Migration 008 — Ensure unique index on schools.slug
+ *
+ * schoolModel.js declares slug with unique:true inline, but Mongoose only
+ * creates schema indexes on new collections. This migration applies the
+ * unique index to existing collections and drops any non-unique slug index
+ * that may already exist.
+ */
+
+const mongoose = require('mongoose');
+
+const VERSION = '008_add_school_slug_unique_index';
+
+async function up() {
+  const collection = mongoose.connection.collection('schools');
+
+  // Drop any existing non-unique index on slug before creating the unique one
+  const indexes = await collection.indexes();
+  for (const idx of indexes) {
+    if (idx.key && idx.key.slug !== undefined && !idx.unique) {
+      await collection.dropIndex(idx.name);
+      console.log(`[008] Dropped non-unique slug index: ${idx.name}`);
+    }
+  }
+
+  await collection.createIndex({ slug: 1 }, { unique: true, background: true });
+  console.log('[008] Created unique index on schools.slug');
+}
+
+async function down() {
+  const collection = mongoose.connection.collection('schools');
+  const indexes = await collection.indexes();
+  for (const idx of indexes) {
+    if (idx.key && idx.key.slug !== undefined && idx.unique) {
+      await collection.dropIndex(idx.name);
+      console.log(`[008] Dropped unique slug index: ${idx.name}`);
+    }
+  }
+}
+
+module.exports = { version: VERSION, up, down };

--- a/backend/src/models/paymentModel.js
+++ b/backend/src/models/paymentModel.js
@@ -57,6 +57,7 @@ softDelete(paymentSchema);
 // Indexes
 // Note: txHash single-field index is declared inline (unique: true, index: true) above.
 // The compound below covers payment-history queries: filter by school+student, sort by date desc.
+paymentSchema.index({ studentId: 1, confirmedAt: -1 });
 paymentSchema.index({ schoolId: 1, confirmedAt: -1 });
 paymentSchema.index({ schoolId: 1, studentId: 1, confirmedAt: -1 });
 paymentSchema.index({ schoolId: 1, feeValidationStatus: 1 });

--- a/backend/src/models/schoolModel.js
+++ b/backend/src/models/schoolModel.js
@@ -41,6 +41,7 @@ const schoolSchema = new mongoose.Schema(
   { timestamps: true }
 );
 
+schoolSchema.index({ slug: 1 }, { unique: true });
 schoolSchema.index({ slug: 1, isActive: 1 });
 
 module.exports = mongoose.model('School', schoolSchema);

--- a/backend/src/services/consistencyScheduler.js
+++ b/backend/src/services/consistencyScheduler.js
@@ -1,4 +1,5 @@
 const { checkConsistency } = require('./consistencyService');
+const School = require('../models/schoolModel');
 
 const INTERVAL_MS = parseInt(process.env.CONSISTENCY_CHECK_INTERVAL_MS, 10) || 5 * 60 * 1000; // default 5 min
 
@@ -6,6 +7,11 @@ let _timer = null;
 
 async function runCheck() {
   try {
+    const schoolCount = await School.countDocuments({ isActive: true });
+    if (schoolCount === 0) {
+      console.log('[ConsistencyChecker] Skipping — no active schools configured');
+      return;
+    }
     const report = await checkConsistency();
     if (report.mismatchCount > 0) {
       console.warn(`[ConsistencyChecker] ${report.mismatchCount} mismatch(es) detected at ${report.checkedAt}:`);

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -7,6 +7,16 @@ const api = axios.create({
   timeout: TIMEOUT_MS,
 });
 
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (error.response?.status === 401 && typeof window !== "undefined") {
+      window.location.href = "/login";
+    }
+    return Promise.reject(error);
+  }
+);
+
 export const getStudents = (page = 1, limit = 50) =>
   api.get("/students", { params: { page, limit } });
 export const registerStudent = (data) => api.post("/students", data);


### PR DESCRIPTION
                                                            
                                                                                                                                                          
  Closes #425                                                                                                                                             
  Closes #426                                                                                                                                             
  Closes #427                                                                                                                                             
  Closes #428                                                                                                                                             
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ## Summary                                                                                                                                              
                                                                                                                                                          
  This PR addresses four bugs identified during a codebase review of StellarEduPay — covering a missing database index, a missing unique index            
  enforcement, a noisy scheduler on fresh installs, and a silent 401 failure on the frontend.                                                             
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ## Changes                                                                                                                                              
                                                                                                                                                          
  ### #425 — `paymentModel.js`: Add `{ studentId: 1, confirmedAt: -1 }` compound index                                                                    
                                                                                                                                                          
  **Problem:** `GET /api/payments/:studentId` sorts payment history by `confirmedAt` descending. No index existed on `studentId + confirmedAt`, causing a 
  full collection scan and in-memory sort on every request.                                                                                               
                                                                                                                                                          
  **Fix:**                                                                                                                                                
  - Added `paymentSchema.index({ studentId: 1, confirmedAt: -1 })` to `backend/src/models/paymentModel.js`                                                
  - Created migration `backend/migrations/007_add_payment_student_confirmedAt_index.js` to apply the index to existing collections. Also ensures `{       
  schoolId: 1, confirmedAt: -1 }` exists for school-level queries.                                                                                        
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ### #426 — `schoolModel.js`: Enforce unique index on `slug` field                                                                                       
                                                                                                                                                          
  **Problem:** The `slug` field had `unique: true` declared inline on the schema field, but Mongoose only creates schema-level indexes on new collections.
  Existing deployments had no unique index enforced at the database level, allowing two schools to be created with the same slug — causing                
  `schoolContext.js` middleware to return the wrong school.                                                                                               
                                                                                                                                                          
  **Fix:**                                                                                                                                                
  - Added `schoolSchema.index({ slug: 1 }, { unique: true })` as an explicit index declaration in `backend/src/models/schoolModel.js`                     
  - Created migration `backend/migrations/008_add_school_slug_unique_index.js` to apply the unique index to existing collections, dropping any            
  pre-existing non-unique slug index first to avoid conflicts.                                                                                            
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ### #427 — `consistencyScheduler.js`: Skip run when no schools are configured                                                                           
                                                                                                                                                          
  **Problem:** `consistencyScheduler.js` ran on a fixed interval regardless of whether any schools existed. On a fresh installation with no schools, every
  run logged errors, polluting logs and wasting CPU cycles.                                                                                               
                                                                                                                                                          
  **Fix:**                                                                                                                                                
  - Added a `School.countDocuments({ isActive: true })` guard at the top of `runCheck()` in `backend/src/services/consistencyScheduler.js`                
  - If the count is zero, the function logs a single informational skip message and returns early — no consistency check is attempted.                    
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ### #428 — `api.js` (frontend): Add global 401 response interceptor                                                                                     
                                                                                                                                                          
  **Problem:** The Axios instance in `frontend/src/services/api.js` had no response interceptor. When the backend returned `401 Unauthorized` (e.g.       
  expired admin token), the frontend silently failed or surfaced a raw error with no redirect to the login page.                                          
                                                                                                                                                          
  **Fix:**                                                                                                                                                
  - Added `api.interceptors.response.use(...)` to `frontend/src/services/api.js`                                                                          
  - On a 401 response, `window.location.href` is set to `/login`, redirecting the user to re-authenticate. A `typeof window !== "undefined"` guard ensures
  SSR compatibility.                                                                                                                                      
                                                                                                                                                          
  ---                                                                                                                                                     
                                                                                                                                                          
  ## Files Changed                                                                                                                                        
                                                                                                                                                          
  | File | Issue |                                                                                                                                        
  |------|-------|                                                                                                                                        
  | `backend/src/models/paymentModel.js` | #425 |                                                                                                         
  | `backend/migrations/007_add_payment_student_confirmedAt_index.js` | #425 |                                                                            
  | `backend/src/models/schoolModel.js` | #426 |                                                                                                          
  | `backend/migrations/008_add_school_slug_unique_index.js` | #426 |                                                                                     
  | `backend/src/services/consistencyScheduler.js` | #427 |                                                                                               
  | `frontend/src/services/api.js` | #428 |                                                                                                               
                                              