### PR TITLE
feat: runtime log level change via admin API 

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,11 @@ MONGO_URI=mongodb://localhost:27017/stellaredupay
 MONGO_ROOT_USERNAME=root
 MONGO_ROOT_PASSWORD=change_me_to_a_secure_password
 
+# ── Logging ──────────────────────────────────────────────────────────────────
+# Initial log level at startup. Can be changed at runtime via POST /api/admin/log-level.
+# Valid values: error | warn | info | debug (default: info)
+LOG_LEVEL=info
+
 # ── Database Connection Pool ─────────────────────────────────────────────────
 # Maximum number of sockets in the connection pool (default: 100)
 DB_MAX_POOL_SIZE=100

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,6 +17,7 @@ const disputeRoutes = require('./routes/disputeRoutes');
 const sourceValidationRuleRoutes = require('./routes/sourceValidationRuleRoutes');
 const receiptsRoutes = require('./routes/receiptsRoutes');
 const feeAdjustmentRoutes = require('./routes/feeAdjustmentRoutes');
+const adminRoutes = require('./routes/adminRoutes');
 
 const { startPolling, stopPolling } = require('./services/transactionPollingService');
 const retrySelector = require('./services/retryServiceSelector');
@@ -82,6 +83,7 @@ app.use('/api/disputes', disputeRoutes);
 app.use('/api/source-rules', sourceValidationRuleRoutes);
 app.use('/api/receipts', receiptsRoutes);
 app.use('/api/fee-adjustments', feeAdjustmentRoutes);
+app.use('/api/admin', adminRoutes);
 app.get('/api/consistency', runConsistencyCheck);
 app.get('/health', healthCheck);
 

--- a/backend/src/controllers/adminController.js
+++ b/backend/src/controllers/adminController.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const logger = require('../utils/logger');
+const { logAudit } = require('../services/auditService');
+
+const VALID_LEVELS = ['debug', 'info', 'warn', 'error'];
+
+/**
+ * POST /api/admin/log-level
+ * Body: { level: 'debug' | 'info' | 'warn' | 'error' }
+ * Requires admin auth.
+ */
+async function setLogLevel(req, res, next) {
+  try {
+    const { level } = req.body;
+
+    if (!level || !VALID_LEVELS.includes(level.toLowerCase())) {
+      return res.status(400).json({
+        error: `Invalid log level. Must be one of: ${VALID_LEVELS.join(', ')}`,
+        code: 'INVALID_LOG_LEVEL',
+      });
+    }
+
+    const previous = logger.getLevel();
+    logger.setLevel(level);
+    const current = logger.getLevel();
+
+    logger.info('Log level changed at runtime', { previous, current, changedBy: req.admin?.email || req.admin?.userId });
+
+    // Audit log (no schoolId for system-level actions)
+    if (req.auditContext) {
+      await logAudit({
+        schoolId: 'system',
+        action: 'log_level_change',
+        performedBy: req.auditContext.performedBy,
+        targetId: 'log_level',
+        targetType: 'system_config',
+        details: { previous, current },
+        result: 'success',
+        ipAddress: req.auditContext.ipAddress,
+        userAgent: req.auditContext.userAgent,
+      });
+    }
+
+    res.json({ previous, current });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { setLogLevel };

--- a/backend/src/controllers/healthController.js
+++ b/backend/src/controllers/healthController.js
@@ -4,6 +4,7 @@ const database = require('../config/database');
 const { server } = require('../config/stellarConfig');
 const config = require('../config');
 const { concurrentPaymentProcessor } = require('../services/concurrentPaymentProcessor');
+const logger = require('../utils/logger');
 
 const STELLAR_CHECK_TIMEOUT_MS = Math.min(config.STELLAR_TIMEOUT_MS, 5000);
 
@@ -47,6 +48,7 @@ async function healthCheck(req, res) {
   const body = {
     status: allHealthy ? 'healthy' : 'degraded',
     timestamp: new Date().toISOString(),
+    logLevel: logger.getLevel(),
     checks: {
       database: {
         status: db.healthy ? 'healthy' : 'unhealthy',

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const { setLogLevel } = require('../controllers/adminController');
+const { requireAdminAuth } = require('../middleware/auth');
+const { auditContext } = require('../middleware/auditContext');
+
+// POST /api/admin/log-level — change log level at runtime
+router.post('/log-level', requireAdminAuth, auditContext, setLogLevel);
+
+module.exports = router;

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -2,9 +2,9 @@
 
 /**
  * Structured Logger Utility
- * 
+ *
  * Provides consistent logging with levels, timestamps, and context.
- * Can be easily swapped for a more robust solution like Winston or Pino.
+ * Supports runtime log level changes via setLevel() — no server restart needed.
  */
 
 const LOG_LEVELS = {
@@ -14,25 +14,48 @@ const LOG_LEVELS = {
   DEBUG: 3,
 };
 
-const currentLevel = process.env.LOG_LEVEL || 'INFO';
+const VALID_LEVELS = Object.keys(LOG_LEVELS);
+
+// Mutable runtime level — starts from env var, can be changed via setLevel()
+let _currentLevel = (process.env.LOG_LEVEL || 'INFO').toUpperCase();
+if (!VALID_LEVELS.includes(_currentLevel)) {
+  _currentLevel = 'INFO';
+}
+
+/**
+ * Set the log level at runtime. Takes effect immediately for all subsequent calls.
+ * @param {string} level - One of 'debug' | 'info' | 'warn' | 'error' (case-insensitive)
+ * @throws {Error} if level is invalid
+ */
+function setLevel(level) {
+  const upper = (level || '').toUpperCase();
+  if (!VALID_LEVELS.includes(upper)) {
+    throw new Error(`Invalid log level "${level}". Must be one of: ${VALID_LEVELS.join(', ').toLowerCase()}`);
+  }
+  _currentLevel = upper;
+}
+
+/**
+ * Get the current log level.
+ * @returns {string} current level in lowercase
+ */
+function getLevel() {
+  return _currentLevel.toLowerCase();
+}
 
 function shouldLog(level) {
-  return LOG_LEVELS[level] <= LOG_LEVELS[currentLevel];
+  return LOG_LEVELS[level] <= LOG_LEVELS[_currentLevel];
 }
 
 function formatMessage(level, message, ...args) {
   const timestamp = new Date().toISOString();
   const formattedArgs = args.map(arg => {
     if (arg instanceof Error) {
-      return {
-        message: arg.message,
-        stack: arg.stack,
-        ...arg,
-      };
+      return { message: arg.message, stack: arg.stack, ...arg };
     }
     return arg;
   });
-  
+
   return {
     timestamp,
     level,
@@ -45,44 +68,45 @@ function formatMessage(level, message, ...args) {
 const logger = {
   error(message, ...args) {
     if (shouldLog('ERROR')) {
-      const formatted = formatMessage('ERROR', message, ...args);
-      console.error(JSON.stringify(formatted));
+      console.error(JSON.stringify(formatMessage('ERROR', message, ...args)));
     }
   },
-  
+
   warn(message, ...args) {
     if (shouldLog('WARN')) {
-      const formatted = formatMessage('WARN', message, ...args);
-      console.warn(JSON.stringify(formatted));
+      console.warn(JSON.stringify(formatMessage('WARN', message, ...args)));
     }
   },
-  
+
   info(message, ...args) {
     if (shouldLog('INFO')) {
-      const formatted = formatMessage('INFO', message, ...args);
-      console.log(JSON.stringify(formatted));
+      console.log(JSON.stringify(formatMessage('INFO', message, ...args)));
     }
   },
-  
+
   debug(message, ...args) {
     if (shouldLog('DEBUG')) {
-      const formatted = formatMessage('DEBUG', message, ...args);
-      console.log(JSON.stringify(formatted));
+      console.log(JSON.stringify(formatMessage('DEBUG', message, ...args)));
     }
   },
-  
+
   /**
-   * Create a child logger with additional context
+   * Create a child logger with additional context prefix.
    */
   child(context) {
     return {
       error: (message, ...args) => logger.error(`[${context}] ${message}`, ...args),
-      warn: (message, ...args) => logger.warn(`[${context}] ${message}`, ...args),
-      info: (message, ...args) => logger.info(`[${context}] ${message}`, ...args),
+      warn:  (message, ...args) => logger.warn(`[${context}] ${message}`, ...args),
+      info:  (message, ...args) => logger.info(`[${context}] ${message}`, ...args),
       debug: (message, ...args) => logger.debug(`[${context}] ${message}`, ...args),
     };
   },
+
+  setLevel,
+  getLevel,
 };
 
 module.exports = logger;
-module.exports.logger = logger; // named export for destructured imports
+module.exports.logger = logger;
+module.exports.setLevel = setLevel;
+module.exports.getLevel = getLevel;

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -20,6 +20,7 @@ All error responses follow the [Error Responses](#error-responses) format.
 - [Reminders](#reminders)
 - [Retry Queue](#retry-queue)
 - [Health Check](#health-check)
+- [Admin](#admin)
 - [Error Responses](#error-responses)
 - [Fee Adjustment Rules](#fee-adjustment-rules)
 
@@ -914,6 +915,7 @@ Simple liveness probe. No auth or school context required.
 {
   "status": "healthy",
   "timestamp": "2026-04-23T15:00:00.000Z",
+  "logLevel": "info",
   "checks": {
     "database": { "status": "healthy", "latency_ms": 2 },
     "stellar": { "status": "healthy", "latency_ms": 120, "network": "testnet", "horizonUrl": "https://horizon-testnet.stellar.org" },
@@ -923,6 +925,37 @@ Simple liveness probe. No auth or school context required.
 ```
 
 `checks.paymentProcessor.queueDepth` is the number of payments currently being processed. When it reaches `maxQueueDepth` (controlled by `MAX_QUEUE_DEPTH` env var), new payments return `QUEUE_FULL` and are retried automatically.
+
+`logLevel` reflects the current runtime log level (see [Admin — Set Log Level](#admin--set-log-level)).
+
+---
+
+## Admin
+
+### Set log level — admin only
+
+Change the server log level at runtime without restarting.
+
+```
+POST /api/admin/log-level
+Authorization: Bearer <token>
+```
+
+**Request body**
+
+| Field | Type | Required | Values |
+|---|---|---|---|
+| `level` | string | Yes | `debug`, `info`, `warn`, `error` |
+
+**Response `200`**
+```json
+{ "previous": "info", "current": "debug" }
+```
+
+**Errors**
+- `400 INVALID_LOG_LEVEL` — level is missing or not one of the accepted values
+- `401 MISSING_AUTH_TOKEN` — no Bearer token provided
+- `403 INSUFFICIENT_ROLE` — token does not have admin role
 
 ---
 

--- a/tests/logLevel.test.js
+++ b/tests/logLevel.test.js
@@ -1,0 +1,233 @@
+'use strict';
+
+/**
+ * Tests for runtime log level change — issue #456
+ * Covers: POST /api/admin/log-level and GET /health logLevel field
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.SCHOOL_WALLET_ADDRESS = 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B';
+process.env.JWT_SECRET = 'test-secret';
+
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  connection: {
+    readyState: 1,
+    close: jest.fn().mockResolvedValue(true),
+    on: jest.fn(),
+    db: {
+      admin: jest.fn().mockReturnValue({ ping: jest.fn().mockResolvedValue(true) }),
+    },
+  },
+  Schema: class { constructor() { this.index = jest.fn(); } },
+  model: jest.fn().mockReturnValue({}),
+}));
+
+jest.mock('../backend/src/config/database', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  disconnect: jest.fn().mockResolvedValue(true),
+  healthCheck: jest.fn().mockResolvedValue({ healthy: true, latency: 1, readyState: 1 }),
+  getConnectionInfo: jest.fn().mockReturnValue({}),
+  getConnection: jest.fn(),
+  POOL_CONFIG: {},
+  RETRY_CONFIG: {},
+  TRANSACTION_CONFIG: {},
+}));
+
+jest.mock('../backend/src/config/stellarConfig', () => ({
+  server: { serverInfo: jest.fn().mockResolvedValue({}) },
+  networkPassphrase: 'Test SDF Network ; September 2015',
+  SCHOOL_WALLET: null,
+  StellarSdk: {},
+  ACCEPTED_ASSETS: {},
+  CONFIRMATION_THRESHOLD: 2,
+  isAcceptedAsset: jest.fn(),
+  resolveAsset: jest.fn(),
+}));
+
+jest.mock('../backend/src/config/retryQueueSetup', () => ({
+  initializeRetryQueue: jest.fn(),
+  setupMonitoring: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/retryService', () => ({
+  queueForRetry: jest.fn().mockResolvedValue(undefined),
+  startRetryWorker: jest.fn(),
+  stopRetryWorker: jest.fn(),
+  isRetryWorkerRunning: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../backend/src/services/transactionService', () => ({
+  startPolling: jest.fn(),
+  stopPolling: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/consistencyScheduler', () => ({
+  startConsistencyScheduler: jest.fn(),
+}));
+
+jest.mock('../backend/src/middleware/concurrentRequestHandler', () => ({
+  createConcurrentRequestMiddleware: jest.fn(() => ({
+    rateLimiter: jest.fn(() => (req, res, next) => next()),
+    requestQueue: jest.fn(() => (req, res, next) => next()),
+  })),
+}));
+
+jest.mock('../backend/src/services/concurrentPaymentProcessor', () => ({
+  concurrentPaymentProcessor: { getStats: jest.fn().mockReturnValue({ queueDepth: 0, maxQueueDepth: 50 }) },
+}));
+
+jest.mock('../backend/src/models/auditLogModel', () => ({
+  create: jest.fn().mockResolvedValue({}),
+}));
+
+// Stub all other routes to avoid unrelated failures
+const routeStub = () => {
+  const fn = jest.fn((req, res, next) => next && next());
+  fn.use = jest.fn().mockReturnThis();
+  fn.get = jest.fn().mockReturnThis();
+  fn.post = jest.fn().mockReturnThis();
+  fn.put = jest.fn().mockReturnThis();
+  fn.patch = jest.fn().mockReturnThis();
+  fn.delete = jest.fn().mockReturnThis();
+  return fn;
+};
+
+jest.mock('../backend/src/routes/schoolRoutes', routeStub);
+jest.mock('../backend/src/routes/studentRoutes', routeStub);
+jest.mock('../backend/src/routes/paymentRoutes', routeStub);
+jest.mock('../backend/src/routes/feeRoutes', routeStub);
+jest.mock('../backend/src/routes/reportRoutes', routeStub);
+jest.mock('../backend/src/controllers/consistencyController', () => ({
+  runConsistencyCheck: jest.fn((req, res) => res.json({ status: 'ok' })),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function adminToken() {
+  return jwt.sign({ role: 'admin', email: 'admin@test.com' }, 'test-secret', { expiresIn: '1h' });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Runtime log level — issue #456', () => {
+  let app;
+  let logger;
+
+  beforeAll(() => {
+    app = require('../backend/src/app');
+    logger = require('../backend/src/utils/logger');
+  });
+
+  afterEach(() => {
+    // Reset to INFO after each test
+    logger.setLevel('info');
+  });
+
+  describe('logger.setLevel / logger.getLevel', () => {
+    it('returns current level', () => {
+      logger.setLevel('debug');
+      expect(logger.getLevel()).toBe('debug');
+    });
+
+    it('is case-insensitive', () => {
+      logger.setLevel('WARN');
+      expect(logger.getLevel()).toBe('warn');
+    });
+
+    it('throws on invalid level', () => {
+      expect(() => logger.setLevel('verbose')).toThrow(/invalid log level/i);
+    });
+
+    it('change takes effect immediately — debug messages suppressed at warn level', () => {
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      logger.setLevel('warn');
+      logger.debug('should not appear');
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+
+    it('change takes effect immediately — debug messages visible at debug level', () => {
+      const spy = jest.spyOn(console, 'log').mockImplementation(() => {});
+      logger.setLevel('debug');
+      logger.debug('should appear');
+      expect(spy).toHaveBeenCalledTimes(1);
+      spy.mockRestore();
+    });
+  });
+
+  describe('POST /api/admin/log-level', () => {
+    it('401 without auth token', async () => {
+      const res = await request(app)
+        .post('/api/admin/log-level')
+        .send({ level: 'debug' });
+      expect(res.status).toBe(401);
+    });
+
+    it('400 for invalid level', async () => {
+      const res = await request(app)
+        .post('/api/admin/log-level')
+        .set('Authorization', `Bearer ${adminToken()}`)
+        .send({ level: 'verbose' });
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('INVALID_LOG_LEVEL');
+    });
+
+    it('400 when level is missing', async () => {
+      const res = await request(app)
+        .post('/api/admin/log-level')
+        .set('Authorization', `Bearer ${adminToken()}`)
+        .send({});
+      expect(res.status).toBe(400);
+    });
+
+    it('200 and changes level to debug', async () => {
+      const res = await request(app)
+        .post('/api/admin/log-level')
+        .set('Authorization', `Bearer ${adminToken()}`)
+        .send({ level: 'debug' });
+      expect(res.status).toBe(200);
+      expect(res.body.current).toBe('debug');
+      expect(res.body.previous).toBeDefined();
+      expect(logger.getLevel()).toBe('debug');
+    });
+
+    it('200 and changes level to error', async () => {
+      const res = await request(app)
+        .post('/api/admin/log-level')
+        .set('Authorization', `Bearer ${adminToken()}`)
+        .send({ level: 'error' });
+      expect(res.status).toBe(200);
+      expect(res.body.current).toBe('error');
+    });
+
+    it('accepts level in uppercase', async () => {
+      const res = await request(app)
+        .post('/api/admin/log-level')
+        .set('Authorization', `Bearer ${adminToken()}`)
+        .send({ level: 'WARN' });
+      expect(res.status).toBe(200);
+      expect(res.body.current).toBe('warn');
+    });
+  });
+
+  describe('GET /health includes logLevel', () => {
+    it('returns logLevel field', async () => {
+      logger.setLevel('info');
+      const res = await request(app).get('/health');
+      expect(res.body).toHaveProperty('logLevel');
+      expect(res.body.logLevel).toBe('info');
+    });
+
+    it('reflects runtime level change', async () => {
+      logger.setLevel('debug');
+      const res = await request(app).get('/health');
+      expect(res.body.logLevel).toBe('debug');
+    });
+  });
+});


### PR DESCRIPTION
- Add setLevel()/getLevel() to logger.js; level stored in mutable variable so changes take effect immediately for all subsequent log calls
- Add POST /api/admin/log-level endpoint (requireAdminAuth + auditContext) accepting { level: 'debug'|'info'|'warn'|'error' }
- Expose current logLevel in GET /health response
- Add adminRoutes.js and mount at /api/admin in app.js
- Add tests/logLevel.test.js covering unit + integration cases
- Document new endpoint in docs/api-spec.md
- Add LOG_LEVEL to backend/.env.example with description
— closes #456