### PR TITLE
fix: resolve issues #465, #466, #467, #468

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -113,13 +113,6 @@ SYNC_INTERVAL_MS=60000
 # Legacy polling interval (kept for backwards compatibility)
 POLL_INTERVAL_MS=30000
 
-# ── Graceful Shutdown ─────────────────────────────────────────
-# Maximum time in milliseconds to wait for in-flight HTTP requests to complete
-# before forcing a shutdown. After this timeout the process exits with code 1.
-# Kubernetes users: set terminationGracePeriodSeconds to at least this value + 5s.
-# Default: 10000 (10 seconds)
-SHUTDOWN_TIMEOUT_MS=10000
-
 # ── Retry / Outage Recovery ───────────────────────────────────
 RETRY_INTERVAL_MS=60000
 RETRY_MAX_ATTEMPTS=10

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -113,6 +113,13 @@ SYNC_INTERVAL_MS=60000
 # Legacy polling interval (kept for backwards compatibility)
 POLL_INTERVAL_MS=30000
 
+# ── Graceful Shutdown ─────────────────────────────────────────
+# Maximum time in milliseconds to wait for in-flight HTTP requests to complete
+# before forcing a shutdown. After this timeout the process exits with code 1.
+# Kubernetes users: set terminationGracePeriodSeconds to at least this value + 5s.
+# Default: 10000 (10 seconds)
+SHUTDOWN_TIMEOUT_MS=10000
+
 # ── Retry / Outage Recovery ───────────────────────────────────
 RETRY_INTERVAL_MS=60000
 RETRY_MAX_ATTEMPTS=10

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,7 +6,7 @@
     "start": "node src/app.js",
     "dev": "nodemon src/app.js",
     "seed": "node ../scripts/seed-test-data.js",
-    "create-wallet": "node ../scripts/create-school-wallet.js"
+    "create-wallet": "node ../scripts/create-school-wallet.js",
     "test": "jest --testPathPattern=tests/"
   },
   "dependencies": {

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -171,32 +171,36 @@ const server = require.main === module
 async function shutdown(signal) {
   logger.info(`Received ${signal} signal — starting graceful shutdown`);
 
+  const SHUTDOWN_TIMEOUT_MS = parseInt(process.env.SHUTDOWN_TIMEOUT_MS, 10) || 10_000;
+
+  // Stop background services — no new work accepted
   stopPolling();
   retrySelector.stop();
   stopTxQueueWorker();
   stopReminderScheduler();
   stopSessionCleanupScheduler();
 
-  const deadline = Date.now() + 8_000;
-  while (retrySelector.isRunning() && Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
+  // Force exit after SHUTDOWN_TIMEOUT_MS regardless of in-flight requests
+  const forceExitTimer = setTimeout(() => {
+    logger.error(`Forced exit after ${SHUTDOWN_TIMEOUT_MS}ms shutdown timeout`);
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+  forceExitTimer.unref(); // don't keep the event loop alive just for this timer
 
+  // (1) Stop accepting new connections; (2) wait for in-flight requests to finish;
+  // (3) only then close the database connection.
   server.close(async () => {
     try {
       await mongoose.disconnect();
       logger.info('MongoDB disconnected — clean exit');
+      clearTimeout(forceExitTimer);
       process.exit(0);
     } catch (err) {
       logger.error('Error closing MongoDB', { error: err.message });
+      clearTimeout(forceExitTimer);
       process.exit(1);
     }
   });
-
-  setTimeout(() => {
-    logger.error('Forced exit after timeout');
-    process.exit(1);
-  }, 10_000);
 }
 
 process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/backend/src/models/paymentModel.js
+++ b/backend/src/models/paymentModel.js
@@ -12,7 +12,7 @@ const paymentSchema = new mongoose.Schema(
     amount: { type: Number, required: true },
     feeAmount: { type: Number, default: null },
     feeCategory: { type: String, default: null, index: true },
-    feeValidationStatus: { type: String, enum: ['valid', 'underpaid', 'overpaid', 'unknown'], default: 'unknown' },
+    feeValidationStatus: { type: String, enum: ['valid', 'underpaid', 'overpaid', 'partial', 'unknown'], default: 'unknown' },
     excessAmount: { type: Number, default: 0 },
 
     assetCode: { type: String, default: null },

--- a/backend/src/models/schoolModel.js
+++ b/backend/src/models/schoolModel.js
@@ -37,6 +37,13 @@ const schoolSchema = new mongoose.Schema(
      * e.g. "USD" for US schools, "PGK" for Papua New Guinea, "NGN" for Nigeria.
      */
     localCurrency:  { type: String, default: 'USD', uppercase: true, trim: true },
+    /**
+     * Per-school HMAC secret used to sign outbound webhook deliveries.
+     * Recipients verify the X-StellarEduPay-Signature header to confirm
+     * the payload originated from this server and was not tampered with.
+     * Generate with: crypto.randomBytes(32).toString('hex')
+     */
+    webhookSecret:  { type: String, default: null },
   },
   { timestamps: true }
 );

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -121,6 +121,8 @@ async function detectMemoCollision(
         ") within the last 24 hours",
     };
   }
+
+  return { suspicious: false, reason: null };
 }
 
 /**
@@ -382,18 +384,6 @@ async function syncPaymentsForSchool(school) {
       if (!student) { summary.unmatched++; continue; }
 
       summary.matched++;
-      const intent = await PaymentIntent.findOne({
-        schoolId,
-        memo,
-        status: "pending",
-      });
-      if (!intent) continue;
-
-      const student = await Student.findOne({
-        schoolId,
-        studentId: intent.studentId,
-      });
-      if (!student) continue;
 
       const paymentAmount = parseFloat(payOp.amount);
 
@@ -435,7 +425,7 @@ async function syncPaymentsForSchool(school) {
       );
 
       let cumulativeStatus;
-      if (cumulativeTotal < student.feeAmount) cumulativeStatus = "underpaid";
+      if (cumulativeTotal < student.feeAmount) cumulativeStatus = "partial";
       else if (cumulativeTotal > student.feeAmount)
         cumulativeStatus = "overpaid";
       else cumulativeStatus = "valid";
@@ -445,42 +435,10 @@ async function syncPaymentsForSchool(school) {
           ? parseFloat((cumulativeTotal - student.feeAmount).toFixed(7))
           : 0;
 
-      const feeValidation = validatePaymentAgainstFee(
-        paymentAmount,
-        intent.amount,
-      );
-
-      if (feeValidation.status === "underpaid") {
-        logger.warn("Underpaid transaction skipped", {
-          txHash: tx.hash,
-          schoolId,
-          studentId: intent.studentId,
-          paid: paymentAmount,
-          required: intent.amount,
-        });
-        await savePayment({
-          schoolId,
-          studentId: intent.studentId,
-          txHash: tx.hash,
-          amount: paymentAmount,
-          feeAmount: intent.amount,
-          feeCategory: intent.feeCategory || null,
-          feeValidationStatus: "underpaid",
-          excessAmount: 0,
-          status: "FAILED",
-          memo,
-          senderAddress,
-          isSuspicious: true,
-          suspicionReason: feeValidation.message,
-          ledger: txLedger,
-          confirmationStatus: "failed",
-          confirmedAt: txDate,
-        });
-        summary.failed++;
-        summary.failedDetails.push({ txHash: tx.hash, reason: feeValidation.message });
-        newPayments++;
-        continue;
-      }
+      // In the sync path, partial payments are accepted — the cumulative status
+      // (partial / valid / overpaid) is what gets recorded. Per-transaction
+      // underpaid rejection is intentionally skipped here; the verifyPayment
+      // endpoint still rejects underpaid single-payment verifications.
 
       await savePayment({
         schoolId,
@@ -516,6 +474,7 @@ async function syncPaymentsForSchool(school) {
         // Update student record
         const updateData = {
           totalPaid: cumulativeTotal,
+          remainingBalance: parseFloat(Math.max(0, student.feeAmount - cumulativeTotal).toFixed(7)),
           feePaid: cumulativeTotal >= student.feeAmount,
         };
 

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -56,25 +56,35 @@ function getBackoffDelay(attemptNumber) {
  * @param {string} url - The webhook endpoint URL
  * @param {string} event - Event type: 'payment.confirmed' | 'payment.pending' | 'payment.failed' | 'payment.suspicious'
  * @param {object} payload - Event-specific payload data
+ * @param {string|null} [secret] - Per-school HMAC secret for signing the delivery
  * @returns {Promise<{success: boolean, statusCode?: number, error?: string, queued?: boolean}>}
  */
-async function fireWebhook(url, event, payload) {
+async function fireWebhook(url, event, payload, secret = null) {
   if (!url) return { success: false, error: 'No webhook URL configured' };
+
+  const body = {
+    event,
+    timestamp: new Date().toISOString(),
+    data: payload,
+  };
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'StellarEduPay-Webhook/1.0',
+    'X-Webhook-Event': event,
+  };
+
+  // Sign the payload when a secret is provided
+  if (secret) {
+    headers['X-StellarEduPay-Signature'] = `sha256=${generateSignature(body, secret)}`;
+  }
 
   const startTime = Date.now();
   try {
-    const response = await axios.post(url, {
-      event,
-      timestamp: new Date().toISOString(),
-      data: payload
-    }, {
+    const response = await axios.post(url, body, {
       timeout: WEBHOOK_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': 'StellarEduPay-Webhook/1.0',
-        'X-Webhook-Event': event
-      },
-      validateStatus: (status) => status >= 200 && status < 300
+      headers,
+      validateStatus: (status) => status >= 200 && status < 300,
     });
 
     const duration = Date.now() - startTime;
@@ -82,7 +92,7 @@ async function fireWebhook(url, event, payload) {
       url,
       event,
       statusCode: response.status,
-      durationMs: duration
+      durationMs: duration,
     });
 
     return { success: true, statusCode: response.status };
@@ -98,19 +108,15 @@ async function fireWebhook(url, event, payload) {
       url,
       event,
       error: errorMessage,
-      durationMs: duration
+      durationMs: duration,
     });
 
-    // Queue for retry
+    // Queue for retry (secret stored so retries can re-sign)
     try {
-      await queueWebhookRetry(url, event, payload, errorMessage);
+      await queueWebhookRetry(url, event, payload, errorMessage, secret);
       return { success: false, error: errorMessage, queued: true };
     } catch (queueErr) {
-      logger.error(`Failed to queue webhook retry`, {
-        url,
-        event,
-        error: queueErr.message
-      });
+      logger.error(`Failed to queue webhook retry`, { url, event, error: queueErr.message });
       return { success: false, error: errorMessage, queued: false };
     }
   }
@@ -123,14 +129,16 @@ async function fireWebhook(url, event, payload) {
  * @param {string} event - Event type
  * @param {object} payload - Event payload
  * @param {string} error - Error message from failed attempt
+ * @param {string|null} [secret] - HMAC secret to re-sign on retry
  */
-async function queueWebhookRetry(url, event, payload, error) {
+async function queueWebhookRetry(url, event, payload, error, secret = null) {
   const nextRetryAt = new Date(Date.now() + getBackoffDelay(0)); // First retry: 1 min
   
   await WebhookRetry.create({
     url,
     event,
     payload,
+    secret: secret || null,
     status: 'pending',
     attemptCount: 0,
     maxAttempts: 3,
@@ -178,19 +186,27 @@ async function retryWebhook(retry) {
   const startTime = Date.now();
   const attemptNumber = retry.attemptCount + 1;
 
+  const body = {
+    event: retry.event,
+    timestamp: new Date().toISOString(),
+    data: retry.payload,
+  };
+
+  const headers = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'StellarEduPay-Webhook/1.0',
+    'X-Webhook-Event': retry.event,
+  };
+
+  if (retry.secret) {
+    headers['X-StellarEduPay-Signature'] = `sha256=${generateSignature(body, retry.secret)}`;
+  }
+
   try {
-    const response = await axios.post(retry.url, {
-      event: retry.event,
-      timestamp: new Date().toISOString(),
-      data: retry.payload
-    }, {
+    const response = await axios.post(retry.url, body, {
       timeout: WEBHOOK_TIMEOUT_MS,
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': 'StellarEduPay-Webhook/1.0',
-        'X-Webhook-Event': retry.event
-      },
-      validateStatus: (status) => status >= 200 && status < 300
+      headers,
+      validateStatus: (status) => status >= 200 && status < 300,
     });
 
     const duration = Date.now() - startTime;
@@ -287,8 +303,9 @@ async function retryWebhook(retry) {
  * @param {string} webhookUrl - Registered webhook URL
  * @param {object} payment - Payment document from MongoDB
  * @param {object} student - Student document
+ * @param {string|null} [secret] - Per-school HMAC secret
  */
-async function notifyPaymentConfirmed(webhookUrl, payment, student) {
+async function notifyPaymentConfirmed(webhookUrl, payment, student, secret = null) {
   return fireWebhook(webhookUrl, 'payment.confirmed', {
     transactionHash: payment.transactionHash || payment.txHash,
     studentId: payment.studentId,
@@ -299,49 +316,49 @@ async function notifyPaymentConfirmed(webhookUrl, payment, student) {
     confirmedAt: payment.confirmedAt,
     referenceCode: payment.referenceCode,
     schoolId: payment.schoolId,
-    senderAddress: payment.senderAddress
-  });
+    senderAddress: payment.senderAddress,
+  }, secret);
 }
 
 /**
  * Notify external system of a pending payment (awaiting ledger confirmation).
  */
-async function notifyPaymentPending(webhookUrl, payment) {
+async function notifyPaymentPending(webhookUrl, payment, secret = null) {
   return fireWebhook(webhookUrl, 'payment.pending', {
     transactionHash: payment.transactionHash || payment.txHash,
     studentId: payment.studentId,
     amount: payment.amount,
     assetCode: payment.assetCode || 'XLM',
     ledgerSequence: payment.ledgerSequence,
-    status: 'pending_confirmation'
-  });
+    status: 'pending_confirmation',
+  }, secret);
 }
 
 /**
  * Notify external system of a failed payment.
  */
-async function notifyPaymentFailed(webhookUrl, payment, reason) {
+async function notifyPaymentFailed(webhookUrl, payment, reason, secret = null) {
   return fireWebhook(webhookUrl, 'payment.failed', {
     transactionHash: payment.transactionHash || payment.txHash,
     studentId: payment.studentId,
     amount: payment.amount || 0,
     reason,
-    status: 'FAILED'
-  });
+    status: 'FAILED',
+  }, secret);
 }
 
 /**
  * Notify external system of a suspicious payment flagged by fraud detection.
  */
-async function notifyPaymentSuspicious(webhookUrl, payment, reason) {
+async function notifyPaymentSuspicious(webhookUrl, payment, reason, secret = null) {
   return fireWebhook(webhookUrl, 'payment.suspicious', {
     transactionHash: payment.transactionHash || payment.txHash,
     studentId: payment.studentId,
     amount: payment.amount,
     reason,
     isSuspicious: true,
-    status: payment.status
-  });
+    status: payment.status,
+  }, secret);
 }
 
 module.exports = {

--- a/frontend/src/pages/dashboard.jsx
+++ b/frontend/src/pages/dashboard.jsx
@@ -50,7 +50,7 @@ export default function Dashboard() {
     setStudentsError(null);
     getStudents(p, PAGE_SIZE)
       .then(({ data }) => {
-        setStudents(data.students || data);
+        setStudents(data.students);
         setPages(data.pages || 1);
       })
       .catch(() => setStudentsError("Could not load student list."))

--- a/tests/gracefulShutdown.test.js
+++ b/tests/gracefulShutdown.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+// #466 — graceful shutdown waits for in-flight requests
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.SCHOOL_WALLET_ADDRESS = 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B';
+
+const http = require('http');
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('../backend/src/middleware/auth', () => ({
+  requireAdminAuth: (req, res, next) => next(),
+}));
+
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  disconnect: jest.fn().mockResolvedValue(true),
+  connection: {
+    on: jest.fn(),
+  },
+  Schema: class {
+    constructor() {
+      this.index = jest.fn();
+      this.pre = jest.fn();
+      this.virtual = jest.fn().mockReturnValue({ get: jest.fn() });
+    }
+  },
+  model: jest.fn().mockReturnValue({
+    findOneAndUpdate: jest.fn().mockResolvedValue({}),
+  }),
+}));
+
+jest.mock('../backend/src/services/transactionPollingService', () => ({
+  startPolling: jest.fn(),
+  stopPolling: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/retryServiceSelector', () => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+  isRunning: jest.fn().mockReturnValue(false),
+  useBullMQ: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../backend/src/services/consistencyScheduler', () => ({
+  startConsistencyScheduler: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/reminderService', () => ({
+  startReminderScheduler: jest.fn(),
+  stopReminderScheduler: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/transactionQueueService', () => ({
+  startWorker: jest.fn(),
+  stopWorker: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/sessionCleanupService', () => ({
+  startSessionCleanupScheduler: jest.fn(),
+  stopSessionCleanupScheduler: jest.fn(),
+}));
+
+jest.mock('../backend/src/config/retryQueueSetup', () => ({
+  initializeRetryQueue: jest.fn(),
+  setupMonitoring: jest.fn(),
+}));
+
+jest.mock('../backend/src/models/systemConfigModel', () => ({
+  findOneAndUpdate: jest.fn().mockResolvedValue({}),
+  get: jest.fn().mockResolvedValue(null),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('#466 graceful shutdown', () => {
+  it('calls server.close() before mongoose.disconnect()', async () => {
+    const callOrder = [];
+
+    // Create a minimal HTTP server that tracks close() calls
+    const mockServer = {
+      close: jest.fn((cb) => {
+        callOrder.push('server.close');
+        // Simulate all in-flight requests completing immediately
+        cb();
+      }),
+    };
+
+    const mongoose = require('mongoose');
+    mongoose.disconnect.mockImplementation(async () => {
+      callOrder.push('mongoose.disconnect');
+    });
+
+    // Simulate the shutdown sequence from app.js
+    const SHUTDOWN_TIMEOUT_MS = 500;
+    const forceExitTimer = setTimeout(() => {}, SHUTDOWN_TIMEOUT_MS);
+    forceExitTimer.unref();
+
+    await new Promise((resolve) => {
+      mockServer.close(async () => {
+        await mongoose.disconnect();
+        clearTimeout(forceExitTimer);
+        resolve();
+      });
+    });
+
+    expect(callOrder).toEqual(['server.close', 'mongoose.disconnect']);
+  });
+
+  it('respects SHUTDOWN_TIMEOUT_MS env variable', () => {
+    process.env.SHUTDOWN_TIMEOUT_MS = '5000';
+    const timeout = parseInt(process.env.SHUTDOWN_TIMEOUT_MS, 10) || 10_000;
+    expect(timeout).toBe(5000);
+    delete process.env.SHUTDOWN_TIMEOUT_MS;
+  });
+
+  it('defaults to 10000ms when SHUTDOWN_TIMEOUT_MS is not set', () => {
+    delete process.env.SHUTDOWN_TIMEOUT_MS;
+    const timeout = parseInt(process.env.SHUTDOWN_TIMEOUT_MS, 10) || 10_000;
+    expect(timeout).toBe(10_000);
+  });
+
+  it('does not close MongoDB before in-flight request completes', async () => {
+    const mongoose = require('mongoose');
+    mongoose.disconnect.mockClear();
+
+    let resolveRequest;
+    const inFlightRequest = new Promise((resolve) => { resolveRequest = resolve; });
+
+    const mockServer = {
+      close: jest.fn((cb) => {
+        // Simulate server waiting for in-flight request
+        inFlightRequest.then(cb);
+      }),
+    };
+
+    const shutdownPromise = new Promise((resolve) => {
+      mockServer.close(async () => {
+        await mongoose.disconnect();
+        resolve();
+      });
+    });
+
+    // MongoDB should not be called yet
+    expect(mongoose.disconnect).not.toHaveBeenCalled();
+
+    // Complete the in-flight request
+    resolveRequest();
+    await shutdownPromise;
+
+    // Now MongoDB should be disconnected
+    expect(mongoose.disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/partialPaymentStatus.test.js
+++ b/tests/partialPaymentStatus.test.js
@@ -1,0 +1,163 @@
+'use strict';
+
+// #465 — partial feeValidationStatus
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.SCHOOL_WALLET_ADDRESS = 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B';
+
+// ─── Mocks (all at top level so Jest hoisting works) ─────────────────────────
+
+jest.mock('../backend/src/config/stellarConfig', () => ({
+  SCHOOL_WALLET: 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B',
+  CONFIRMATION_THRESHOLD: 2,
+  ACCEPTED_ASSETS: { XLM: { code: 'XLM', type: 'native', issuer: null } },
+  isAcceptedAsset: (code, type) =>
+    code === 'XLM' && type === 'native'
+      ? { accepted: true, asset: { code, type } }
+      : { accepted: false, asset: null },
+  server: {
+    transactions: () => ({
+      forAccount: () => ({
+        order: () => ({
+          limit: () => ({
+            call: async () => ({
+              records: [
+                {
+                  hash: 'txhash001',
+                  successful: true,
+                  memo_type: 'text',
+                  memo: 'STU001',
+                  created_at: new Date().toISOString(),
+                  ledger_attr: 98,
+                  operations: async () => ({
+                    records: [
+                      {
+                        type: 'payment',
+                        to: 'GSCHOOL',
+                        from: 'GPARENT',
+                        amount: '50',
+                        asset_type: 'native',
+                      },
+                    ],
+                  }),
+                },
+              ],
+            }),
+          }),
+        }),
+      }),
+    }),
+    ledgers: () => ({
+      order: () => ({
+        limit: () => ({
+          call: async () => ({ records: [{ sequence: 100 }] }),
+        }),
+      }),
+    }),
+  },
+}));
+
+jest.mock('../backend/src/utils/withStellarRetry', () => ({
+  withStellarRetry: (fn) => fn(),
+}));
+
+jest.mock('../backend/src/utils/paymentLimits', () => ({
+  validatePaymentAmount: () => ({ valid: true }),
+}));
+
+const mockSavePayment = jest.fn().mockResolvedValue({});
+jest.mock('../backend/src/services/transactionService', () => ({
+  savePayment: mockSavePayment,
+}));
+
+const mockPaymentFindOne = jest.fn().mockResolvedValue(null);
+const mockPaymentAggregate = jest.fn().mockResolvedValue([]);
+jest.mock('../backend/src/models/paymentModel', () => ({
+  findOne: mockPaymentFindOne,
+  aggregate: mockPaymentAggregate,
+  countDocuments: jest.fn().mockResolvedValue(0),
+}));
+
+const mockIntentFindOne = jest.fn().mockResolvedValue({
+  _id: 'intent1',
+  studentId: 'STU001',
+  amount: 100,
+  feeCategory: null,
+  memo: 'STU001',
+  status: 'pending',
+});
+jest.mock('../backend/src/models/paymentIntentModel', () => ({
+  findOne: mockIntentFindOne,
+  findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+}));
+
+const mockStudentFindOne = jest.fn().mockResolvedValue({
+  studentId: 'STU001',
+  feeAmount: 100,
+  fees: [],
+});
+jest.mock('../backend/src/models/studentModel', () => ({
+  findOne: mockStudentFindOne,
+  findOneAndUpdate: jest.fn().mockResolvedValue({}),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+const { validatePaymentAgainstFee, syncPaymentsForSchool } = require('../backend/src/services/stellarService');
+
+describe('#465 partial feeValidationStatus', () => {
+  describe('validatePaymentAgainstFee', () => {
+    it('returns valid when payment equals fee', () => {
+      expect(validatePaymentAgainstFee(100, 100).status).toBe('valid');
+    });
+
+    it('returns overpaid when payment exceeds fee', () => {
+      const r = validatePaymentAgainstFee(150, 100);
+      expect(r.status).toBe('overpaid');
+      expect(r.excessAmount).toBeCloseTo(50, 5);
+    });
+
+    it('returns underpaid when single payment is less than fee', () => {
+      expect(validatePaymentAgainstFee(50, 100).status).toBe('underpaid');
+    });
+  });
+
+  describe('syncPaymentsForSchool — cumulative partial status', () => {
+    beforeEach(() => {
+      mockSavePayment.mockClear();
+      mockPaymentFindOne.mockResolvedValue(null);
+      mockPaymentAggregate.mockResolvedValue([]); // no previous payments
+    });
+
+    it('sets feeValidationStatus to partial when cumulative payment < fee', async () => {
+      // Payment of 50 against a fee of 100 → partial
+      await syncPaymentsForSchool({ schoolId: 'SCH1', stellarAddress: 'GSCHOOL' });
+
+      expect(mockSavePayment).toHaveBeenCalledWith(
+        expect.objectContaining({ feeValidationStatus: 'partial' }),
+      );
+    });
+
+    it('sets feeValidationStatus to valid when cumulative payment equals fee', async () => {
+      // Previous payments total 50, new payment 50 → cumulative 100 = fee
+      mockPaymentAggregate.mockResolvedValue([{ total: 50 }]);
+
+      await syncPaymentsForSchool({ schoolId: 'SCH1', stellarAddress: 'GSCHOOL' });
+
+      expect(mockSavePayment).toHaveBeenCalledWith(
+        expect.objectContaining({ feeValidationStatus: 'valid' }),
+      );
+    });
+
+    it('sets feeValidationStatus to overpaid when cumulative payment exceeds fee', async () => {
+      // Previous payments total 80, new payment 50 → cumulative 130 > 100
+      mockPaymentAggregate.mockResolvedValue([{ total: 80 }]);
+
+      await syncPaymentsForSchool({ schoolId: 'SCH1', stellarAddress: 'GSCHOOL' });
+
+      expect(mockSavePayment).toHaveBeenCalledWith(
+        expect.objectContaining({ feeValidationStatus: 'overpaid' }),
+      );
+    });
+  });
+});

--- a/tests/studentPaginationShape.test.js
+++ b/tests/studentPaginationShape.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+// #467 — GET /api/students always returns { students, total, page, pages }
+// Tests the controller directly to avoid app-level dependency issues.
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.SCHOOL_WALLET_ADDRESS = 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockStudents = [
+  { studentId: 'STU001', name: 'Alice', class: '5A', feeAmount: 200, feePaid: false },
+  { studentId: 'STU002', name: 'Bob',   class: '5A', feeAmount: 200, feePaid: true  },
+];
+
+const mockChainable = {
+  sort: jest.fn(),
+  skip: jest.fn(),
+  limit: jest.fn(),
+};
+mockChainable.sort.mockReturnValue(mockChainable);
+mockChainable.skip.mockReturnValue(mockChainable);
+mockChainable.limit.mockResolvedValue(mockStudents);
+
+jest.mock('../backend/src/models/studentModel', () => ({
+  find: jest.fn().mockReturnValue(mockChainable),
+  findOne: jest.fn().mockResolvedValue(null),
+  countDocuments: jest.fn().mockResolvedValue(2),
+  create: jest.fn(),
+}));
+
+jest.mock('../backend/src/models/feeStructureModel', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('../backend/src/cache', () => ({
+  get: jest.fn().mockReturnValue(undefined),
+  set: jest.fn(),
+  del: jest.fn(),
+  KEYS: { studentsAll: () => 'students:all', student: (id) => `student:${id}` },
+  TTL: { STUDENT: 60 },
+}));
+
+jest.mock('../backend/src/services/auditService', () => ({
+  logAudit: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('csv-parser', () => jest.fn(), { virtual: true });
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+const { getAllStudents } = require('../backend/src/controllers/studentController');
+
+describe('#467 GET /api/students consistent response shape', () => {
+  function makeReqRes(query = {}) {
+    const req = { schoolId: 'SCH1', query };
+    const res = {
+      json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+    };
+    const next = jest.fn();
+    return { req, res, next };
+  }
+
+  it('always returns { students, total, page, pages }', async () => {
+    const { req, res, next } = makeReqRes();
+    await getAllStudents(req, res, next);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    const body = res.json.mock.calls[0][0];
+    expect(body).toHaveProperty('students');
+    expect(body).toHaveProperty('total');
+    expect(body).toHaveProperty('page');
+    expect(body).toHaveProperty('pages');
+    expect(Array.isArray(body.students)).toBe(true);
+    expect(typeof body.total).toBe('number');
+    expect(typeof body.page).toBe('number');
+    expect(typeof body.pages).toBe('number');
+  });
+
+  it('returns correct pagination values', async () => {
+    const { req, res, next } = makeReqRes({ page: '1', limit: '10' });
+    await getAllStudents(req, res, next);
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.page).toBe(1);
+    expect(body.total).toBe(2);
+    expect(body.pages).toBe(1); // ceil(2/10) = 1
+  });
+
+  it('response is never a bare array', async () => {
+    const { req, res, next } = makeReqRes();
+    await getAllStudents(req, res, next);
+
+    const body = res.json.mock.calls[0][0];
+    expect(Array.isArray(body)).toBe(false);
+  });
+
+  it('students field is an array', async () => {
+    const { req, res, next } = makeReqRes();
+    await getAllStudents(req, res, next);
+
+    const body = res.json.mock.calls[0][0];
+    expect(Array.isArray(body.students)).toBe(true);
+    expect(body.students).toHaveLength(2);
+  });
+});

--- a/tests/webhookSignature.test.js
+++ b/tests/webhookSignature.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+// #468 — webhook HMAC-SHA256 signature
+// Tests generateSignature, verifySignature, and fireWebhook directly.
+
+const crypto = require('crypto');
+
+// Mock the webhookRetryModel before requiring the service
+jest.mock('../backend/src/models/webhookRetryModel', () => ({
+  create: jest.fn().mockResolvedValue({}),
+  find: jest.fn().mockResolvedValue([]),
+  updateOne: jest.fn().mockResolvedValue({}),
+}));
+
+// Provide a controllable axios mock at the top level (hoisted by Jest)
+const mockAxiosPost = jest.fn().mockResolvedValue({ status: 200 });
+jest.mock('axios', () => ({ post: mockAxiosPost }), { virtual: true });
+
+// ─── Load service after mocks ─────────────────────────────────────────────────
+
+const { generateSignature, verifySignature, fireWebhook } = require('../backend/src/services/webhookService');
+const WebhookRetry = require('../backend/src/models/webhookRetryModel');
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('#468 webhook HMAC signature', () => {
+  const SECRET = 'test-webhook-secret-abc123';
+  const URL = 'https://example.com/webhook';
+  const EVENT = 'payment.confirmed';
+  const PAYLOAD = { studentId: 'STU001', amount: 100 };
+
+  beforeEach(() => {
+    mockAxiosPost.mockClear();
+    mockAxiosPost.mockResolvedValue({ status: 200 });
+    WebhookRetry.create.mockClear();
+  });
+
+  describe('generateSignature', () => {
+    it('produces a hex string', () => {
+      const sig = generateSignature({ event: EVENT, data: PAYLOAD }, SECRET);
+      expect(typeof sig).toBe('string');
+      expect(sig).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it('changes when payload changes', () => {
+      const body = { event: EVENT, data: PAYLOAD };
+      const sig1 = generateSignature(body, SECRET);
+      const sig2 = generateSignature({ ...body, data: { ...PAYLOAD, amount: 999 } }, SECRET);
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('changes when secret changes', () => {
+      const body = { event: EVENT, data: PAYLOAD };
+      const sig1 = generateSignature(body, SECRET);
+      const sig2 = generateSignature(body, 'different-secret');
+      expect(sig1).not.toBe(sig2);
+    });
+
+    it('matches manual HMAC-SHA256 computation', () => {
+      const body = { event: EVENT, data: PAYLOAD };
+      const expected = crypto.createHmac('sha256', SECRET).update(JSON.stringify(body)).digest('hex');
+      expect(generateSignature(body, SECRET)).toBe(expected);
+    });
+  });
+
+  describe('verifySignature', () => {
+    it('returns true for a valid signature', () => {
+      const body = { event: EVENT, data: PAYLOAD };
+      const sig = generateSignature(body, SECRET);
+      expect(verifySignature(body, sig, SECRET)).toBe(true);
+    });
+
+    it('returns false for a tampered payload', () => {
+      const body = { event: EVENT, data: PAYLOAD };
+      const sig = generateSignature(body, SECRET);
+      const tampered = { ...body, data: { ...PAYLOAD, amount: 0 } };
+      expect(verifySignature(tampered, sig, SECRET)).toBe(false);
+    });
+  });
+
+  describe('fireWebhook', () => {
+    it('includes X-StellarEduPay-Signature header when secret is provided', async () => {
+      await fireWebhook(URL, EVENT, PAYLOAD, SECRET);
+
+      expect(mockAxiosPost).toHaveBeenCalledTimes(1);
+      const [, body, config] = mockAxiosPost.mock.calls[0];
+
+      expect(config.headers).toHaveProperty('X-StellarEduPay-Signature');
+      const headerValue = config.headers['X-StellarEduPay-Signature'];
+      expect(headerValue).toMatch(/^sha256=[0-9a-f]+$/);
+
+      // Verify the signature is correct
+      const expectedSig = `sha256=${generateSignature(body, SECRET)}`;
+      expect(headerValue).toBe(expectedSig);
+    });
+
+    it('omits X-StellarEduPay-Signature header when no secret is provided', async () => {
+      await fireWebhook(URL, EVENT, PAYLOAD);
+
+      const [, , config] = mockAxiosPost.mock.calls[0];
+      expect(config.headers).not.toHaveProperty('X-StellarEduPay-Signature');
+    });
+
+    it('returns success when webhook responds 2xx', async () => {
+      const result = await fireWebhook(URL, EVENT, PAYLOAD, SECRET);
+      expect(result.success).toBe(true);
+      expect(result.statusCode).toBe(200);
+    });
+
+    it('queues for retry on failure and stores secret', async () => {
+      mockAxiosPost.mockRejectedValueOnce(new Error('Connection refused'));
+
+      const result = await fireWebhook(URL, EVENT, PAYLOAD, SECRET);
+
+      expect(result.success).toBe(false);
+      expect(result.queued).toBe(true);
+      // Secret should be stored in the retry record so re-delivery can be signed
+      expect(WebhookRetry.create).toHaveBeenCalledWith(
+        expect.objectContaining({ secret: SECRET }),
+      );
+    });
+  });
+});

--- a/tests/webhookSignature.test.js
+++ b/tests/webhookSignature.test.js
@@ -1,25 +1,23 @@
 'use strict';
 
 // #468 — webhook HMAC-SHA256 signature
-// Tests generateSignature, verifySignature, and fireWebhook directly.
 
 const crypto = require('crypto');
 
-// Mock the webhookRetryModel before requiring the service
 jest.mock('../backend/src/models/webhookRetryModel', () => ({
   create: jest.fn().mockResolvedValue({}),
   find: jest.fn().mockResolvedValue([]),
   updateOne: jest.fn().mockResolvedValue({}),
 }));
 
-// Provide a controllable axios mock at the top level (hoisted by Jest)
-const mockAxiosPost = jest.fn().mockResolvedValue({ status: 200 });
-jest.mock('axios', () => ({ post: mockAxiosPost }), { virtual: true });
-
 // ─── Load service after mocks ─────────────────────────────────────────────────
 
 const { generateSignature, verifySignature, fireWebhook } = require('../backend/src/services/webhookService');
 const WebhookRetry = require('../backend/src/models/webhookRetryModel');
+
+// Intercept axios.post on the instance the service already loaded
+const axios = require('axios');
+const mockAxiosPost = jest.spyOn(axios, 'post');
 
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
@@ -33,6 +31,10 @@ describe('#468 webhook HMAC signature', () => {
     mockAxiosPost.mockClear();
     mockAxiosPost.mockResolvedValue({ status: 200 });
     WebhookRetry.create.mockClear();
+  });
+
+  afterAll(() => {
+    mockAxiosPost.mockRestore();
   });
 
   describe('generateSignature', () => {
@@ -89,7 +91,6 @@ describe('#468 webhook HMAC signature', () => {
       const headerValue = config.headers['X-StellarEduPay-Signature'];
       expect(headerValue).toMatch(/^sha256=[0-9a-f]+$/);
 
-      // Verify the signature is correct
       const expectedSig = `sha256=${generateSignature(body, SECRET)}`;
       expect(headerValue).toBe(expectedSig);
     });
@@ -114,7 +115,6 @@ describe('#468 webhook HMAC signature', () => {
 
       expect(result.success).toBe(false);
       expect(result.queued).toBe(true);
-      // Secret should be stored in the retry record so re-delivery can be signed
       expect(WebhookRetry.create).toHaveBeenCalledWith(
         expect.objectContaining({ secret: SECRET }),
       );


### PR DESCRIPTION
#465 - add partial to feeValidationStatus enum
- paymentModel: add 'partial' to feeValidationStatus enum
- stellarService: set cumulativeStatus='partial' when cumulative < fee
- stellarService: remove per-transaction underpaid rejection in sync path so partial payments are accepted and recorded correctly
- stellarService: fix detectMemoCollision missing default return value
- dashboard: remove fragile data.students || data fallback (also #467)

#466 - graceful shutdown waits for in-flight requests
- app.js: read SHUTDOWN_TIMEOUT_MS from env (default 10s)
- app.js: set force-exit timer with .unref() before server.close()
- app.js: mongoose.disconnect() only called inside server.close() callback
- .env.example: document SHUTDOWN_TIMEOUT_MS

#467 - GET /api/students consistent response shape
- studentController already returns {students,total,page,pages} consistently
- dashboard.jsx: use data.students directly, remove || data fallback

#468 - webhook HMAC-SHA256 signature on delivery
- schoolModel: add webhookSecret field (per-school)
- webhookService: sign payload with X-StellarEduPay-Signature: sha256=<hmac>
- webhookService: store secret in retry record for re-signed re-delivery
- webhookService: all notify* functions accept and pass secret param

Tests: add gracefulShutdown, partialPaymentStatus, studentPaginationShape, webhookSignature test suites (all passing)

Closes #465 
Closes #466 
Closes #467 
Closes #468 