### PR TITLE
fix(#451): exponential backoff on repeated Horizon errors in polling service

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -125,6 +125,11 @@ SYNC_INTERVAL_MS=60000
 # Legacy polling interval (kept for backwards compatibility)
 POLL_INTERVAL_MS=30000
 
+# Maximum backoff interval for polling when Horizon returns repeated errors (default: 300000 = 5 minutes).
+# The polling service doubles the interval on each consecutive error up to this cap,
+# then resets to POLL_INTERVAL_MS on the first successful cycle.
+POLL_MAX_BACKOFF_MS=300000
+
 # ── Retry / Outage Recovery ───────────────────────────────────
 RETRY_INTERVAL_MS=60000
 RETRY_MAX_ATTEMPTS=10

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -17,6 +17,12 @@ let isPolling = false;
 const POLLING_INTERVAL_MS = 30000; // Poll every 30 seconds
 const TRANSACTIONS_PER_POLL = 20;
 
+// Exponential backoff state — reset on first successful poll after errors.
+// POLL_MAX_BACKOFF_MS defaults to 5 minutes; configurable via env var.
+const POLL_MAX_BACKOFF_MS = parseInt(process.env.POLL_MAX_BACKOFF_MS || '300000', 10);
+let consecutiveErrors = 0;
+let currentIntervalMs = POLLING_INTERVAL_MS;
+
 /**
  * Process a single transaction for a school
  */
@@ -204,12 +210,14 @@ async function pollSchoolTransactions(school) {
       schoolId: school.schoolId,
       error: error.message,
     });
-    return { schoolId: school.schoolId, error: error.message };
+    return { schoolId: school.schoolId, error: error.message, horizonError: true };
   }
 }
 
 /**
- * Poll all active schools for new transactions
+ * Poll all active schools for new transactions.
+ * Applies exponential backoff when Horizon returns errors; resets to the
+ * normal interval on the first fully-successful cycle.
  */
 async function pollAllSchools() {
   if (!isPolling) return;
@@ -219,6 +227,7 @@ async function pollAllSchools() {
     
     if (schools.length === 0) {
       logger.debug('No active schools to poll');
+      scheduleNextPoll();
       return;
     }
 
@@ -232,18 +241,53 @@ async function pollAllSchools() {
       if (result.status === 'fulfilled') {
         acc.processed += result.value.processed || 0;
         acc.skipped += result.value.skipped || 0;
+        if (result.value.horizonError) acc.errors++;
       } else {
         acc.errors++;
       }
       return acc;
     }, { processed: 0, skipped: 0, errors: 0 });
 
+    if (summary.errors > 0) {
+      // At least one school hit a Horizon error — back off.
+      consecutiveErrors++;
+      const backoff = Math.min(POLLING_INTERVAL_MS * Math.pow(2, consecutiveErrors), POLL_MAX_BACKOFF_MS);
+      currentIntervalMs = backoff;
+      logger.info('Horizon errors detected; backing off polling interval', {
+        consecutiveErrors,
+        nextIntervalMs: currentIntervalMs,
+      });
+    } else {
+      // Successful cycle — reset backoff.
+      if (consecutiveErrors > 0) {
+        logger.info('Polling recovered; resetting interval to normal', {
+          intervalMs: POLLING_INTERVAL_MS,
+        });
+      }
+      consecutiveErrors = 0;
+      currentIntervalMs = POLLING_INTERVAL_MS;
+    }
+
     if (summary.processed > 0 || summary.errors > 0) {
       logger.info('Polling cycle completed', summary);
     }
   } catch (error) {
-    logger.error('Error in polling cycle', { error: error.message });
+    consecutiveErrors++;
+    const backoff = Math.min(POLLING_INTERVAL_MS * Math.pow(2, consecutiveErrors), POLL_MAX_BACKOFF_MS);
+    currentIntervalMs = backoff;
+    logger.error('Error in polling cycle', { error: error.message, nextIntervalMs: currentIntervalMs });
   }
+
+  scheduleNextPoll();
+}
+
+/**
+ * Schedule the next poll using the current (possibly backed-off) interval.
+ * Uses setTimeout so the interval can change dynamically between cycles.
+ */
+function scheduleNextPoll() {
+  if (!isPolling) return;
+  pollingInterval = setTimeout(pollAllSchools, currentIntervalMs);
 }
 
 /**
@@ -256,13 +300,12 @@ function startPolling() {
   }
 
   isPolling = true;
+  consecutiveErrors = 0;
+  currentIntervalMs = POLLING_INTERVAL_MS;
   logger.info('Starting transaction polling service', { intervalMs: POLLING_INTERVAL_MS });
 
-  // Run immediately on startup
+  // Run immediately on startup, then self-schedule via setTimeout for backoff support
   pollAllSchools();
-
-  // Then poll at regular intervals
-  pollingInterval = setInterval(pollAllSchools, POLLING_INTERVAL_MS);
 }
 
 /**
@@ -273,7 +316,7 @@ function stopPolling() {
 
   isPolling = false;
   if (pollingInterval) {
-    clearInterval(pollingInterval);
+    clearTimeout(pollingInterval);
     pollingInterval = null;
   }
   logger.info('Transaction polling service stopped');
@@ -285,4 +328,12 @@ module.exports = {
   pollAllSchools,
   pollSchoolTransactions,
   processTransaction,
+  // Exposed for testing
+  _getBackoffState: () => ({ consecutiveErrors, currentIntervalMs }),
+  _resetBackoffState: () => {
+    consecutiveErrors = 0;
+    currentIntervalMs = POLLING_INTERVAL_MS;
+    isPolling = true; // allow direct pollAllSchools() calls in tests
+    if (pollingInterval) { clearTimeout(pollingInterval); pollingInterval = null; }
+  },
 };

--- a/tests/transactionPollingBackoff.test.js
+++ b/tests/transactionPollingBackoff.test.js
@@ -1,0 +1,133 @@
+'use strict';
+
+/**
+ * Tests for exponential backoff in transactionPollingService (issue #451).
+ *
+ * We test the backoff logic by mocking School.find and the Stellar server,
+ * then calling pollAllSchools() directly and inspecting the backoff state.
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  Schema: class { constructor() { this.index = jest.fn(); } },
+  model: jest.fn().mockReturnValue({}),
+  connection: { startSession: jest.fn() },
+}));
+
+const mockTransactionsCall = jest.fn();
+jest.mock('../backend/src/config/stellarConfig', () => ({
+  server: {
+    transactions: () => ({
+      forAccount: () => ({
+        order: () => ({
+          limit: () => ({ call: mockTransactionsCall }),
+        }),
+      }),
+    }),
+  },
+}));
+
+jest.mock('../backend/src/models/schoolModel', () => ({
+  find: jest.fn(),
+}));
+jest.mock('../backend/src/models/paymentModel', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  aggregate: jest.fn().mockResolvedValue([]),
+  create: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/models/studentModel', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  findOneAndUpdate: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/services/stellarService', () => ({
+  extractValidPayment: jest.fn().mockResolvedValue(null),
+  validatePaymentAgainstFee: jest.fn().mockReturnValue({ status: 'valid' }),
+  detectMemoCollision: jest.fn().mockResolvedValue({ suspicious: false }),
+  detectAbnormalPatterns: jest.fn().mockResolvedValue({ suspicious: false }),
+  checkConfirmationStatus: jest.fn().mockResolvedValue(true),
+}));
+jest.mock('../backend/src/services/sseService', () => ({ emit: jest.fn() }));
+jest.mock('../backend/src/utils/paymentLimits', () => ({
+  validatePaymentAmount: jest.fn().mockReturnValue({ valid: true }),
+}));
+jest.mock('../backend/src/utils/generateReferenceCode', () => ({
+  generateReferenceCode: jest.fn().mockResolvedValue('REF001'),
+}));
+jest.mock('../backend/src/utils/logger', () => ({
+  child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+
+const School = require('../backend/src/models/schoolModel');
+const { pollAllSchools, _getBackoffState, _resetBackoffState } = require('../backend/src/services/transactionPollingService');
+
+const MOCK_SCHOOL = { schoolId: 'SCH001', stellarAddress: 'GTEST...', isActive: true };
+const POLL_INTERVAL_MS = 30000;
+const MAX_BACKOFF_MS = parseInt(process.env.POLL_MAX_BACKOFF_MS || '300000', 10);
+
+beforeEach(() => {
+  _resetBackoffState();
+  jest.clearAllMocks();
+  School.find.mockResolvedValue([MOCK_SCHOOL]);
+});
+
+describe('transactionPollingService — exponential backoff (#451)', () => {
+  test('interval stays at normal value after a successful poll', async () => {
+    mockTransactionsCall.mockResolvedValue({ records: [] });
+    await pollAllSchools();
+    const { consecutiveErrors, currentIntervalMs } = _getBackoffState();
+    expect(consecutiveErrors).toBe(0);
+    expect(currentIntervalMs).toBe(POLL_INTERVAL_MS);
+  });
+
+  test('interval doubles after first Horizon error', async () => {
+    mockTransactionsCall.mockRejectedValue(new Error('Horizon timeout'));
+    await pollAllSchools();
+    const { consecutiveErrors, currentIntervalMs } = _getBackoffState();
+    expect(consecutiveErrors).toBe(1);
+    expect(currentIntervalMs).toBe(POLL_INTERVAL_MS * 2);
+  });
+
+  test('interval doubles again after second consecutive error', async () => {
+    mockTransactionsCall.mockRejectedValue(new Error('Horizon timeout'));
+    await pollAllSchools();
+    await pollAllSchools();
+    const { consecutiveErrors, currentIntervalMs } = _getBackoffState();
+    expect(consecutiveErrors).toBe(2);
+    expect(currentIntervalMs).toBe(POLL_INTERVAL_MS * 4);
+  });
+
+  test('interval is capped at POLL_MAX_BACKOFF_MS', async () => {
+    mockTransactionsCall.mockRejectedValue(new Error('Horizon timeout'));
+    // Run enough cycles to exceed the cap
+    for (let i = 0; i < 10; i++) {
+      await pollAllSchools();
+    }
+    const { currentIntervalMs } = _getBackoffState();
+    expect(currentIntervalMs).toBeLessThanOrEqual(MAX_BACKOFF_MS);
+    expect(currentIntervalMs).toBe(MAX_BACKOFF_MS);
+  });
+
+  test('interval resets to normal after a successful poll following errors', async () => {
+    mockTransactionsCall.mockRejectedValue(new Error('Horizon timeout'));
+    await pollAllSchools();
+    await pollAllSchools();
+    // Now recover
+    mockTransactionsCall.mockResolvedValue({ records: [] });
+    await pollAllSchools();
+    const { consecutiveErrors, currentIntervalMs } = _getBackoffState();
+    expect(consecutiveErrors).toBe(0);
+    expect(currentIntervalMs).toBe(POLL_INTERVAL_MS);
+  });
+
+  test('no schools — interval stays normal', async () => {
+    School.find.mockResolvedValue([]);
+    await pollAllSchools();
+    const { consecutiveErrors, currentIntervalMs } = _getBackoffState();
+    expect(consecutiveErrors).toBe(0);
+    expect(currentIntervalMs).toBe(POLL_INTERVAL_MS);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #451

`transactionPollingService.js` was using `setInterval` with a fixed 30-second interval regardless of Horizon error history. During an outage this hammers Horizon every 30 s, consuming rate-limit quota and potentially worsening the outage.

## Changes

- **`backend/src/services/transactionPollingService.js`**
  - Replaced `setInterval` with `setTimeout`-based self-scheduling so the interval can change dynamically between cycles.
  - On each consecutive Horizon error the interval doubles (`base × 2^n`) up to `POLL_MAX_BACKOFF_MS` (default 5 min).
  - Resets to the normal interval on the first fully-successful cycle.
  - Logs backoff state at INFO level on every change.
  - Exposes `_getBackoffState` / `_resetBackoffState` for unit testing.
- **`backend/.env.example`** — documents new `POLL_MAX_BACKOFF_MS` variable.
- **`tests/transactionPollingBackoff.test.js`** — new test file covering backoff progression, cap, and reset.

## Acceptance Criteria

- [x] Exponential backoff implemented on consecutive Horizon errors
- [x] Maximum backoff interval configurable via `POLL_MAX_BACKOFF_MS` (default 5 min)
- [x] Backoff resets to normal interval on first successful poll
- [x] Current backoff state logged at INFO level
- [x] Test covers backoff progression and reset

## Testing

```
npx jest tests/transactionPollingBackoff.test.js
# 6 passed
```