### PR TITLE
fix: close mobile menu on route change (back/forward nav)

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import TestnetBanner from './TestnetBanner';
@@ -15,6 +15,9 @@ export default function Navbar() {
   const { pathname } = useRouter();
   const [open, setOpen] = useState(false);
   const { dark, toggle } = useTheme();
+
+  // Close the mobile menu on every route change, including browser back/forward.
+  useEffect(() => { setOpen(false); }, [pathname]);
 
   return (
     <>

--- a/tests/navbarMenuClose.test.js
+++ b/tests/navbarMenuClose.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+// Tests for the mobile menu close-on-route-change behaviour in Navbar.
+// The fix adds: useEffect(() => { setOpen(false); }, [pathname])
+// We test the state-transition logic directly without a DOM renderer,
+// matching the pattern used in testnetBanner.test.js.
+
+/**
+ * Minimal simulation of the useEffect([pathname]) hook:
+ * returns the new `open` state after a pathname change.
+ */
+function menuStateAfterRouteChange(wasOpen, pathnameChanged) {
+  // The effect fires whenever pathname changes, unconditionally closing the menu.
+  if (pathnameChanged) return false;
+  return wasOpen;
+}
+
+describe('Navbar mobile menu — close on route change', () => {
+  it('closes an open menu when the route changes', () => {
+    expect(menuStateAfterRouteChange(true, true)).toBe(false);
+  });
+
+  it('keeps the menu closed when the route changes', () => {
+    expect(menuStateAfterRouteChange(false, true)).toBe(false);
+  });
+
+  it('does not change menu state when the route has not changed', () => {
+    expect(menuStateAfterRouteChange(true, false)).toBe(true);
+    expect(menuStateAfterRouteChange(false, false)).toBe(false);
+  });
+
+  it('closes the menu on browser back navigation (route change)', () => {
+    // Back navigation changes pathname, so the effect fires.
+    const openBeforeBack = true;
+    const pathnameChangedByBack = true;
+    expect(menuStateAfterRouteChange(openBeforeBack, pathnameChangedByBack)).toBe(false);
+  });
+
+  it('closes the menu on browser forward navigation (route change)', () => {
+    const openBeforeForward = true;
+    const pathnameChangedByForward = true;
+    expect(menuStateAfterRouteChange(openBeforeForward, pathnameChangedByForward)).toBe(false);
+  });
+});


### PR DESCRIPTION
Add useEffect(() => { setOpen(false); }, [pathname]) to Navbar so the mobile menu resets on every route change, including browser back/forward. The onClick handler on link taps was already closing it; this covers the history-navigation case that was missed.

Add navbarMenuClose.test.js with 5 tests covering the state-transition logic for open→closed, closed→closed, and no-change cases.

closes #471 