### PR TITLE
fix: wrap Payment.create and Student.updateOne in MongoDB session transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,9 +229,25 @@ Before you begin, ensure you have the following installed:
 
 - **Node.js** 18 or higher ([Download](https://nodejs.org/))
 - **npm** 9 or higher (bundled with Node.js)
-- **MongoDB** 4.4 or higher ([Download](https://www.mongodb.com/try/download/community) or use [MongoDB Atlas](https://www.mongodb.com/atlas))
+- **MongoDB** 6.0 or higher, running as a **replica set** ([Download](https://www.mongodb.com/try/download/community) or use [MongoDB Atlas](https://www.mongodb.com/atlas))
 - **Git** ([Download](https://git-scm.com/downloads))
 - **Docker + Docker Compose v2** (optional, for containerized deployment) ([Download](https://www.docker.com/get-started))
+
+> ⚠️ **MongoDB Replica Set Required**
+>
+> StellarEduPay uses [MongoDB multi-document transactions](https://www.mongodb.com/docs/manual/core/transactions/) to atomically record a payment and update the student's fee status. MongoDB only supports multi-document transactions on replica sets (or sharded clusters). A standalone `mongod` instance will cause transaction operations to fail at runtime.
+>
+> **Local development** — start a single-node replica set instead of a plain `mongod`:
+> ```bash
+> mongod --replSet rs0 --dbpath /path/to/data
+> # In a separate terminal, initialise the replica set once:
+> mongosh --eval "rs.initiate()"
+> ```
+> Then use `MONGO_URI=mongodb://localhost:27017/stellaredupay?replicaSet=rs0` in your `.env`.
+>
+> **Docker Compose** — the provided `docker-compose.yml` already configures MongoDB as a single-node replica set; no extra steps are needed.
+>
+> **MongoDB Atlas** — all Atlas clusters (including the free M0 tier) run as replica sets by default.
 
 ### Installation
 

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const mongoose = require('mongoose');
 const School = require('../models/schoolModel');
 const Payment = require('../models/paymentModel');
 const Student = require('../models/studentModel');
@@ -115,20 +116,24 @@ async function processTransaction(tx, school) {
     networkFee,
   };
 
+  const session = await mongoose.connection.startSession();
   try {
-    await Payment.create(paymentData);
-    
-    // Update student balance if confirmed and not suspicious
-    if (isConfirmed && !isSuspicious) {
-      await Student.findOneAndUpdate(
-        { schoolId, studentId: memo },
-        {
-          totalPaid: cumulativeTotal,
-          remainingBalance: Math.max(0, remaining),
-          feePaid: cumulativeTotal >= student.feeAmount,
-        }
-      );
-    }
+    await session.withTransaction(async () => {
+      await Payment.create([paymentData], { session });
+
+      // Atomically update student balance if confirmed and not suspicious
+      if (isConfirmed && !isSuspicious) {
+        await Student.findOneAndUpdate(
+          { schoolId, studentId: memo },
+          {
+            totalPaid: cumulativeTotal,
+            remainingBalance: Math.max(0, remaining),
+            feePaid: cumulativeTotal >= student.feeAmount,
+          },
+          { session }
+        );
+      }
+    });
 
     sseEmit(schoolId, 'payment', {
       txHash: tx.hash,
@@ -156,6 +161,8 @@ async function processTransaction(tx, school) {
     }
     logger.error('Failed to record payment', { error: error.message, txHash: tx.hash });
     throw error;
+  } finally {
+    await session.endSession();
   }
 }
 

--- a/tests/transactionAtomicity.test.js
+++ b/tests/transactionAtomicity.test.js
@@ -1,0 +1,216 @@
+'use strict';
+
+// ─── Env setup ────────────────────────────────────────────────────────────────
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.SCHOOL_WALLET_ADDRESS = 'GTEST123';
+
+// ─── Session / transaction mock ───────────────────────────────────────────────
+// withTransaction executes the callback; endSession is a no-op.
+const mockWithTransaction = jest.fn(async (cb) => cb());
+const mockEndSession = jest.fn().mockResolvedValue(undefined);
+const mockStartSession = jest.fn().mockResolvedValue({
+  withTransaction: mockWithTransaction,
+  endSession: mockEndSession,
+});
+
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  Schema: class { constructor() { this.index = jest.fn(); } },
+  model: jest.fn().mockReturnValue({}),
+  connection: { startSession: mockStartSession },
+}));
+
+// ─── Model mocks ──────────────────────────────────────────────────────────────
+const mockPaymentCreate = jest.fn().mockResolvedValue([{}]);
+const mockPaymentFindOne = jest.fn().mockResolvedValue(null);
+const mockPaymentAggregate = jest.fn().mockResolvedValue([]);
+
+jest.mock('../backend/src/models/paymentModel', () => ({
+  findOne: (...a) => mockPaymentFindOne(...a),
+  create: (...a) => mockPaymentCreate(...a),
+  aggregate: (...a) => mockPaymentAggregate(...a),
+}));
+
+const mockStudentFindOne = jest.fn().mockResolvedValue({
+  schoolId: 'school1',
+  studentId: 'STU001',
+  feeAmount: 250,
+  totalPaid: 0,
+});
+const mockStudentFindOneAndUpdate = jest.fn().mockResolvedValue({});
+
+jest.mock('../backend/src/models/studentModel', () => ({
+  findOne: (...a) => mockStudentFindOne(...a),
+  findOneAndUpdate: (...a) => mockStudentFindOneAndUpdate(...a),
+}));
+
+jest.mock('../backend/src/models/schoolModel', () => ({
+  find: jest.fn().mockResolvedValue([]),
+}));
+
+// ─── Service / utility mocks ──────────────────────────────────────────────────
+jest.mock('../backend/src/config/stellarConfig', () => ({
+  server: {},
+  SCHOOL_WALLET: 'GTEST123',
+}));
+
+jest.mock('../backend/src/services/stellarService', () => ({
+  extractValidPayment: jest.fn().mockResolvedValue({
+    payOp: { amount: '250', from: 'GSENDER' },
+    memo: 'STU001',
+    asset: { code: 'XLM' },
+  }),
+  validatePaymentAgainstFee: jest.fn().mockReturnValue({ status: 'valid', message: 'ok' }),
+  detectMemoCollision: jest.fn().mockResolvedValue({ suspicious: false, reason: null }),
+  detectAbnormalPatterns: jest.fn().mockResolvedValue({ suspicious: false, reason: null }),
+  checkConfirmationStatus: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../backend/src/utils/paymentLimits', () => ({
+  validatePaymentAmount: jest.fn().mockReturnValue({ valid: true }),
+}));
+
+jest.mock('../backend/src/utils/generateReferenceCode', () => ({
+  generateReferenceCode: jest.fn().mockResolvedValue('REF001'),
+}));
+
+jest.mock('../backend/src/services/sseService', () => ({
+  emit: jest.fn(),
+}));
+
+jest.mock('../backend/src/utils/logger', () => {
+  const logger = { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() };
+  logger.child = () => logger;
+  return logger;
+});
+
+// ─── Subject under test ───────────────────────────────────────────────────────
+const { processTransaction } = require('../backend/src/services/transactionPollingService');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+const makeSchool = () => ({ schoolId: 'school1', stellarAddress: 'GTEST123' });
+const makeTx = (hash = 'txhash1') => ({
+  hash,
+  created_at: new Date().toISOString(),
+  fee_paid: '100',
+  ledger_attr: 42,
+  memo: 'STU001',
+});
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Restore defaults
+  mockPaymentFindOne.mockResolvedValue(null);
+  mockPaymentCreate.mockResolvedValue([{}]);
+  mockStudentFindOne.mockResolvedValue({
+    schoolId: 'school1', studentId: 'STU001', feeAmount: 250, totalPaid: 0,
+  });
+  mockStudentFindOneAndUpdate.mockResolvedValue({});
+  mockWithTransaction.mockImplementation(async (cb) => cb());
+});
+
+describe('processTransaction – atomicity', () => {
+  test('starts a session and uses withTransaction', async () => {
+    await processTransaction(makeTx(), makeSchool());
+
+    expect(mockStartSession).toHaveBeenCalledTimes(1);
+    expect(mockWithTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  test('Payment.create and Student.findOneAndUpdate are called inside the transaction', async () => {
+    const callOrder = [];
+    mockWithTransaction.mockImplementation(async (cb) => {
+      // Track that both writes happen inside the callback
+      mockPaymentCreate.mockImplementationOnce(async (...args) => {
+        callOrder.push('Payment.create');
+        return [{}];
+      });
+      mockStudentFindOneAndUpdate.mockImplementationOnce(async (...args) => {
+        callOrder.push('Student.findOneAndUpdate');
+        return {};
+      });
+      await cb();
+    });
+
+    await processTransaction(makeTx(), makeSchool());
+
+    expect(callOrder).toEqual(['Payment.create', 'Student.findOneAndUpdate']);
+  });
+
+  test('Payment.create receives the session object', async () => {
+    const fakeSession = { id: 'sess-1' };
+    mockStartSession.mockResolvedValueOnce({
+      withTransaction: async (cb) => cb(),
+      endSession: mockEndSession,
+    });
+    // We can't easily inspect the session arg here without a real session,
+    // but we verify create is called with an array (session-compatible form).
+    await processTransaction(makeTx(), makeSchool());
+
+    const [docs] = mockPaymentCreate.mock.calls[0];
+    expect(Array.isArray(docs)).toBe(true);
+  });
+
+  test('endSession is always called (finally block)', async () => {
+    mockWithTransaction.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(processTransaction(makeTx(), makeSchool())).rejects.toThrow('boom');
+
+    expect(mockEndSession).toHaveBeenCalledTimes(1);
+  });
+
+  test('rollback: if Payment.create throws, Student.findOneAndUpdate is not called', async () => {
+    mockWithTransaction.mockImplementationOnce(async (cb) => {
+      // Simulate Payment.create failing inside the transaction
+      mockPaymentCreate.mockRejectedValueOnce(new Error('DB write error'));
+      await cb(); // this will throw
+    });
+
+    await expect(processTransaction(makeTx(), makeSchool())).rejects.toThrow('DB write error');
+
+    expect(mockStudentFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('duplicate transaction returns processed:false without starting a session', async () => {
+    mockPaymentFindOne.mockResolvedValueOnce({ txHash: 'txhash1' }); // already exists
+
+    const result = await processTransaction(makeTx('txhash1'), makeSchool());
+
+    expect(result).toEqual({ processed: false, reason: 'duplicate' });
+    expect(mockStartSession).not.toHaveBeenCalled();
+  });
+
+  test('duplicate key error (11000) from Payment.create returns processed:false', async () => {
+    const dupErr = new Error('duplicate key');
+    dupErr.code = 11000;
+    mockWithTransaction.mockImplementationOnce(async (cb) => {
+      mockPaymentCreate.mockRejectedValueOnce(dupErr);
+      await cb();
+    });
+
+    const result = await processTransaction(makeTx(), makeSchool());
+
+    expect(result).toEqual({ processed: false, reason: 'duplicate' });
+    expect(mockEndSession).toHaveBeenCalledTimes(1);
+  });
+
+  test('Student.findOneAndUpdate is skipped when payment is not confirmed', async () => {
+    const { checkConfirmationStatus } = require('../backend/src/services/stellarService');
+    checkConfirmationStatus.mockResolvedValueOnce(false); // not confirmed
+
+    await processTransaction(makeTx(), makeSchool());
+
+    expect(mockStudentFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('Student.findOneAndUpdate is skipped for suspicious payments', async () => {
+    const { detectMemoCollision } = require('../backend/src/services/stellarService');
+    detectMemoCollision.mockResolvedValueOnce({ suspicious: true, reason: 'collision' });
+
+    await processTransaction(makeTx(), makeSchool());
+
+    expect(mockStudentFindOneAndUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #443

---

## Problem

`processTransaction()` in `transactionPollingService.js` called `Payment.create()` and `Student.findOneAndUpdate()` as two separate, unguarded writes. A server crash between them would leave a payment recorded while the student's `feePaid`/`totalPaid` fields remained stale.

## Fix

Wrapped both writes in `session.withTransaction()` so they commit or roll back atomically:

- `mongoose.connection.startSession()` opens a session before the writes
- `Payment.create([paymentData], { session })` (array form required for session support)
- `Student.findOneAndUpdate(..., { session })` inside the same callback
- `session.endSession()` called in a `finally` block

## Tests

Added `tests/transactionAtomicity.test.js` (8 tests):
- Session is started for every real payment
- Both writes execute inside the transaction callback
- `endSession` is always called (finally block)
- If `Payment.create` throws, `Student.findOneAndUpdate` is never called
- Duplicate transactions skip the session entirely
- Duplicate key error (11000) returns `processed: false`
- Student update is skipped for unconfirmed or suspicious payments

## Docs

Updated README prerequisite bullet to explicitly state MongoDB 6.0+ must run as a replica set (required for multi-document transactions).