### PR TITLE
fix(#469): set dynamic Content-Disposition filename on CSV export

### DIFF
--- a/backend/src/controllers/reportController.js
+++ b/backend/src/controllers/reportController.js
@@ -54,10 +54,10 @@ async function getReport(req, res, next) {
 }
 
 function buildFilename(startDate, endDate) {
-  const parts = ['school-payment-report'];
-  if (startDate) parts.push(startDate);
-  if (endDate) parts.push(endDate);
-  return `${parts.join('_')}.csv`;
+  if (startDate && endDate) return `report-${startDate}-to-${endDate}.csv`;
+  if (startDate) return `report-${startDate}-to-all-time.csv`;
+  if (endDate) return `report-all-time-to-${endDate}.csv`;
+  return 'report-all-time.csv';
 }
 
 /**

--- a/tests/reportDateValidation.test.js
+++ b/tests/reportDateValidation.test.js
@@ -125,3 +125,35 @@ describe('GET /api/reports — date validation (#389)', () => {
     });
   });
 });
+
+describe('GET /api/reports — Content-Disposition filename (#469)', () => {
+  async function getCsvHeaders(query) {
+    const req = makeReq(query);
+    const res = makeRes();
+    await getReport(req, res, () => {});
+    // Collect all setHeader calls into a map
+    const headers = {};
+    res.setHeader.mock.calls.forEach(([k, v]) => { headers[k] = v; });
+    return headers;
+  }
+
+  it('sets filename with date range when both dates provided', async () => {
+    const headers = await getCsvHeaders({ startDate: '2026-01-01', endDate: '2026-03-31', format: 'csv' });
+    expect(headers['Content-Disposition']).toBe('attachment; filename="report-2026-01-01-to-2026-03-31.csv"');
+  });
+
+  it('sets report-all-time.csv when no dates provided', async () => {
+    const headers = await getCsvHeaders({ format: 'csv' });
+    expect(headers['Content-Disposition']).toBe('attachment; filename="report-all-time.csv"');
+  });
+
+  it('sets partial filename when only startDate provided', async () => {
+    const headers = await getCsvHeaders({ startDate: '2026-01-01', format: 'csv' });
+    expect(headers['Content-Disposition']).toBe('attachment; filename="report-2026-01-01-to-all-time.csv"');
+  });
+
+  it('sets partial filename when only endDate provided', async () => {
+    const headers = await getCsvHeaders({ endDate: '2026-03-31', format: 'csv' });
+    expect(headers['Content-Disposition']).toBe('attachment; filename="report-all-time-to-2026-03-31.csv"');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #469

`GET /api/reports?format=csv` was returning a generic `school-payment-report.csv` filename in the `Content-Disposition` header, making it impossible to identify which date range a downloaded file covers.

## Changes

- **`backend/src/controllers/reportController.js`** — rewrote `buildFilename` to produce:
  - `report-{start}-to-{end}.csv` when both dates are provided
  - `report-{start}-to-all-time.csv` / `report-all-time-to-{end}.csv` for single-date requests
  - `report-all-time.csv` when no dates are given
- **`tests/reportDateValidation.test.js`** — added 4 new tests verifying the `Content-Disposition` header value for each case.

## Acceptance Criteria

- [x] `Content-Disposition: attachment; filename="report-{startDate}-to-{endDate}.csv"` set
- [x] If no date range, filename is `report-all-time.csv`
- [x] Test verifies Content-Disposition header value

## Testing

```
npx jest tests/reportDateValidation.test.js
# 16 passed
```