### PR TITLE
fix(#449): use anchor element for CSV download instead of window.open

### DIFF
--- a/frontend/src/components/ReportDownload.jsx
+++ b/frontend/src/components/ReportDownload.jsx
@@ -28,7 +28,18 @@ export default function ReportDownload() {
     const params = {};
     if (startDate) params.startDate = startDate;
     if (endDate)   params.endDate   = endDate;
-    window.open(getReportCsvUrl(params), "_blank");
+    // Use an anchor element to trigger the download directly, avoiding popup
+    // blockers that may suppress programmatic tab-open calls after async ops.
+    const filename = startDate && endDate
+      ? `report-${startDate}-to-${endDate}.csv`
+      : 'report-all-time.csv';
+    const a = document.createElement('a');
+    a.href = getReportCsvUrl(params);
+    a.download = filename;
+    a.rel = 'noopener noreferrer';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
   }
 
   const COLS = ["Date", "Amount", "Payments", "Valid", "Overpaid", "Underpaid", "Students"];

--- a/tests/reportDownload.test.js
+++ b/tests/reportDownload.test.js
@@ -33,12 +33,18 @@ async function runHandleGenerate(startDate, endDate, mockGetReport) {
   }
 }
 
-/** Mirrors handleCsv from ReportDownload.jsx */
-function buildCsvUrl(startDate, endDate) {
+/**
+ * Mirrors handleCsv from ReportDownload.jsx — returns the anchor attrs
+ * that would be set on the programmatic <a> element.
+ */
+function buildCsvDownload(startDate, endDate) {
   const params = {};
   if (startDate) params.startDate = startDate;
   if (endDate)   params.endDate   = endDate;
-  return getReportCsvUrl(params);
+  const filename = startDate && endDate
+    ? `report-${startDate}-to-${endDate}.csv`
+    : 'report-all-time.csv';
+  return { href: getReportCsvUrl(params), filename };
 }
 
 // ── Sample report fixture ─────────────────────────────────────────────────────
@@ -136,22 +142,27 @@ describe('handleGenerate logic', () => {
   });
 });
 
-describe('handleCsv URL builder', () => {
-  test('builds correct CSV URL with both dates', () => {
-    const url = buildCsvUrl('2026-01-01', '2026-01-31');
-    expect(url).toBe(`${BASE_URL}/reports?startDate=2026-01-01&endDate=2026-01-31&format=csv`);
+describe('handleCsv anchor download (#449)', () => {
+  test('builds correct href and filename with both dates', () => {
+    const { href, filename } = buildCsvDownload('2026-01-01', '2026-01-31');
+    expect(href).toBe(`${BASE_URL}/reports?startDate=2026-01-01&endDate=2026-01-31&format=csv`);
+    expect(filename).toBe('report-2026-01-01-to-2026-01-31.csv');
   });
 
-  test('builds CSV URL with only startDate', () => {
-    const url = buildCsvUrl('2026-01-01', '');
-    expect(url).toContain('startDate=2026-01-01');
-    expect(url).not.toContain('endDate');
-    expect(url).toContain('format=csv');
+  test('uses report-all-time.csv when no dates provided', () => {
+    const { href, filename } = buildCsvDownload('', '');
+    expect(href).toContain('format=csv');
+    expect(filename).toBe('report-all-time.csv');
   });
 
-  test('builds CSV URL with no dates', () => {
-    const url = buildCsvUrl('', '');
-    expect(url).toBe(`${BASE_URL}/reports?format=csv`);
+  test('uses report-all-time.csv when only startDate provided', () => {
+    const { filename } = buildCsvDownload('2026-01-01', '');
+    expect(filename).toBe('report-all-time.csv');
+  });
+
+  test('uses report-all-time.csv when only endDate provided', () => {
+    const { filename } = buildCsvDownload('', '2026-01-31');
+    expect(filename).toBe('report-all-time.csv');
   });
 });
 
@@ -215,6 +226,18 @@ describe('ReportDownload component source – acceptance criteria', () => {
   test('has CSV download button calling getReportCsvUrl', () => {
     expect(src).toMatch(/getReportCsvUrl/);
     expect(src).toMatch(/Download CSV/);
+  });
+
+  test('uses anchor element for download, not window.open', () => {
+    expect(src).not.toMatch(/window\.open/);
+    expect(src).toMatch(/createElement\(['"]a['"]\)/);
+    expect(src).toMatch(/\.download\s*=/);
+    expect(src).toMatch(/\.click\(\)/);
+  });
+
+  test('download filename includes date range when both dates set', () => {
+    expect(src).toMatch(/report-\$\{startDate\}-to-\$\{endDate\}\.csv/);
+    expect(src).toMatch(/report-all-time\.csv/);
   });
 
   test('imports getReport and getReportCsvUrl from api service', () => {


### PR DESCRIPTION
## Summary

Fixes #449

`handleCsv()` in `ReportDownload.jsx` was calling `window.open(url, '_blank')` to trigger the CSV download. Modern browsers block this as a popup when it follows an async operation, making the download silently fail for many users.

## Changes

- **`frontend/src/components/ReportDownload.jsx`** — replaced `window.open` with a programmatic `<a>` element click (`document.createElement('a')` → set `href` + `download` → `click()` → remove). The `download` attribute is set to `report-{start}-to-{end}.csv` when both dates are provided, or `report-all-time.csv` otherwise.
- **`tests/reportDownload.test.js`** — updated `handleCsv` test suite to verify anchor-based download, filename format, and absence of `window.open`.

## Acceptance Criteria

- [x] CSV download uses `<a download>` element
- [x] Download works without popup blocker interference
- [x] Download filename includes the date range (e.g. `report-2026-01-01-to-2026-03-31.csv`)
- [x] Test verifies download is triggered correctly

## Testing

```
npx jest tests/reportDownload.test.js
# 26 passed
```