### PR TITLE
fix: enforce configurable JSON body size limit

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -255,6 +255,12 @@ MAX_TRANSACTION_AMOUNT=100000000000
 # Leave unset to use plain-text memos (default behaviour).
 # MEMO_ENCRYPTION_KEY=
 
+# ── Body Size Limit ───────────────────────────────────────────────────────────
+# Maximum JSON body size for most endpoints (default: 10kb).
+# The bulk import endpoint always allows up to 1mb regardless of this setting.
+# Oversized payloads are rejected with HTTP 413 Payload Too Large.
+MAX_BODY_SIZE=10kb
+
 # ── Payment Limits ─────────────────────────────────────────────
 # Minimum payment amount in XLM/USDC (default: 0.01)
 MIN_PAYMENT_AMOUNT=0.01

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -61,7 +61,7 @@ app.use(helmet({
   crossOriginEmbedderPolicy: false,
   crossOriginResourcePolicy: { policy: "cross-origin" },
 }));
-app.use(express.json());
+app.use(express.json({ limit: config.MAX_BODY_SIZE }));
 app.use(requestLogger());
 
 const concurrentMiddleware = createConcurrentRequestMiddleware({

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -81,6 +81,10 @@ if (MAX_PAYMENT_AMOUNT <= MIN_PAYMENT_AMOUNT) {
   );
 }
 
+// ── Body Size Limit ───────────────────────────────────────────────────────────
+// Global JSON body size limit (default: 10kb). Bulk import uses 1mb regardless.
+const MAX_BODY_SIZE = process.env.MAX_BODY_SIZE || '10kb';
+
 // ── Timeouts ──────────────────────────────────────────────────────────────────
 const REQUEST_TIMEOUT_MS = parseInt(
   process.env.REQUEST_TIMEOUT_MS || "30000",
@@ -136,6 +140,7 @@ const config = Object.freeze({
   MIN_PAYMENT_AMOUNT,
   MAX_PAYMENT_AMOUNT,
   MAX_QUEUE_DEPTH,
+  MAX_BODY_SIZE,
   REQUEST_TIMEOUT_MS,
   STELLAR_TIMEOUT_MS,
   JWT_SECRET,

--- a/backend/src/routes/studentRoutes.js
+++ b/backend/src/routes/studentRoutes.js
@@ -25,7 +25,7 @@ router.use(resolveSchool);
 
 // Admin-only routes
 router.post('/', requireAdminAuth, validateRegisterStudent, registerStudent);
-router.post('/bulk', requireAdminAuth, upload.single('file'), bulkImportStudents);
+router.post('/bulk', requireAdminAuth, express.json({ limit: '1mb' }), upload.single('file'), bulkImportStudents);
 router.get('/', requireAdminAuth, getAllStudents);
 
 // Public routes

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -11,6 +11,7 @@ All error responses follow the [Error Responses](#error-responses) format.
 - [Authentication](#authentication)
 - [School Context](#school-context)
 - [Idempotency](#idempotency)
+- [Request Body Size Limits](#request-body-size-limits)
 - [Schools](#schools)
 - [Students](#students)
 - [Fee Structures](#fee-structures)
@@ -70,6 +71,26 @@ Missing the header on these routes returns:
 HTTP 400
 { "error": "Idempotency-Key header is required for this request", "code": "MISSING_IDEMPOTENCY_KEY" }
 ```
+
+---
+
+## Request Body Size Limits
+
+To protect against oversized payload attacks, the API enforces JSON body size limits:
+
+| Endpoint | Limit |
+|----------|-------|
+| All endpoints (default) | `10kb` (configurable via `MAX_BODY_SIZE` env var) |
+| `POST /api/students/bulk` | `1mb` |
+
+Requests that exceed the applicable limit are rejected before reaching any handler:
+
+```json
+HTTP 413
+{ "error": "request entity too large" }
+```
+
+The global limit can be tuned via the `MAX_BODY_SIZE` environment variable (e.g. `MAX_BODY_SIZE=50kb`). The bulk import override is fixed at `1mb` regardless of `MAX_BODY_SIZE`.
 
 ---
 

--- a/tests/bodySize.test.js
+++ b/tests/bodySize.test.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Tests for body size limit enforcement (Issue: oversized JSON payload DoS).
+ *
+ * Verifies that:
+ *  1. MAX_BODY_SIZE is exported from config with the correct default.
+ *  2. app.js applies express.json({ limit: config.MAX_BODY_SIZE }) globally.
+ *  3. The bulk import route applies a 1mb override before the handler.
+ *  4. MAX_BODY_SIZE is documented in .env.example.
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+
+const fs = require('fs');
+const path = require('path');
+
+const APP_SRC = fs.readFileSync(
+  path.join(__dirname, '../backend/src/app.js'),
+  'utf8'
+);
+
+const STUDENT_ROUTES_SRC = fs.readFileSync(
+  path.join(__dirname, '../backend/src/routes/studentRoutes.js'),
+  'utf8'
+);
+
+const ENV_EXAMPLE = fs.readFileSync(
+  path.join(__dirname, '../backend/.env.example'),
+  'utf8'
+);
+
+describe('Body size limit — configuration', () => {
+  it('config exports MAX_BODY_SIZE with default 10kb', () => {
+    // Temporarily clear any override so we get the default
+    const saved = process.env.MAX_BODY_SIZE;
+    delete process.env.MAX_BODY_SIZE;
+    // Re-require with a fresh module registry to pick up the cleared env var
+    jest.resetModules();
+    const config = require('../backend/src/config');
+    expect(config.MAX_BODY_SIZE).toBe('10kb');
+    // Restore
+    if (saved !== undefined) process.env.MAX_BODY_SIZE = saved;
+    jest.resetModules();
+  });
+
+  it('config respects MAX_BODY_SIZE env var override', () => {
+    const saved = process.env.MAX_BODY_SIZE;
+    process.env.MAX_BODY_SIZE = '50kb';
+    jest.resetModules();
+    const config = require('../backend/src/config');
+    expect(config.MAX_BODY_SIZE).toBe('50kb');
+    if (saved !== undefined) process.env.MAX_BODY_SIZE = saved;
+    else delete process.env.MAX_BODY_SIZE;
+    jest.resetModules();
+  });
+});
+
+describe('Body size limit — app.js middleware', () => {
+  it('applies express.json with config.MAX_BODY_SIZE as the global limit', () => {
+    expect(APP_SRC).toMatch(/express\.json\(\s*\{\s*limit\s*:\s*config\.MAX_BODY_SIZE\s*\}\s*\)/);
+  });
+
+  it('does not use express.json() without a limit option globally', () => {
+    // The bare express.json() call (no options) must not appear
+    expect(APP_SRC).not.toMatch(/express\.json\(\s*\)/);
+  });
+});
+
+describe('Body size limit — bulk import route override', () => {
+  it('bulk import route applies a 1mb express.json override', () => {
+    expect(STUDENT_ROUTES_SRC).toMatch(/express\.json\(\s*\{\s*limit\s*:\s*['"]1mb['"]\s*\}\s*\)/);
+  });
+
+  it('bulk import route places the json override before the handler', () => {
+    const bulkLine = STUDENT_ROUTES_SRC
+      .split('\n')
+      .find((line) => line.includes("'/bulk'") || line.includes('"/bulk"'));
+    expect(bulkLine).toBeDefined();
+    // The 1mb override must appear before bulkImportStudents in the same route definition
+    const overrideIdx = bulkLine.indexOf('1mb');
+    const handlerIdx = bulkLine.indexOf('bulkImportStudents');
+    expect(overrideIdx).toBeGreaterThan(-1);
+    expect(handlerIdx).toBeGreaterThan(overrideIdx);
+  });
+});
+
+describe('Body size limit — documentation', () => {
+  it('MAX_BODY_SIZE is documented in .env.example', () => {
+    expect(ENV_EXAMPLE).toContain('MAX_BODY_SIZE');
+  });
+
+  it('.env.example documents the 413 behaviour', () => {
+    expect(ENV_EXAMPLE).toContain('413');
+  });
+});


### PR DESCRIPTION
Closes #442

---

## Summary

Fixes the unbounded `express.json()` call in `app.js` that allowed malicious actors to send arbitrarily large JSON payloads, consuming memory and CPU during parsing.

## Changes

- **`backend/src/app.js`** — `express.json()` → `express.json({ limit: config.MAX_BODY_SIZE })`; oversized bodies now return `413 Payload Too Large`
- **`backend/src/config/index.js`** — exports `MAX_BODY_SIZE` (default `'10kb'`, reads from env)
- **`backend/src/routes/studentRoutes.js`** — adds `express.json({ limit: '1mb' })` override on `POST /api/students/bulk`
- **`backend/.env.example`** — documents `MAX_BODY_SIZE` with description and 413 note
- **`docs/api-spec.md`** — adds Request Body Size Limits section
- **`tests/bodySize.test.js`** — 8 tests covering config default, env override, middleware presence, bulk override position, and documentation

## Testing

```
npx jest tests/bodySize.test.js --no-coverage
# 8 passed
```

## Acceptance criteria

- [x] `express.json({ limit: '10kb' })` set globally
- [x] Bulk import endpoint uses a higher limit via route-specific middleware
- [x] Oversized payloads return 413 Payload Too Large
- [x] `MAX_BODY_SIZE` env var controls the global limit
- [ ] Test covers oversized payload rejection