### PR TITLE
feat: filter inactive schools from GET /api/schools — 

### DIFF
--- a/backend/src/controllers/schoolController.js
+++ b/backend/src/controllers/schoolController.js
@@ -70,7 +70,27 @@ async function createSchool(req, res, next) {
 // GET /api/schools
 async function getAllSchools(req, res, next) {
   try {
-    const schools = await School.find({ isActive: true }).sort({ name: 1 }).lean();
+    const includeInactive = req.query.includeInactive === 'true';
+
+    // ?includeInactive=true is admin-only — verify JWT inline
+    if (includeInactive) {
+      const jwt = require('jsonwebtoken');
+      const authHeader = req.headers['authorization'];
+      if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return res.status(401).json({ error: 'Authentication required to include inactive schools.', code: 'MISSING_AUTH_TOKEN' });
+      }
+      try {
+        const decoded = jwt.verify(authHeader.slice(7), process.env.JWT_SECRET);
+        if (decoded.role !== 'admin') {
+          return res.status(403).json({ error: 'Admin role required to include inactive schools.', code: 'INSUFFICIENT_ROLE' });
+        }
+      } catch {
+        return res.status(401).json({ error: 'Invalid token.', code: 'INVALID_AUTH_TOKEN' });
+      }
+    }
+
+    const query = includeInactive ? {} : { isActive: true };
+    const schools = await School.find(query).sort({ name: 1 }).lean();
     res.json(schools);
   } catch (err) {
     next(err);

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -78,10 +78,23 @@ HTTP 400
 ```
 GET /api/schools
 ```
+Returns only active schools by default.
+
+**Query parameters**
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `includeInactive` | boolean | `false` | If `true`, returns all schools including inactive. Requires admin auth. |
+
 **Response `200`**
 ```json
 [{ "schoolId": "SCH-3F2A", "name": "Lincoln High", "slug": "lincoln-high", "stellarAddress": "G...", "network": "testnet", "isActive": true }]
 ```
+
+**Errors (when `?includeInactive=true`)**
+- `401 MISSING_AUTH_TOKEN` — no Bearer token provided
+- `401 INVALID_AUTH_TOKEN` — token is invalid or expired
+- `403 INSUFFICIENT_ROLE` — token does not have admin role
 
 ### Get a school
 ```

--- a/tests/schoolsFilterInactive.test.js
+++ b/tests/schoolsFilterInactive.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+/**
+ * Tests for GET /api/schools isActive filtering — issue #455
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.SCHOOL_WALLET_ADDRESS = 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B';
+process.env.JWT_SECRET = 'test-secret';
+
+const jwt = require('jsonwebtoken');
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockSchools = [
+  { schoolId: 'SCH-001', name: 'Active School', slug: 'active-school', isActive: true },
+  { schoolId: 'SCH-002', name: 'Inactive School', slug: 'inactive-school', isActive: false },
+];
+
+jest.mock('../backend/src/models/schoolModel', () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/auditService', () => ({
+  logAudit: jest.fn().mockResolvedValue(undefined),
+}));
+
+const School = require('../backend/src/models/schoolModel');
+const { getAllSchools } = require('../backend/src/controllers/schoolController');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockReq(query = {}, authHeader = undefined) {
+  return {
+    query,
+    headers: authHeader ? { authorization: authHeader } : {},
+    body: {},
+    params: {},
+  };
+}
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function adminToken() {
+  return `Bearer ${jwt.sign({ role: 'admin', email: 'admin@test.com' }, 'test-secret', { expiresIn: '1h' })}`;
+}
+
+function userToken() {
+  return `Bearer ${jwt.sign({ role: 'user', email: 'user@test.com' }, 'test-secret', { expiresIn: '1h' })}`;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GET /api/schools — isActive filtering (issue #455)', () => {
+  let next;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    next = jest.fn();
+    School.find.mockReturnValue({ sort: jest.fn().mockReturnValue({ lean: jest.fn() }) });
+  });
+
+  it('default response excludes inactive schools', async () => {
+    const activeOnly = mockSchools.filter(s => s.isActive);
+    School.find.mockReturnValue({ sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(activeOnly) }) });
+
+    const req = mockReq();
+    const res = mockRes();
+    await getAllSchools(req, res, next);
+
+    expect(School.find).toHaveBeenCalledWith({ isActive: true });
+    expect(res.json).toHaveBeenCalledWith(activeOnly);
+  });
+
+  it('?includeInactive=true without auth returns 401', async () => {
+    const req = mockReq({ includeInactive: 'true' });
+    const res = mockRes();
+    await getAllSchools(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'MISSING_AUTH_TOKEN' }));
+  });
+
+  it('?includeInactive=true with non-admin token returns 403', async () => {
+    const req = mockReq({ includeInactive: 'true' }, userToken());
+    const res = mockRes();
+    await getAllSchools(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INSUFFICIENT_ROLE' }));
+  });
+
+  it('?includeInactive=true with invalid token returns 401', async () => {
+    const req = mockReq({ includeInactive: 'true' }, 'Bearer not.a.valid.token');
+    const res = mockRes();
+    await getAllSchools(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'INVALID_AUTH_TOKEN' }));
+  });
+
+  it('?includeInactive=true with admin token returns all schools', async () => {
+    School.find.mockReturnValue({ sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(mockSchools) }) });
+
+    const req = mockReq({ includeInactive: 'true' }, adminToken());
+    const res = mockRes();
+    await getAllSchools(req, res, next);
+
+    expect(School.find).toHaveBeenCalledWith({});
+    expect(res.json).toHaveBeenCalledWith(mockSchools);
+  });
+
+  it('?includeInactive=false behaves like default (active only)', async () => {
+    const activeOnly = mockSchools.filter(s => s.isActive);
+    School.find.mockReturnValue({ sort: jest.fn().mockReturnValue({ lean: jest.fn().mockResolvedValue(activeOnly) }) });
+
+    const req = mockReq({ includeInactive: 'false' });
+    const res = mockRes();
+    await getAllSchools(req, res, next);
+
+    expect(School.find).toHaveBeenCalledWith({ isActive: true });
+  });
+});


### PR DESCRIPTION
- getAllSchools now returns only isActive: true schools by default
- ?includeInactive=true query param returns all schools (active + inactive) but requires a valid admin JWT — returns 401/403 otherwise
- Add tests/schoolsFilterInactive.test.js covering both cases and auth errors
- Document ?includeInactive param in docs/api-spec.md

closes #455