### PR TITLE
feat: add Cache-Control and ETag headers to GET /api/payments/accepted-assets

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -868,15 +868,26 @@ async function getStudentPayments(req, res, next) {
   }
 }
 
+// Compute once at startup — changes only when stellarConfig changes.
+const _acceptedAssetsBody = JSON.stringify({
+  assets: Object.values(ACCEPTED_ASSETS).map((a) => ({
+    code: a.code,
+    type: a.type,
+    displayName: a.displayName,
+  })),
+});
+const _acceptedAssetsETag = `"${crypto.createHash('sha1').update(_acceptedAssetsBody).digest('hex')}"`;
+
 async function getAcceptedAssets(req, res, next) {
   try {
-    res.json({
-      assets: Object.values(ACCEPTED_ASSETS).map((a) => ({
-        code: a.code,
-        type: a.type,
-        displayName: a.displayName,
-      })),
-    });
+    res.set('Cache-Control', 'public, max-age=3600');
+    res.set('ETag', _acceptedAssetsETag);
+
+    if (req.headers['if-none-match'] === _acceptedAssetsETag) {
+      return res.status(304).end();
+    }
+
+    res.type('json').send(_acceptedAssetsBody);
   } catch (err) {
     next(err);
   }

--- a/docs/api-spec.md
+++ b/docs/api-spec.md
@@ -599,10 +599,22 @@ X-School-ID: SCH-3F2A
 GET /api/payments/accepted-assets
 X-School-ID: SCH-3F2A
 ```
+This endpoint is safe to cache. The response never changes at runtime (assets are fixed by server configuration).
+
+**Response headers**
+| Header | Value | Description |
+|--------|-------|-------------|
+| `Cache-Control` | `public, max-age=3600` | Browsers and CDNs may cache the response for 1 hour. |
+| `ETag` | `"<sha1>"` | Fingerprint of the current asset list. Use with `If-None-Match` for conditional requests. |
+
+**Conditional requests** — send the `ETag` value back as `If-None-Match` on subsequent requests. The server returns `304 Not Modified` (no body) when the asset list has not changed, saving bandwidth.
+
 **Response `200`**
 ```json
 { "assets": [{ "code": "XLM", "type": "native", "displayName": "Stellar Lumens" }] }
 ```
+
+**Response `304`** — returned when `If-None-Match` matches the current ETag. No response body.
 
 ### Get payment limits
 ```

--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -332,10 +332,19 @@ describe('Payment API', () => {
     expect(res.body).toHaveProperty('code', 'DUPLICATE_TX');
   });
 
-  test('GET /api/payments/accepted-assets — returns XLM and USDC', async () => {
+  test('GET /api/payments/accepted-assets — returns assets with cache headers', async () => {
     const res = await testApi.get('/api/payments/accepted-assets');
     expect(res.status).toBe(200);
     expect(res.body.assets.map(a => a.code)).toEqual(expect.arrayContaining(['XLM', 'USDC']));
+    expect(res.headers['cache-control']).toBe('public, max-age=3600');
+    expect(res.headers['etag']).toMatch(/^"[0-9a-f]+"$/);
+  });
+
+  test('GET /api/payments/accepted-assets — returns 304 on matching If-None-Match', async () => {
+    const first = await testApi.get('/api/payments/accepted-assets');
+    const etag = first.headers['etag'];
+    const second = await testApi.get('/api/payments/accepted-assets').set('If-None-Match', etag);
+    expect(second.status).toBe(304);
   });
 });
 


### PR DESCRIPTION
Closes #446

---

## Summary

Adds HTTP caching headers to `GET /api/payments/accepted-assets` so browsers and CDNs can cache the response for 1 hour.

## Changes

- **`backend/src/controllers/paymentController.js`** — ETag and response body computed once at module load from `ACCEPTED_ASSETS` config. Handler sets `Cache-Control: public, max-age=3600` and `ETag` on every response, and returns `304 Not Modified` when the client sends a matching `If-None-Match` header. Cache invalidates automatically on server restart if config changes.
- **`tests/payment.test.js`** — replaced the single accepted-assets test with two: one verifying the 200 response includes the correct cache headers, one verifying the 304 conditional-request path.
- **`docs/api-spec.md`** — documents the new response headers and 304 behaviour.

## Acceptance criteria

- [x] `Cache-Control: public, max-age=3600` header on response
- [x] `ETag` header for conditional requests
- [x] Test verifies cache headers are present
- [x] Cache invalidated if accepted assets config changes (server restart recomputes ETag)