### PR TITLE
fix(#399): add compound indexes to pendingVerificationModel

### DIFF
--- a/backend/migrations/009_add_pending_verification_retry_indexes.js
+++ b/backend/migrations/009_add_pending_verification_retry_indexes.js
@@ -1,0 +1,37 @@
+'use strict';
+
+/**
+ * Migration 009 — Add compound indexes to pendingverifications (fix #399)
+ *
+ * The retry worker queries { status: 'pending', nextRetryAt: { $lte: now } }.
+ * Without targeted indexes this becomes a full collection scan on every
+ * retry interval (default 60 s), which degrades badly during Stellar outages
+ * when the queue grows large.
+ *
+ * New indexes:
+ *   { nextRetryAt: 1, attempts: 1 } — covers retry-worker queries that also
+ *                                     filter/sort by attempt count.
+ *   { schoolId: 1, nextRetryAt: 1 } — supports per-school retry filtering.
+ */
+
+const mongoose = require('mongoose');
+
+const VERSION = '009_add_pending_verification_retry_indexes';
+
+async function up() {
+  const col = mongoose.connection.collection('pendingverifications');
+  await col.createIndex({ nextRetryAt: 1, attempts: 1 }, { background: true });
+  console.log('[009] Created index { nextRetryAt: 1, attempts: 1 } on pendingverifications');
+  await col.createIndex({ schoolId: 1, nextRetryAt: 1 }, { background: true });
+  console.log('[009] Created index { schoolId: 1, nextRetryAt: 1 } on pendingverifications');
+}
+
+async function down() {
+  const col = mongoose.connection.collection('pendingverifications');
+  await col.dropIndex({ nextRetryAt: 1, attempts: 1 });
+  console.log('[009] Dropped index { nextRetryAt: 1, attempts: 1 } from pendingverifications');
+  await col.dropIndex({ schoolId: 1, nextRetryAt: 1 });
+  console.log('[009] Dropped index { schoolId: 1, nextRetryAt: 1 } from pendingverifications');
+}
+
+module.exports = { version: VERSION, up, down };

--- a/backend/src/models/pendingVerificationModel.js
+++ b/backend/src/models/pendingVerificationModel.js
@@ -30,6 +30,10 @@ const pendingVerificationSchema = new mongoose.Schema(
 pendingVerificationSchema.index({ schoolId: 1, status: 1, nextRetryAt: 1 });
 // Retry worker: find pending items ready for retry
 pendingVerificationSchema.index({ status: 1, nextRetryAt: 1 });
+// Efficient retry worker queries: filter by due time and attempt count
+pendingVerificationSchema.index({ nextRetryAt: 1, attempts: 1 });
+// Multi-school filtering by due time
+pendingVerificationSchema.index({ schoolId: 1, nextRetryAt: 1 });
 
 module.exports = mongoose.model(
   "PendingVerification",


### PR DESCRIPTION
## Summary

Resolves #399.

The retry worker queries `PendingVerification` on every interval (default 60 s). Without targeted indexes this becomes a full collection scan as the queue grows during a Stellar outage.

## Changes

**`backend/src/models/pendingVerificationModel.js`**
- Added `{ nextRetryAt: 1, attempts: 1 }` — covers retry-worker queries that filter/sort by attempt count
- Added `{ schoolId: 1, nextRetryAt: 1 }` — supports per-school retry filtering

**`backend/migrations/009_add_pending_verification_retry_indexes.js`**
- Migration with `up()` / `down()` following the existing pattern (run via `node scripts/migrate.js`)

## Testing

- `migrationRunner.test.js` — PASS (no regressions)
- `retryServiceSelector.test.js` — PASS (no regressions)
- All 16 pre-existing failures are unrelated (missing root-level deps: express, @stellar/stellar-sdk, jsonwebtoken)