### PR TITLE
fix: resolve issues #342, #365, #366, #367

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -55,6 +55,8 @@ PAYMENT_WEBHOOK_URL=
 RATE_LIMIT_WINDOW_MS=60000
 # Maximum requests per window (default: 100)
 RATE_LIMIT_MAX_REQUESTS=100
+# Dedicated rate limit for POST /api/payments/verify (requests per minute, default: 10)
+VERIFY_RATE_LIMIT=10
 #
 # PERSISTENCE: When REDIS_HOST is set, rate-limit counters are stored in Redis
 # and survive server restarts. Without REDIS_HOST the counters are in-process

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -100,6 +100,20 @@ const STELLAR_TIMEOUT_MS = parseInt(
 const JWT_SECRET = process.env.JWT_SECRET || null;
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "8h";
 
+if (!JWT_SECRET) {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      '[Config] JWT_SECRET is required in production. ' +
+      'Generate one with: node -e "console.log(require(\'crypto\').randomBytes(64).toString(\'hex\'))"'
+    );
+  } else {
+    console.warn(
+      '[Config] WARNING: JWT_SECRET is not set. Admin authentication is non-functional. ' +
+      'Set JWT_SECRET in your .env file before deploying to production.'
+    );
+  }
+}
+
 // ── Fee Reminders ─────────────────────────────────────────────────────────────
 // How often the scheduler checks for unpaid fees (default: 24 hours)
 const REMINDER_INTERVAL_MS = parseInt(

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -20,6 +20,16 @@ const strictLimiter = rateLimit({
   message: { error: 'Too many requests to this endpoint, please try again later.', code: 'RATE_LIMIT_EXCEEDED' },
 });
 
+// Verify limiter — dedicated limiter for POST /api/payments/verify
+// Defaults to 10 req/min; configurable via VERIFY_RATE_LIMIT env var.
+const verifyLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute
+  max: parseInt(process.env.VERIFY_RATE_LIMIT || '10', 10),
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many verify requests, please try again later.', code: 'RATE_LIMIT_EXCEEDED' },
+});
+
 // Reminder trigger limiter — prevents spamming students with reminder emails
 const reminderTriggerLimiter = rateLimit({
   windowMs: 60 * 60 * 1000, // 1 hour
@@ -29,4 +39,4 @@ const reminderTriggerLimiter = rateLimit({
   message: { error: 'Too many reminder trigger requests. Please wait before sending more reminders.', code: 'RATE_LIMIT_EXCEEDED' },
 });
 
-module.exports = { generalLimiter, strictLimiter, reminderTriggerLimiter };
+module.exports = { generalLimiter, strictLimiter, reminderTriggerLimiter, verifyLimiter };

--- a/backend/src/routes/paymentRoutes.js
+++ b/backend/src/routes/paymentRoutes.js
@@ -44,7 +44,7 @@ const { resolveSchool } = require("../middleware/schoolContext");
 const idempotency = require("../middleware/idempotency");
 const { requireAdminAuth } = require("../middleware/auth");
 const { auditContext } = require("../middleware/auditContext");
-const { strictLimiter } = require("../middleware/rateLimiter");
+const { strictLimiter, verifyLimiter } = require("../middleware/rateLimiter");
 
 // No school context required
 router.get("/verify/:txHash", validateTxHashParam, verifyTransactionHash);
@@ -83,7 +83,7 @@ router.get("/dlq", getDeadLetterJobs);
 
 router.post(
   "/verify",
-  strictLimiter,
+  verifyLimiter,
   idempotency,
   validateVerifyPayment,
   verifyPayment,

--- a/backend/src/services/consistencyService.js
+++ b/backend/src/services/consistencyService.js
@@ -1,13 +1,16 @@
-const { server, SCHOOL_WALLET } = require('../config/stellarConfig');
+'use strict';
+
+const { server } = require('../config/stellarConfig');
 const Payment = require('../models/paymentModel');
-const Student = require('../models/studentModel');
+const School = require('../models/schoolModel');
 
 /**
- * Fetch all transactions for the school wallet from Horizon (up to 200).
+ * Fetch up to 200 transactions for a given wallet address from Horizon.
+ * @param {string} walletAddress
  */
-async function fetchChainTransactions() {
+async function fetchChainTransactions(walletAddress) {
   const result = await server.transactions()
-    .forAccount(SCHOOL_WALLET)
+    .forAccount(walletAddress)
     .order('desc')
     .limit(200)
     .call();
@@ -15,24 +18,23 @@ async function fetchChainTransactions() {
 }
 
 /**
- * Compare DB payments against on-chain transactions and return mismatches.
+ * Check consistency for a single school.
  *
- * Mismatch types:
- *  - missing_on_chain : payment recorded in DB but not found on Stellar
- *  - amount_mismatch  : DB amount differs from on-chain amount
- *  - student_mismatch : DB studentId doesn't match the tx memo
+ * @param {{ schoolId: string, stellarAddress: string }} school
  */
-async function checkConsistency() {
+async function checkSchoolConsistency({ schoolId, stellarAddress }) {
   const [dbPayments, chainTxs] = await Promise.all([
-    Payment.find({}).lean(),
-    fetchChainTransactions(),
+    Payment.find({ schoolId }).lean(),
+    fetchChainTransactions(stellarAddress),
   ]);
 
   // Build a map of txHash → on-chain tx for O(1) lookup
   const chainMap = new Map();
   for (const tx of chainTxs) {
     const ops = await tx.operations();
-    const payOp = ops.records.find(op => op.type === 'payment' && op.to === SCHOOL_WALLET);
+    const payOp = ops.records.find(
+      (op) => op.type === 'payment' && op.to === stellarAddress
+    );
     if (payOp) {
       chainMap.set(tx.hash, {
         hash: tx.hash,
@@ -81,11 +83,46 @@ async function checkConsistency() {
   }
 
   return {
-    checkedAt: new Date().toISOString(),
+    schoolId,
     totalDbPayments: dbPayments.length,
     totalChainTxsScanned: chainMap.size,
     mismatchCount: mismatches.length,
     mismatches,
+  };
+}
+
+/**
+ * Compare DB payments against on-chain transactions for ALL active schools.
+ *
+ * Mismatch types:
+ *  - missing_on_chain : payment recorded in DB but not found on Stellar
+ *  - amount_mismatch  : DB amount differs from on-chain amount
+ *  - student_mismatch : DB studentId doesn't match the tx memo
+ */
+async function checkConsistency() {
+  const schools = await School.find({ isActive: true }).lean();
+
+  const schoolResults = await Promise.all(
+    schools.map((school) =>
+      checkSchoolConsistency({
+        schoolId: school.schoolId,
+        stellarAddress: school.stellarAddress,
+      })
+    )
+  );
+
+  const totalDbPayments = schoolResults.reduce((s, r) => s + r.totalDbPayments, 0);
+  const totalChainTxsScanned = schoolResults.reduce((s, r) => s + r.totalChainTxsScanned, 0);
+  const allMismatches = schoolResults.flatMap((r) => r.mismatches);
+
+  return {
+    checkedAt: new Date().toISOString(),
+    schoolsChecked: schools.length,
+    totalDbPayments,
+    totalChainTxsScanned,
+    mismatchCount: allMismatches.length,
+    mismatches: allMismatches,
+    bySchool: schoolResults,
   };
 }
 

--- a/backend/src/services/reportService.js
+++ b/backend/src/services/reportService.js
@@ -10,7 +10,7 @@ const FeeStructure = require('../models/feeStructureModel');
  * @param {{ schoolId: string, startDate?: string, endDate?: string }} options
  */
 async function aggregateByDate({ schoolId, startDate, endDate } = {}) {
-  const match = { schoolId, status: 'confirmed', studentDeleted: { $ne: true } };
+  const match = { schoolId, status: 'SUCCESS', studentDeleted: { $ne: true } };
 
   if (startDate || endDate) {
     match.confirmedAt = {};
@@ -70,7 +70,7 @@ async function generateReport({ schoolId, startDate, endDate } = {}) {
   );
 
   // Count students who have fully paid within the period
-  const match = { schoolId, status: 'confirmed', studentDeleted: { $ne: true } };
+  const match = { schoolId, status: 'SUCCESS', studentDeleted: { $ne: true } };
   if (startDate || endDate) {
     match.confirmedAt = {};
     if (startDate) match.confirmedAt.$gte = new Date(startDate + 'T00:00:00.000Z');

--- a/tests/consistency.test.js
+++ b/tests/consistency.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const { checkConsistency } = require('../backend/src/services/consistencyService');
 
 // ─── Mocks ────────────────────────────────────────────────────────────────────
@@ -5,13 +7,12 @@ const { checkConsistency } = require('../backend/src/services/consistencyService
 const mockOperations = jest.fn();
 
 jest.mock('../backend/src/config/stellarConfig', () => ({
-  SCHOOL_WALLET: 'GSCHOOL123',
   server: {
     transactions: () => ({
-      forAccount: () => ({
+      forAccount: (wallet) => ({
         order: () => ({
           limit: () => ({
-            call: async () => ({ records: mockChainTxs }),
+            call: async () => ({ records: mockChainTxsByWallet[wallet] || [] }),
           }),
         }),
       }),
@@ -24,20 +25,23 @@ jest.mock('../backend/src/models/paymentModel', () => ({
   find: (...args) => ({ lean: () => mockFind(...args) }),
 }));
 
+const mockSchoolFind = jest.fn();
+jest.mock('../backend/src/models/schoolModel', () => ({
+  find: () => ({ lean: () => mockSchoolFind() }),
+}));
+
 jest.mock('../backend/src/models/studentModel', () => ({}));
 
-const Payment = { find: mockFind };
+// Shared mutable state
+let mockChainTxsByWallet = {};
 
-// Shared mutable array so individual tests can populate it
-let mockChainTxs = [];
-
-function makeChainTx(hash, memo, amount) {
+function makeChainTx(hash, memo, amount, toWallet) {
   return {
     hash,
     memo,
     successful: true,
     operations: async () => ({
-      records: [{ type: 'payment', to: 'GSCHOOL123', amount: String(amount) }],
+      records: [{ type: 'payment', to: toWallet, amount: String(amount) }],
     }),
   };
 }
@@ -46,99 +50,132 @@ function makeChainTx(hash, memo, amount) {
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockChainTxs = [];
+  mockChainTxsByWallet = {};
   mockFind.mockReset();
+  mockSchoolFind.mockReset();
 });
 
-describe('checkConsistency', () => {
-  test('returns clean report when DB and chain match', async () => {
-    mockChainTxs = [makeChainTx('hash1', 'STU001', 250)];
-    mockFind.mockResolvedValue([
-      { txHash: 'hash1', studentId: 'STU001', amount: 250 },
+describe('checkConsistency — multi-school', () => {
+  test('checks each school wallet independently', async () => {
+    mockSchoolFind.mockResolvedValue([
+      { schoolId: 'SCH-A', stellarAddress: 'GWALLET_A' },
+      { schoolId: 'SCH-B', stellarAddress: 'GWALLET_B' },
     ]);
+
+    mockChainTxsByWallet['GWALLET_A'] = [makeChainTx('hashA1', 'STU001', 250, 'GWALLET_A')];
+    mockChainTxsByWallet['GWALLET_B'] = [makeChainTx('hashB1', 'STU002', 300, 'GWALLET_B')];
+
+    mockFind.mockImplementation(({ schoolId }) => {
+      if (schoolId === 'SCH-A') return Promise.resolve([{ txHash: 'hashA1', studentId: 'STU001', amount: 250 }]);
+      if (schoolId === 'SCH-B') return Promise.resolve([{ txHash: 'hashB1', studentId: 'STU002', amount: 300 }]);
+      return Promise.resolve([]);
+    });
+
+    const report = await checkConsistency();
+
+    expect(report.schoolsChecked).toBe(2);
+    expect(report.mismatchCount).toBe(0);
+    expect(report.bySchool).toHaveLength(2);
+    expect(report.bySchool.map((s) => s.schoolId)).toEqual(
+      expect.arrayContaining(['SCH-A', 'SCH-B'])
+    );
+  });
+
+  test('does not cross-contaminate payments between schools', async () => {
+    mockSchoolFind.mockResolvedValue([
+      { schoolId: 'SCH-A', stellarAddress: 'GWALLET_A' },
+      { schoolId: 'SCH-B', stellarAddress: 'GWALLET_B' },
+    ]);
+
+    // SCH-A has a payment that is NOT on GWALLET_B's chain
+    mockChainTxsByWallet['GWALLET_A'] = [makeChainTx('hashA1', 'STU001', 250, 'GWALLET_A')];
+    mockChainTxsByWallet['GWALLET_B'] = [];
+
+    mockFind.mockImplementation(({ schoolId }) => {
+      if (schoolId === 'SCH-A') return Promise.resolve([{ txHash: 'hashA1', studentId: 'STU001', amount: 250 }]);
+      if (schoolId === 'SCH-B') return Promise.resolve([]); // no payments for SCH-B
+      return Promise.resolve([]);
+    });
 
     const report = await checkConsistency();
 
     expect(report.mismatchCount).toBe(0);
-    expect(report.mismatches).toHaveLength(0);
-    expect(report.totalDbPayments).toBe(1);
-    expect(report.totalChainTxsScanned).toBe(1);
+    const schA = report.bySchool.find((s) => s.schoolId === 'SCH-A');
+    const schB = report.bySchool.find((s) => s.schoolId === 'SCH-B');
+    expect(schA.mismatchCount).toBe(0);
+    expect(schB.mismatchCount).toBe(0);
   });
 
-  test('flags missing_on_chain when DB payment has no matching chain tx', async () => {
-    mockChainTxs = [];
-    mockFind.mockResolvedValue([
-      { txHash: 'ghost_hash', studentId: 'STU002', amount: 100 },
+  test('flags missing_on_chain per school', async () => {
+    mockSchoolFind.mockResolvedValue([
+      { schoolId: 'SCH-A', stellarAddress: 'GWALLET_A' },
     ]);
+    mockChainTxsByWallet['GWALLET_A'] = [];
+    mockFind.mockResolvedValue([{ txHash: 'ghost', studentId: 'STU001', amount: 100 }]);
 
     const report = await checkConsistency();
 
     expect(report.mismatchCount).toBe(1);
     expect(report.mismatches[0].type).toBe('missing_on_chain');
-    expect(report.mismatches[0].txHash).toBe('ghost_hash');
   });
 
-  test('flags amount_mismatch when DB amount differs from chain', async () => {
-    mockChainTxs = [makeChainTx('hash2', 'STU003', 300)];
-    mockFind.mockResolvedValue([
-      { txHash: 'hash2', studentId: 'STU003', amount: 150 }, // wrong amount
-    ]);
+  test('returns empty report when no active schools', async () => {
+    mockSchoolFind.mockResolvedValue([]);
 
     const report = await checkConsistency();
 
-    expect(report.mismatchCount).toBe(1);
-    expect(report.mismatches[0].type).toBe('amount_mismatch');
-    expect(report.mismatches[0].dbAmount).toBe(150);
-    expect(report.mismatches[0].chainAmount).toBe(300);
-  });
-
-  test('flags student_mismatch when DB studentId differs from chain memo', async () => {
-    mockChainTxs = [makeChainTx('hash3', 'STU999', 200)];
-    mockFind.mockResolvedValue([
-      { txHash: 'hash3', studentId: 'STU001', amount: 200 }, // wrong student
-    ]);
-
-    const report = await checkConsistency();
-
-    expect(report.mismatchCount).toBe(1);
-    expect(report.mismatches[0].type).toBe('student_mismatch');
-    expect(report.mismatches[0].dbStudentId).toBe('STU001');
-    expect(report.mismatches[0].chainMemo).toBe('STU999');
-  });
-
-  test('reports multiple mismatches across different payments', async () => {
-    mockChainTxs = [makeChainTx('hash4', 'STU010', 500)];
-    mockFind.mockResolvedValue([
-      { txHash: 'hash4', studentId: 'STU010', amount: 999 }, // amount mismatch
-      { txHash: 'missing', studentId: 'STU011', amount: 100 }, // missing on chain
-    ]);
-
-    const report = await checkConsistency();
-
-    expect(report.mismatchCount).toBe(2);
-    const types = report.mismatches.map(m => m.type);
-    expect(types).toContain('amount_mismatch');
-    expect(types).toContain('missing_on_chain');
-  });
-
-  test('returns empty report when DB has no payments', async () => {
-    mockChainTxs = [makeChainTx('hash5', 'STU020', 100)];
-    mockFind.mockResolvedValue([]);
-
-    const report = await checkConsistency();
-
+    expect(report.schoolsChecked).toBe(0);
     expect(report.mismatchCount).toBe(0);
     expect(report.totalDbPayments).toBe(0);
   });
 
   test('report includes checkedAt timestamp', async () => {
-    mockChainTxs = [];
-    mockFind.mockResolvedValue([]);
+    mockSchoolFind.mockResolvedValue([]);
 
     const report = await checkConsistency();
 
     expect(report.checkedAt).toBeDefined();
     expect(new Date(report.checkedAt).toString()).not.toBe('Invalid Date');
+  });
+});
+
+// ─── Backward-compatible single-school tests ──────────────────────────────────
+
+describe('checkConsistency — single school (backward compat)', () => {
+  function setup(wallet, chainTxs, dbPayments) {
+    mockSchoolFind.mockResolvedValue([{ schoolId: 'SCH-DEFAULT', stellarAddress: wallet }]);
+    mockChainTxsByWallet[wallet] = chainTxs;
+    mockFind.mockResolvedValue(dbPayments);
+  }
+
+  test('returns clean report when DB and chain match', async () => {
+    setup('GSCHOOL123', [makeChainTx('hash1', 'STU001', 250, 'GSCHOOL123')], [
+      { txHash: 'hash1', studentId: 'STU001', amount: 250 },
+    ]);
+
+    const report = await checkConsistency();
+    expect(report.mismatchCount).toBe(0);
+    expect(report.totalDbPayments).toBe(1);
+  });
+
+  test('flags amount_mismatch', async () => {
+    setup('GSCHOOL123', [makeChainTx('hash2', 'STU003', 300, 'GSCHOOL123')], [
+      { txHash: 'hash2', studentId: 'STU003', amount: 150 },
+    ]);
+
+    const report = await checkConsistency();
+    expect(report.mismatchCount).toBe(1);
+    expect(report.mismatches[0].type).toBe('amount_mismatch');
+  });
+
+  test('flags student_mismatch', async () => {
+    setup('GSCHOOL123', [makeChainTx('hash3', 'STU999', 200, 'GSCHOOL123')], [
+      { txHash: 'hash3', studentId: 'STU001', amount: 200 },
+    ]);
+
+    const report = await checkConsistency();
+    expect(report.mismatchCount).toBe(1);
+    expect(report.mismatches[0].type).toBe('student_mismatch');
   });
 });
 
@@ -151,15 +188,21 @@ describe('consistencyScheduler', () => {
     jest.useFakeTimers();
     jest.resetModules();
 
-    // Re-mock consistencyService for the scheduler module
     jest.mock('../backend/src/services/consistencyService', () => ({
       checkConsistency: jest.fn().mockResolvedValue({
         checkedAt: new Date().toISOString(),
+        schoolsChecked: 1,
         totalDbPayments: 0,
         totalChainTxsScanned: 0,
         mismatchCount: 0,
         mismatches: [],
+        bySchool: [],
       }),
+    }));
+
+    // Scheduler calls School.countDocuments before checkConsistency
+    jest.mock('../backend/src/models/schoolModel', () => ({
+      countDocuments: jest.fn().mockResolvedValue(1),
     }));
 
     ({ startConsistencyScheduler, stopConsistencyScheduler } =
@@ -174,7 +217,8 @@ describe('consistencyScheduler', () => {
   test('runs an immediate check on start', async () => {
     const { checkConsistency } = require('../backend/src/services/consistencyService');
     startConsistencyScheduler();
-    await Promise.resolve(); // flush microtasks
+    await Promise.resolve();
+    await Promise.resolve(); // flush School.countDocuments microtask
     expect(checkConsistency).toHaveBeenCalledTimes(1);
   });
 
@@ -182,7 +226,9 @@ describe('consistencyScheduler', () => {
     const { checkConsistency } = require('../backend/src/services/consistencyService');
     startConsistencyScheduler();
     await Promise.resolve();
+    await Promise.resolve();
     jest.advanceTimersByTime(5 * 60 * 1000);
+    await Promise.resolve();
     await Promise.resolve();
     expect(checkConsistency).toHaveBeenCalledTimes(2);
   });
@@ -191,8 +237,10 @@ describe('consistencyScheduler', () => {
     const { checkConsistency } = require('../backend/src/services/consistencyService');
     startConsistencyScheduler();
     await Promise.resolve();
+    await Promise.resolve();
     stopConsistencyScheduler();
     jest.advanceTimersByTime(5 * 60 * 1000);
+    await Promise.resolve();
     await Promise.resolve();
     expect(checkConsistency).toHaveBeenCalledTimes(1);
   });
@@ -201,14 +249,17 @@ describe('consistencyScheduler', () => {
     const { checkConsistency } = require('../backend/src/services/consistencyService');
     checkConsistency.mockResolvedValueOnce({
       checkedAt: new Date().toISOString(),
+      schoolsChecked: 1,
       totalDbPayments: 1,
       totalChainTxsScanned: 0,
       mismatchCount: 1,
       mismatches: [{ type: 'missing_on_chain', message: 'tx ghost not found on-chain' }],
+      bySchool: [],
     });
 
     const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     startConsistencyScheduler();
+    await Promise.resolve();
     await Promise.resolve();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('1 mismatch(es) detected'));
     warnSpy.mockRestore();

--- a/tests/jwtSecretValidation.test.js
+++ b/tests/jwtSecretValidation.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/**
+ * Tests for JWT_SECRET startup validation (#342).
+ *
+ * config/index.js must:
+ *  - throw (exit-equivalent) in production when JWT_SECRET is absent
+ *  - log a warning in non-production when JWT_SECRET is absent
+ *  - pass silently when JWT_SECRET is present
+ */
+
+function loadConfig(env = {}) {
+  // Isolate module so each call gets a fresh evaluation
+  jest.resetModules();
+  const saved = { ...process.env };
+  // Minimal required vars
+  process.env.MONGO_URI = 'mongodb://localhost/test';
+  Object.assign(process.env, env);
+  try {
+    return require('../backend/src/config/index');
+  } finally {
+    // Restore original env
+    Object.keys(process.env).forEach((k) => delete process.env[k]);
+    Object.assign(process.env, saved);
+  }
+}
+
+describe('JWT_SECRET startup validation', () => {
+  it('throws in production when JWT_SECRET is missing', () => {
+    expect(() =>
+      loadConfig({ NODE_ENV: 'production', JWT_SECRET: '' })
+    ).toThrow(/JWT_SECRET is required in production/);
+  });
+
+  it('logs a warning in development when JWT_SECRET is missing', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    loadConfig({ NODE_ENV: 'development', JWT_SECRET: '' });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('JWT_SECRET is not set')
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('passes silently when JWT_SECRET is present', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() =>
+      loadConfig({ NODE_ENV: 'production', JWT_SECRET: 'supersecret' })
+    ).not.toThrow();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes four bugs reported across issues #342, #365, #366, and #367.

---

### #367 — reportService.js aggregates with `status: 'confirmed'` but Payment model uses `'SUCCESS'`

**Root cause:** `aggregateByDate()` and `generateReport()` used `{ status: 'confirmed' }` as the MongoDB match filter. The Payment model enum is `['PENDING', 'SUBMITTED', 'SUCCESS', 'FAILED', ...]` — `'confirmed'` never matches any document, so every report returned zero totals.

**Fix:** Changed both match filters to `status: 'SUCCESS'`.

**Files changed:**
- `backend/src/services/reportService.js`

---

### #366 — No rate limiting on `POST /api/payments/verify` — vulnerable to hash enumeration

**Root cause:** The verify endpoint shared the global `strictLimiter` (15 min window) with other endpoints, providing no meaningful per-endpoint protection against rapid hash enumeration or Horizon quota exhaustion.

**Fix:** Added a dedicated `verifyLimiter` (1-minute window, 10 req/min per IP) in `rateLimiter.js`, configurable via the `VERIFY_RATE_LIMIT` environment variable. Applied it exclusively to `POST /api/payments/verify`. Documented `VERIFY_RATE_LIMIT` in `.env.example`.

**Files changed:**
- `backend/src/middleware/rateLimiter.js`
- `backend/src/routes/paymentRoutes.js`
- `backend/.env.example`

---

### #342 — JWT_SECRET not required at startup — server starts insecurely without authentication

**Root cause:** `JWT_SECRET` defaulted to `null` and was never validated at startup. A missing secret was only discovered when an admin route was hit, returning a confusing 500 error.

**Fix:** Added validation in `config/index.js`:
- In **production** (`NODE_ENV=production`): throws with a clear error message, preventing startup.
- In **non-production**: logs a prominent `WARNING` that admin authentication is non-functional.

Added `tests/jwtSecretValidation.test.js` covering all three cases (prod missing → throw, dev missing → warn, present → silent pass).

**Files changed:**
- `backend/src/config/index.js`
- `tests/jwtSecretValidation.test.js`

---

### #365 — consistencyService.js uses global SCHOOL_WALLET — breaks multi-school support

**Root cause:** `consistencyService.js` imported `SCHOOL_WALLET` from `stellarConfig.js` (a single env-var address) and used it for all Horizon queries. Schools whose wallet differed from that env var were silently skipped.

**Fix:** Removed the global `SCHOOL_WALLET` import. `checkConsistency()` now:
1. Fetches all active `School` documents from MongoDB.
2. Iterates each school's `stellarAddress` independently for Horizon queries.
3. Filters `Payment` records by `schoolId` before comparison to prevent cross-school contamination.
4. Returns per-school results in a `bySchool` array alongside aggregate totals.

Updated `tests/consistency.test.js` with multi-school isolation tests and backward-compatible single-school tests.

**Files changed:**
- `backend/src/services/consistencyService.js`
- `tests/consistency.test.js`

---

## Testing

All new and updated tests pass:
- `tests/consistency.test.js` — 15 tests ✅
- `tests/jwtSecretValidation.test.js` — 3 tests ✅

No regressions in the existing passing test suite.

---

Closes #342
Closes #365
Closes #366
Closes #367