### PR TITLE
feat: PATCH /api/schools/:id/deactivate and /activate endpoints — 

### DIFF
--- a/backend/src/controllers/schoolController.js
+++ b/backend/src/controllers/schoolController.js
@@ -186,4 +186,72 @@ async function deactivateSchool(req, res, next) {
   }
 }
 
-module.exports = { createSchool, getAllSchools, getSchool, updateSchool, deactivateSchool };
+// PATCH /api/schools/:schoolSlug/deactivate
+async function deactivateSchoolEndpoint(req, res, next) {
+  try {
+    const school = await School.findOneAndUpdate(
+      { slug: req.params.schoolSlug.toLowerCase() },
+      { isActive: false },
+      { new: true }
+    );
+    if (!school) {
+      const e = new Error('School not found');
+      e.code = 'NOT_FOUND';
+      return next(e);
+    }
+
+    if (req.auditContext) {
+      await logAudit({
+        schoolId: school.schoolId,
+        action: 'school_deactivate',
+        performedBy: req.auditContext.performedBy,
+        targetId: school.schoolId,
+        targetType: 'school',
+        details: { name: school.name, slug: school.slug },
+        result: 'success',
+        ipAddress: req.auditContext.ipAddress,
+        userAgent: req.auditContext.userAgent,
+      });
+    }
+
+    res.json({ message: `School "${school.name}" deactivated`, schoolId: school.schoolId, isActive: false });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// PATCH /api/schools/:schoolSlug/activate
+async function activateSchool(req, res, next) {
+  try {
+    const school = await School.findOneAndUpdate(
+      { slug: req.params.schoolSlug.toLowerCase() },
+      { isActive: true },
+      { new: true }
+    );
+    if (!school) {
+      const e = new Error('School not found');
+      e.code = 'NOT_FOUND';
+      return next(e);
+    }
+
+    if (req.auditContext) {
+      await logAudit({
+        schoolId: school.schoolId,
+        action: 'school_activate',
+        performedBy: req.auditContext.performedBy,
+        targetId: school.schoolId,
+        targetType: 'school',
+        details: { name: school.name, slug: school.slug },
+        result: 'success',
+        ipAddress: req.auditContext.ipAddress,
+        userAgent: req.auditContext.userAgent,
+      });
+    }
+
+    res.json({ message: `School "${school.name}" activated`, schoolId: school.schoolId, isActive: true });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { createSchool, getAllSchools, getSchool, updateSchool, deactivateSchool, deactivateSchoolEndpoint, activateSchool };

--- a/backend/src/routes/schoolRoutes.js
+++ b/backend/src/routes/schoolRoutes.js
@@ -8,6 +8,8 @@ const {
   getSchool,
   updateSchool,
   deactivateSchool,
+  deactivateSchoolEndpoint,
+  activateSchool,
 } = require('../controllers/schoolController');
 const { requireAdminAuth } = require('../middleware/auth');
 const { auditContext } = require('../middleware/auditContext');
@@ -20,5 +22,9 @@ router.get('/:schoolId',        getSchool);
 router.post('/',                requireAdminAuth, auditContext, createSchool);
 router.patch('/:schoolId',      requireAdminAuth, auditContext, updateSchool);
 router.delete('/:schoolId',     requireAdminAuth, auditContext, deactivateSchool);
+
+// Explicit activate / deactivate endpoints
+router.patch('/:schoolId/deactivate', requireAdminAuth, auditContext, deactivateSchoolEndpoint);
+router.patch('/:schoolId/activate',   requireAdminAuth, auditContext, activateSchool);
 
 module.exports = router;

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -124,6 +124,32 @@ Authorization: Bearer <token>
 { "message": "School deactivated" }
 ```
 
+### Deactivate a school (explicit endpoint) — admin only
+```
+PATCH /api/schools/:schoolId/deactivate
+Authorization: Bearer <token>
+```
+Sets `isActive: false`. Deactivated schools are excluded from `GET /api/schools` by default and all payment operations return `404 SCHOOL_NOT_FOUND` via the school context middleware.
+
+**Response `200`**
+```json
+{ "message": "School \"Lincoln High\" deactivated", "schoolId": "SCH-3F2A", "isActive": false }
+```
+**Errors** — `404 NOT_FOUND` if school does not exist.
+
+### Reactivate a school — admin only
+```
+PATCH /api/schools/:schoolId/activate
+Authorization: Bearer <token>
+```
+Sets `isActive: true`. The school immediately becomes visible in `GET /api/schools` and accepts payment operations again.
+
+**Response `200`**
+```json
+{ "message": "School \"Lincoln High\" activated", "schoolId": "SCH-3F2A", "isActive": true }
+```
+**Errors** — `404 NOT_FOUND` if school does not exist.
+
 ---
 
 ## Students

--- a/tests/schoolDeactivateActivate.test.js
+++ b/tests/schoolDeactivateActivate.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+/**
+ * Tests for PATCH /api/schools/:id/deactivate and /activate — issue #453
+ */
+
+const { deactivateSchoolEndpoint, activateSchool } = require('../backend/src/controllers/schoolController');
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../backend/src/models/schoolModel', () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  findOneAndUpdate: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/auditService', () => ({
+  logAudit: jest.fn().mockResolvedValue(undefined),
+}));
+
+const School = require('../backend/src/models/schoolModel');
+const { logAudit } = require('../backend/src/services/auditService');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockReq(slug = 'lincoln-high') {
+  return {
+    params: { schoolSlug: slug },
+    body: {},
+    headers: {},
+    auditContext: { performedBy: 'admin@test.com', ipAddress: '127.0.0.1', userAgent: 'jest' },
+  };
+}
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('School deactivate/activate endpoints — issue #453', () => {
+  let next;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    next = jest.fn();
+  });
+
+  // ── PATCH /deactivate ──────────────────────────────────────────────────────
+
+  describe('PATCH /api/schools/:id/deactivate', () => {
+    it('404 when school not found', async () => {
+      School.findOneAndUpdate.mockResolvedValue(null);
+      const req = mockReq('unknown-school');
+      const res = mockRes();
+      await deactivateSchoolEndpoint(req, res, next);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_FOUND' }));
+    });
+
+    it('200 sets isActive: false', async () => {
+      const school = { schoolId: 'SCH-001', name: 'Lincoln High', slug: 'lincoln-high', isActive: false };
+      School.findOneAndUpdate.mockResolvedValue(school);
+      const req = mockReq('lincoln-high');
+      const res = mockRes();
+      await deactivateSchoolEndpoint(req, res, next);
+      expect(School.findOneAndUpdate).toHaveBeenCalledWith(
+        { slug: 'lincoln-high' },
+        { isActive: false },
+        { new: true }
+      );
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ isActive: false, schoolId: 'SCH-001' }));
+    });
+
+    it('creates audit log with action school_deactivate', async () => {
+      const school = { schoolId: 'SCH-001', name: 'Lincoln High', slug: 'lincoln-high', isActive: false };
+      School.findOneAndUpdate.mockResolvedValue(school);
+      const req = mockReq('lincoln-high');
+      const res = mockRes();
+      await deactivateSchoolEndpoint(req, res, next);
+      expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'school_deactivate',
+        targetType: 'school',
+        result: 'success',
+      }));
+    });
+  });
+
+  // ── PATCH /activate ────────────────────────────────────────────────────────
+
+  describe('PATCH /api/schools/:id/activate', () => {
+    it('404 when school not found', async () => {
+      School.findOneAndUpdate.mockResolvedValue(null);
+      const req = mockReq('unknown-school');
+      const res = mockRes();
+      await activateSchool(req, res, next);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_FOUND' }));
+    });
+
+    it('200 sets isActive: true', async () => {
+      const school = { schoolId: 'SCH-001', name: 'Lincoln High', slug: 'lincoln-high', isActive: true };
+      School.findOneAndUpdate.mockResolvedValue(school);
+      const req = mockReq('lincoln-high');
+      const res = mockRes();
+      await activateSchool(req, res, next);
+      expect(School.findOneAndUpdate).toHaveBeenCalledWith(
+        { slug: 'lincoln-high' },
+        { isActive: true },
+        { new: true }
+      );
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ isActive: true, schoolId: 'SCH-001' }));
+    });
+
+    it('creates audit log with action school_activate', async () => {
+      const school = { schoolId: 'SCH-001', name: 'Lincoln High', slug: 'lincoln-high', isActive: true };
+      School.findOneAndUpdate.mockResolvedValue(school);
+      const req = mockReq('lincoln-high');
+      const res = mockRes();
+      await activateSchool(req, res, next);
+      expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'school_activate',
+        targetType: 'school',
+        result: 'success',
+      }));
+    });
+  });
+
+  // ── schoolContext rejects inactive schools ─────────────────────────────────
+
+  describe('schoolContext middleware rejects inactive schools', () => {
+    it('resolveSchool returns 404 for inactive school', async () => {
+      // schoolContext already queries { isActive: true } — simulate not found
+      const { resolveSchool } = require('../backend/src/middleware/schoolContext');
+
+      jest.mock('../backend/src/cache', () => ({
+        get: jest.fn().mockReturnValue(null),
+        set: jest.fn(),
+        KEYS: { school: jest.fn((id) => `school:${id}`) },
+        TTL: { SCHOOL: 300 },
+      }));
+
+      School.findOne.mockResolvedValue(null); // inactive school not returned
+
+      const req = { headers: { 'x-school-id': 'SCH-001' } };
+      const res = mockRes();
+      const nextFn = jest.fn();
+      await resolveSchool(req, res, nextFn);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'SCHOOL_NOT_FOUND' }));
+    });
+  });
+
+  // ── Full deactivate → reactivate flow ─────────────────────────────────────
+
+  describe('deactivation and reactivation flow', () => {
+    it('deactivate then activate restores isActive: true', async () => {
+      const school = { schoolId: 'SCH-001', name: 'Lincoln High', slug: 'lincoln-high' };
+
+      // First call: deactivate
+      School.findOneAndUpdate.mockResolvedValueOnce({ ...school, isActive: false });
+      const deactivateReq = mockReq('lincoln-high');
+      const deactivateRes = mockRes();
+      await deactivateSchoolEndpoint(deactivateReq, deactivateRes, next);
+      expect(deactivateRes.json).toHaveBeenCalledWith(expect.objectContaining({ isActive: false }));
+
+      // Second call: activate
+      School.findOneAndUpdate.mockResolvedValueOnce({ ...school, isActive: true });
+      const activateReq = mockReq('lincoln-high');
+      const activateRes = mockRes();
+      await activateSchool(activateReq, activateRes, next);
+      expect(activateRes.json).toHaveBeenCalledWith(expect.objectContaining({ isActive: true }));
+    });
+  });
+});


### PR DESCRIPTION
closes #453

- Add deactivateSchoolEndpoint (PATCH /:id/deactivate) and activateSchool (PATCH /:id/activate) to schoolController.js
- Both endpoints require admin auth + auditContext middleware
- Both create audit log entries (school_deactivate / school_activate)
- schoolContext middleware already rejects inactive schools with 404 SCHOOL_NOT_FOUND, blocking all payment operations for deactivated schools
- Add tests/schoolDeactivateActivate.test.js covering deactivate, activate, 404 cases, audit logs, and full deactivate→reactivate flow
- Document new endpoints in docs/api-spec.md