### PR TITLE
feat: PUT /api/fees/:className with cascadeToStudents — 

### DIFF
--- a/backend/src/controllers/feeController.js
+++ b/backend/src/controllers/feeController.js
@@ -153,7 +153,7 @@ async function deleteFeeStructure(req, res, next) {
 async function updateFeeStructure(req, res, next) {
   try {
     const { className } = req.params;
-    const { feeAmount, description, paymentDeadline } = req.body;
+    const { feeAmount, description, academicYear, paymentDeadline, cascadeToStudents } = req.body;
 
     if (feeAmount == null) {
       const err = new Error('feeAmount is required');
@@ -161,13 +161,15 @@ async function updateFeeStructure(req, res, next) {
       return next(err);
     }
 
+    // Build update object — only include fields explicitly provided
+    const updateFields = { feeAmount };
+    if (description !== undefined) updateFields.description = description;
+    if (academicYear !== undefined) updateFields.academicYear = academicYear;
+    if (paymentDeadline !== undefined) updateFields.paymentDeadline = paymentDeadline;
+
     const fee = await FeeStructure.findOneAndUpdate(
       { schoolId: req.schoolId, className, isActive: true },
-      {
-        feeAmount,
-        description: description !== undefined ? description : undefined,
-        paymentDeadline: paymentDeadline !== undefined ? paymentDeadline : undefined,
-      },
+      updateFields,
       { new: true, runValidators: true }
     );
 
@@ -180,6 +182,17 @@ async function updateFeeStructure(req, res, next) {
     // Invalidate fee caches
     del(KEYS.feesAll(), KEYS.feeByClass(className));
 
+    // Optionally cascade feeAmount update to all students in this class
+    let studentsUpdated = 0;
+    if (cascadeToStudents === true) {
+      const Student = require('../models/studentModel');
+      const result = await Student.updateMany(
+        { schoolId: req.schoolId, class: className, deletedAt: null },
+        { feeAmount, remainingBalance: null }
+      );
+      studentsUpdated = result.modifiedCount || 0;
+    }
+
     // Audit log
     if (req.auditContext) {
       await logAudit({
@@ -188,14 +201,14 @@ async function updateFeeStructure(req, res, next) {
         performedBy: req.auditContext.performedBy,
         targetId: className,
         targetType: 'fee',
-        details: { className, feeAmount, description, paymentDeadline },
+        details: { className, feeAmount, description, academicYear, paymentDeadline, cascadeToStudents, studentsUpdated },
         result: 'success',
         ipAddress: req.auditContext.ipAddress,
         userAgent: req.auditContext.userAgent,
       });
     }
 
-    res.json(fee);
+    res.json({ fee, studentsUpdated });
   } catch (err) {
     next(err);
   }

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -299,6 +299,36 @@ Sets `isActive: false`. Record is retained for audit.
 { "message": "Fee structure for class Grade 5A deactivated" }
 ```
 
+### Update a fee structure — admin only
+```
+PUT /api/fees/:className
+Authorization: Bearer <token>
+X-School-ID: SCH-3F2A
+```
+
+**Request body**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `feeAmount` | number | Yes | New fee amount (positive) |
+| `description` | string | No | |
+| `academicYear` | string | No | e.g. `"2026"` |
+| `paymentDeadline` | string | No | ISO date string |
+| `cascadeToStudents` | boolean | No | If `true`, updates `feeAmount` on all students in this class |
+
+**Response `200`**
+```json
+{
+  "fee": { "className": "Grade 5A", "feeAmount": 300, "description": "Updated fee", "academicYear": "2026", "isActive": true },
+  "studentsUpdated": 42
+}
+```
+`studentsUpdated` is `0` when `cascadeToStudents` is omitted or `false`.
+
+**Errors**
+- `400 VALIDATION_ERROR` — `feeAmount` missing
+- `404 NOT_FOUND` — no active fee structure for this class
+
 ---
 
 ## Payments

--- a/tests/feeStructureUpdate.test.js
+++ b/tests/feeStructureUpdate.test.js
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * Tests for PUT /api/fees/:className with cascadeToStudents — issue #454
+ */
+
+const { updateFeeStructure } = require('../backend/src/controllers/feeController');
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../backend/src/models/feeStructureModel');
+jest.mock('../backend/src/models/studentModel');
+jest.mock('../backend/src/cache', () => ({
+  get: jest.fn().mockReturnValue(undefined),
+  set: jest.fn(),
+  del: jest.fn(),
+  KEYS: {
+    feesAll: jest.fn().mockReturnValue('fees:all'),
+    feeByClass: jest.fn((c) => `fees:class:${c}`),
+  },
+  TTL: { FEES: 300 },
+}));
+jest.mock('../backend/src/services/auditService', () => ({
+  logAudit: jest.fn().mockResolvedValue(undefined),
+}));
+
+const FeeStructure = require('../backend/src/models/feeStructureModel');
+const Student = require('../backend/src/models/studentModel');
+const { logAudit } = require('../backend/src/services/auditService');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockReq(body = {}, params = {}) {
+  return {
+    schoolId: 'SCH-TEST',
+    params: { className: 'Grade 5A', ...params },
+    body,
+    auditContext: { performedBy: 'admin@test.com', ipAddress: '127.0.0.1', userAgent: 'jest' },
+  };
+}
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+const mockFee = {
+  _id: 'fee-id-1',
+  schoolId: 'SCH-TEST',
+  className: 'Grade 5A',
+  feeAmount: 300,
+  description: 'Updated fee',
+  academicYear: '2026',
+  isActive: true,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PUT /api/fees/:className — issue #454', () => {
+  let next;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    next = jest.fn();
+  });
+
+  it('400 when feeAmount is missing', async () => {
+    const req = mockReq({});
+    const res = mockRes();
+    await updateFeeStructure(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'VALIDATION_ERROR' }));
+  });
+
+  it('404 when fee structure not found', async () => {
+    FeeStructure.findOneAndUpdate = jest.fn().mockResolvedValue(null);
+    const req = mockReq({ feeAmount: 300 });
+    const res = mockRes();
+    await updateFeeStructure(req, res, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_FOUND' }));
+  });
+
+  it('200 updates fee without cascade', async () => {
+    FeeStructure.findOneAndUpdate = jest.fn().mockResolvedValue(mockFee);
+    const req = mockReq({ feeAmount: 300, description: 'Updated fee', academicYear: '2026' });
+    const res = mockRes();
+    await updateFeeStructure(req, res, next);
+    expect(res.json).toHaveBeenCalledWith({ fee: mockFee, studentsUpdated: 0 });
+    expect(Student.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('200 updates fee with cascadeToStudents: true', async () => {
+    FeeStructure.findOneAndUpdate = jest.fn().mockResolvedValue(mockFee);
+    Student.updateMany = jest.fn().mockResolvedValue({ modifiedCount: 5 });
+    const req = mockReq({ feeAmount: 300, cascadeToStudents: true });
+    const res = mockRes();
+    await updateFeeStructure(req, res, next);
+    expect(Student.updateMany).toHaveBeenCalledWith(
+      { schoolId: 'SCH-TEST', class: 'Grade 5A', deletedAt: null },
+      { feeAmount: 300, remainingBalance: null }
+    );
+    expect(res.json).toHaveBeenCalledWith({ fee: mockFee, studentsUpdated: 5 });
+  });
+
+  it('cascadeToStudents: false does not update students', async () => {
+    FeeStructure.findOneAndUpdate = jest.fn().mockResolvedValue(mockFee);
+    const req = mockReq({ feeAmount: 300, cascadeToStudents: false });
+    const res = mockRes();
+    await updateFeeStructure(req, res, next);
+    expect(Student.updateMany).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ fee: mockFee, studentsUpdated: 0 });
+  });
+
+  it('creates audit log entry on update', async () => {
+    FeeStructure.findOneAndUpdate = jest.fn().mockResolvedValue(mockFee);
+    const req = mockReq({ feeAmount: 300 });
+    const res = mockRes();
+    await updateFeeStructure(req, res, next);
+    expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'fee_update',
+      targetType: 'fee',
+      targetId: 'Grade 5A',
+      result: 'success',
+    }));
+  });
+
+  it('includes academicYear in update when provided', async () => {
+    FeeStructure.findOneAndUpdate = jest.fn().mockResolvedValue(mockFee);
+    const req = mockReq({ feeAmount: 300, academicYear: '2027' });
+    const res = mockRes();
+    await updateFeeStructure(req, res, next);
+    expect(FeeStructure.findOneAndUpdate).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ academicYear: '2027' }),
+      expect.any(Object)
+    );
+  });
+
+  it('audit log includes studentsUpdated count', async () => {
+    FeeStructure.findOneAndUpdate = jest.fn().mockResolvedValue(mockFee);
+    Student.updateMany = jest.fn().mockResolvedValue({ modifiedCount: 3 });
+    const req = mockReq({ feeAmount: 300, cascadeToStudents: true });
+    const res = mockRes();
+    await updateFeeStructure(req, res, next);
+    expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+      details: expect.objectContaining({ studentsUpdated: 3, cascadeToStudents: true }),
+    }));
+  });
+});


### PR DESCRIPTION
- updateFeeStructure now accepts academicYear in request body
- Add cascadeToStudents: true param — bulk-updates feeAmount on all students in the class (deletedAt: null) when set
- Response now returns { fee, studentsUpdated } so callers know how many student records were affected
- Audit log details include cascadeToStudents flag and studentsUpdated count
- Add tests/feeStructureUpdate.test.js covering update with/without cascade, 404, 400, audit log, and academicYear field
- Document PUT /api/fees/:className in docs/api-spec.md
closes #454