### PR TITLE
fix: resolve audit pagination, payment hook, student ID, dashboard pagination

### DIFF
--- a/backend/src/controllers/auditController.js
+++ b/backend/src/controllers/auditController.js
@@ -17,20 +17,21 @@ const { getAuditLogs, getRecentAuditLogs } = require('../services/auditService')
 async function getAuditLogsEndpoint(req, res, next) {
   try {
     const { schoolId } = req;
-    const { action, targetType, performedBy, startDate, endDate, page, limit } = req.query;
+    const { action, targetType, performedBy, result, startDate, endDate, page, limit } = req.query;
 
-    const result = await getAuditLogs({
+    const auditResult = await getAuditLogs({
       schoolId,
       action,
       targetType,
       performedBy,
+      result,
       startDate,
       endDate,
       page: page ? parseInt(page, 10) : 1,
       limit: limit ? parseInt(limit, 10) : 50,
     });
 
-    res.json(result);
+    res.json(auditResult);
   } catch (err) {
     next(err);
   }

--- a/backend/src/controllers/studentController.js
+++ b/backend/src/controllers/studentController.js
@@ -14,7 +14,7 @@ async function registerStudent(req, res, next) {
 
     if (!studentId) {
       const { generateStudentId } = require('../utils/generateStudentId');
-      studentId = await generateStudentId();
+      studentId = await generateStudentId(5, schoolId);
     }
 
     const existingStudent = await Student.findOne({ schoolId, studentId });

--- a/backend/src/models/paymentModel.js
+++ b/backend/src/models/paymentModel.js
@@ -83,20 +83,44 @@ paymentSchema.virtual('stellarExplorerUrl').get(function () {
   return this.explorerUrl;
 });
 
+/**
+ * Allowed manual status transitions, mirroring the controller's ALLOWED_TRANSITIONS.
+ * This table is the single source of truth for model-level transition validation.
+ *
+ * SUCCESS   → DISPUTED  : admin marks a confirmed payment as disputed
+ * PENDING   → FAILED    : admin manually fails a stuck pending payment
+ * SUBMITTED → FAILED    : admin manually fails a stuck submitted payment
+ *
+ * All other transitions (e.g. FAILED → SUCCESS) are explicitly disallowed.
+ */
+const PAYMENT_STATUS_TRANSITIONS = {
+  SUCCESS:   ['DISPUTED'],
+  PENDING:   ['FAILED'],
+  SUBMITTED: ['FAILED'],
+};
+
 paymentSchema.pre('save', function (next) {
   // Use in-memory Mongoose helpers instead of a DB query to avoid an N+1
   // round-trip on every save. this.isNew is true for inserts; for existing
   // documents Mongoose tracks the original field values so we can check the
   // persisted status without any additional database call.
   if (!this.isNew) {
-    // $__getValue returns the current (possibly modified) value.
-    // For the immutability check we need the *original* persisted status.
+    // For the transition check we need the *original* persisted status.
     // Mongoose stores it in this.$__.savedState when the document was loaded.
     const savedState = this.$__ && this.$__.savedState;
-    const originalStatus = savedState ? savedState.status : this.status;
+    const originalStatus = savedState ? savedState.status : null;
+    const newStatus = this.status;
 
-    if (originalStatus === 'SUCCESS' || originalStatus === 'FAILED') {
-      return next(new Error('Payment audit trail is immutable once in SUCCESS or FAILED state'));
+    if (originalStatus !== null && originalStatus !== newStatus) {
+      // Status is being changed — validate against the allowed transition table.
+      const allowed = PAYMENT_STATUS_TRANSITIONS[originalStatus] || [];
+      if (!allowed.includes(newStatus)) {
+        const err = new Error(
+          `Payment status transition from ${originalStatus} to ${newStatus} is not allowed`,
+        );
+        err.code = 'INVALID_TRANSITION';
+        return next(err);
+      }
     }
   }
 

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -67,6 +67,7 @@ async function getAuditLogs(filters = {}) {
     action,
     targetType,
     performedBy,
+    result,
     startDate,
     endDate,
     page = 1,
@@ -78,6 +79,7 @@ async function getAuditLogs(filters = {}) {
   if (action) query.action = action;
   if (targetType) query.targetType = targetType;
   if (performedBy) query.performedBy = performedBy;
+  if (result) query.result = result;
 
   if (startDate || endDate) {
     query.createdAt = {};
@@ -85,8 +87,8 @@ async function getAuditLogs(filters = {}) {
     if (endDate) query.createdAt.$lte = new Date(endDate);
   }
 
-  const skip = (page - 1) * Math.min(limit, 200);
   const actualLimit = Math.min(limit, 200);
+  const skip = (page - 1) * actualLimit;
 
   const [logs, total] = await Promise.all([
     AuditLog.find(query)
@@ -101,7 +103,8 @@ async function getAuditLogs(filters = {}) {
     logs,
     total,
     page,
-    pages: Math.ceil(total / actualLimit),
+    limit: actualLimit,
+    pages: Math.ceil(total / actualLimit) || 1,
   };
 }
 

--- a/backend/src/utils/generateStudentId.js
+++ b/backend/src/utils/generateStudentId.js
@@ -1,26 +1,55 @@
 const Student = require('../models/studentModel');
 
 /**
- * Generate a unique student ID of the form STU-XXXXXX (6 random uppercase alphanumeric chars).
- * Retries up to `maxAttempts` times to avoid collisions.
- * 
- * @param {number} maxAttempts - Maximum number of retry attempts (default: 10)
- * @returns {Promise<string>} Unique student ID
- * @throws {Error} If unable to generate unique ID after maxAttempts
+ * Generate a unique student ID of the form STU-XXXXXX
+ * (6 random uppercase alphanumeric characters, e.g. "STU-A3BZ9Q").
+ *
+ * Format details:
+ *   - Prefix  : "STU-"  (4 chars)
+ *   - Suffix  : 6 chars from [A-Z0-9]  (36^6 ≈ 2.18 billion combinations)
+ *   - Total   : 10 characters — well within the 28-char Stellar memo limit.
+ *
+ * Uniqueness is guaranteed within the given school via a retry loop.
+ * The function retries up to `maxAttempts` times before throwing
+ * STUDENT_ID_GENERATION_FAILED, so callers never receive a raw duplicate-key
+ * error from MongoDB.
+ *
+ * @param {number} maxAttempts - Maximum retry attempts (default: 5)
+ * @param {string|null} schoolId  - School scope for the uniqueness check.
+ *   When provided, only checks for duplicates within that school (matching
+ *   the compound unique index { studentId, schoolId }). When omitted, checks
+ *   globally (more conservative but still safe).
+ * @returns {Promise<string>} Unique student ID string
+ * @throws {Error} With code 'STUDENT_ID_GENERATION_FAILED' after exhausting all attempts
  */
-async function generateStudentId(maxAttempts = 10) {
+async function generateStudentId(maxAttempts = 5, schoolId = null) {
   if (maxAttempts < 1) {
-    throw Object.assign(new Error('maxAttempts must be at least 1'), { code: 'ID_GENERATION_FAILED' });
+    throw Object.assign(
+      new Error('maxAttempts must be at least 1'),
+      { code: 'STUDENT_ID_GENERATION_FAILED' },
+    );
   }
-  
+
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+
   for (let i = 0; i < maxAttempts; i++) {
-    const suffix = Array.from({ length: 6 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+    const suffix = Array.from(
+      { length: 6 },
+      () => chars[Math.floor(Math.random() * chars.length)],
+    ).join('');
     const id = `STU-${suffix}`;
-    const exists = await Student.exists({ studentId: id });
+
+    // Scope the existence check to the school when possible so we don't
+    // unnecessarily reject IDs that are free within the target school.
+    const existsQuery = schoolId ? { schoolId, studentId: id } : { studentId: id };
+    const exists = await Student.exists(existsQuery);
     if (!exists) return id;
   }
-  throw Object.assign(new Error(`Failed to generate a unique student ID after ${maxAttempts} attempts`), { code: 'ID_GENERATION_FAILED' });
+
+  throw Object.assign(
+    new Error(`Failed to generate a unique student ID after ${maxAttempts} attempts`),
+    { code: 'STUDENT_ID_GENERATION_FAILED' },
+  );
 }
 
 module.exports = { generateStudentId };

--- a/frontend/src/pages/audit-logs.jsx
+++ b/frontend/src/pages/audit-logs.jsx
@@ -36,6 +36,7 @@ export default function AuditLogsPage() {
   // Filters
   const [actionFilter, setActionFilter] = useState("");
   const [targetTypeFilter, setTargetTypeFilter] = useState("");
+  const [resultFilter, setResultFilter] = useState("");
   const [startDate, setStartDate] = useState("");
   const [endDate, setEndDate] = useState("");
 
@@ -46,6 +47,7 @@ export default function AuditLogsPage() {
     const params = { page: p, limit: 50 };
     if (actionFilter) params.action = actionFilter;
     if (targetTypeFilter) params.targetType = targetTypeFilter;
+    if (resultFilter) params.result = resultFilter;
     if (startDate) params.startDate = startDate;
     if (endDate) params.endDate = endDate;
 
@@ -65,7 +67,7 @@ export default function AuditLogsPage() {
 
   useEffect(() => {
     fetchLogs(1);
-  }, [actionFilter, targetTypeFilter, startDate, endDate]);
+  }, [actionFilter, targetTypeFilter, resultFilter, startDate, endDate]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <div style={containerStyle}>
@@ -108,6 +110,20 @@ export default function AuditLogsPage() {
             <option value="payment">Payment</option>
             <option value="fee">Fee</option>
             <option value="school">School</option>
+          </select>
+        </div>
+
+        <div style={filterGroupStyle}>
+          <label style={labelStyle}>Result</label>
+          <select
+            value={resultFilter}
+            onChange={(e) => setResultFilter(e.target.value)}
+            style={selectStyle}
+            aria-label="Filter by result"
+          >
+            <option value="">All Results</option>
+            <option value="success">Success</option>
+            <option value="failure">Failure</option>
           </select>
         </div>
 
@@ -198,10 +214,11 @@ export default function AuditLogsPage() {
           </div>
 
           {/* Pagination */}
-          <div style={paginationStyle}>
+          <div style={paginationStyle} role="navigation" aria-label="Audit log pagination">
             <button
               onClick={() => fetchLogs(page - 1)}
               disabled={page === 1}
+              aria-label="Previous page"
               style={{
                 ...pageBtnStyle,
                 opacity: page === 1 ? 0.5 : 1,
@@ -210,12 +227,13 @@ export default function AuditLogsPage() {
             >
               Previous
             </button>
-            <span style={{ fontSize: "0.9rem", color: "#666" }}>
-              Page {page} of {pages} ({total} total)
+            <span style={{ fontSize: "0.9rem", color: "#666" }} aria-live="polite">
+              Page {page} of {pages} &mdash; {total.toLocaleString()} total entries
             </span>
             <button
               onClick={() => fetchLogs(page + 1)}
               disabled={page === pages}
+              aria-label="Next page"
               style={{
                 ...pageBtnStyle,
                 opacity: page === pages ? 0.5 : 1,

--- a/frontend/src/pages/dashboard.jsx
+++ b/frontend/src/pages/dashboard.jsx
@@ -1,9 +1,9 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import SyncButton from "../components/SyncButton";
 import ErrorBoundary from "../components/ErrorBoundary";
 import { getSyncStatus, getPaymentSummary, getStudents } from "../services/api";
 
-const PAGE_SIZE = 10;
+const PAGE_SIZE = 20;
 
 function timeAgo(iso) {
   if (!iso) return "Never";
@@ -32,9 +32,21 @@ export default function Dashboard() {
   const [studentsError, setStudentsError]   = useState(null);
   const [page, setPage]                 = useState(1);
   const [pages, setPages]               = useState(1);
+  const [total, setTotal]               = useState(0);
   const [search, setSearch]             = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
+  const [classFilter, setClassFilter]   = useState("");
   const [error, setError]               = useState(null);
+
+  // Debounce search input so we don't fire a request on every keystroke.
+  const searchDebounceRef = useRef(null);
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+
+  useEffect(() => {
+    clearTimeout(searchDebounceRef.current);
+    searchDebounceRef.current = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(searchDebounceRef.current);
+  }, [search]);
 
   const fetchSummary = useCallback(() => {
     setSummaryLoading(true);
@@ -45,13 +57,14 @@ export default function Dashboard() {
       .finally(() => setSummaryLoading(false));
   }, []);
 
-  const fetchStudents = useCallback((p) => {
+  const fetchStudents = useCallback((p, srch, st, cls) => {
     setStudentsLoading(true);
     setStudentsError(null);
-    getStudents(p, PAGE_SIZE)
+    getStudents(p, PAGE_SIZE, { search: srch, status: st, className: cls })
       .then(({ data }) => {
         setStudents(data.students);
         setPages(data.pages || 1);
+        setTotal(data.total || 0);
       })
       .catch(() => setStudentsError("Could not load student list."))
       .finally(() => setStudentsLoading(false));
@@ -64,14 +77,24 @@ export default function Dashboard() {
     fetchSummary();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  useEffect(() => { fetchStudents(page); }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Reset to page 1 whenever any filter changes, then fetch.
+  useEffect(() => {
+    setPage(1);
+    fetchStudents(1, debouncedSearch, statusFilter, classFilter);
+  }, [debouncedSearch, statusFilter, classFilter]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch when page changes (filter-change above already resets to p=1).
+  useEffect(() => {
+    fetchStudents(page, debouncedSearch, statusFilter, classFilter);
+  }, [page]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleSyncComplete(data) {
     setLastSyncAt(new Date().toISOString());
     setSyncMsg(data?.message || "Sync complete.");
     setTimeout(() => setSyncMsg(null), 3000);
     fetchSummary();
-    fetchStudents(1);
+    setPage(1);
+    fetchStudents(1, debouncedSearch, statusFilter, classFilter);
   }
 
   const stats = [
@@ -81,12 +104,9 @@ export default function Dashboard() {
     { label: "XLM Collected",    value: summary ? `${(summary.totalXlmCollected || 0).toLocaleString(undefined, { maximumFractionDigits: 2 })}` : "—", sub: "XLM", accent: "#1d4ed8" },
   ];
 
-  const filtered = students.filter(s => {
-    const q = search.toLowerCase();
-    const matchQ = !q || s.name?.toLowerCase().includes(q) || s.studentId?.toLowerCase().includes(q);
-    const matchS = statusFilter === "all" || (s.status || "unpaid").toLowerCase() === statusFilter;
-    return matchQ && matchS;
-  });
+  // Page-range display, e.g. "Showing 21–40 of 347 students"
+  const rangeStart = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const rangeEnd   = Math.min(page * PAGE_SIZE, total);
 
   return (
     <>
@@ -113,6 +133,8 @@ export default function Dashboard() {
         .skeleton { height: 1.4rem; width: 55%; background: var(--border); border-radius: 4px; animation: pulse 1.5s infinite; }
         @keyframes pulse { 0%,100%{opacity:1} 50%{opacity:0.4} }
         .table-wrap { background: var(--bg); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+        .pagination-bar { display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; margin-top: 1rem; font-size: 0.85rem; flex-wrap: wrap; }
+        .pagination-controls { display: flex; align-items: center; gap: 0.5rem; }
       `}</style>
 
       <div className="dash-wrap">
@@ -129,12 +151,12 @@ export default function Dashboard() {
 
         {/* Alerts */}
         {syncMsg && (
-          <div style={{ background: "#dcfce7", border: "1px solid #bbf7d0", borderRadius: 8, padding: "0.65rem 1rem", color: "#166534", fontSize: "0.875rem", margin: "1rem 0" }}>
+          <div role="status" style={{ background: "#dcfce7", border: "1px solid #bbf7d0", borderRadius: 8, padding: "0.65rem 1rem", color: "#166534", fontSize: "0.875rem", margin: "1rem 0" }}>
             ✓ {syncMsg}
           </div>
         )}
         {error && (
-          <div style={{ background: "#fee2e2", border: "1px solid #fecaca", borderRadius: 8, padding: "0.65rem 1rem", color: "#991b1b", fontSize: "0.875rem", margin: "1rem 0" }}>
+          <div role="alert" style={{ background: "#fee2e2", border: "1px solid #fecaca", borderRadius: 8, padding: "0.65rem 1rem", color: "#991b1b", fontSize: "0.875rem", margin: "1rem 0" }}>
             {error}
           </div>
         )}
@@ -142,7 +164,7 @@ export default function Dashboard() {
         {/* Stats */}
         <ErrorBoundary>
           {summaryError ? (
-            <div style={{ background: "#fee2e2", border: "1px solid #fecaca", borderRadius: 8, padding: "0.65rem 1rem", color: "#991b1b", fontSize: "0.875rem", margin: "1rem 0", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <div role="alert" style={{ background: "#fee2e2", border: "1px solid #fecaca", borderRadius: 8, padding: "0.65rem 1rem", color: "#991b1b", fontSize: "0.875rem", margin: "1rem 0", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
               {summaryError}
               <button onClick={fetchSummary} style={{ marginLeft: "1rem", padding: "0.25rem 0.75rem", borderRadius: 6, border: "1px solid #fecaca", background: "transparent", color: "#991b1b", cursor: "pointer", fontSize: "0.8rem" }}>Retry</button>
             </div>
@@ -163,30 +185,54 @@ export default function Dashboard() {
           )}
         </ErrorBoundary>
 
-        {/* Toolbar */}
-        <div className="toolbar">
+        {/* Toolbar — search + filters (server-side) */}
+        <div className="toolbar" role="search" aria-label="Filter students">
           <input
+            type="search"
             placeholder="Search by name or ID…"
             value={search}
             onChange={e => setSearch(e.target.value)}
+            aria-label="Search students by name or ID"
           />
-          <select value={statusFilter} onChange={e => setStatusFilter(e.target.value)}>
+          <select
+            value={statusFilter}
+            onChange={e => setStatusFilter(e.target.value)}
+            aria-label="Filter by payment status"
+          >
             <option value="all">All Status</option>
             <option value="paid">Paid</option>
             <option value="partial">Partial</option>
             <option value="unpaid">Unpaid</option>
+          </select>
+          <select
+            value={classFilter}
+            onChange={e => setClassFilter(e.target.value)}
+            aria-label="Filter by class"
+          >
+            <option value="">All Classes</option>
+            <option value="JSS1">JSS1</option>
+            <option value="JSS2">JSS2</option>
+            <option value="JSS3">JSS3</option>
+            <option value="SS1">SS1</option>
+            <option value="SS2">SS2</option>
+            <option value="SS3">SS3</option>
           </select>
         </div>
 
         {/* Table */}
         <ErrorBoundary>
           {studentsError ? (
-            <div style={{ background: "#fee2e2", border: "1px solid #fecaca", borderRadius: 8, padding: "0.65rem 1rem", color: "#991b1b", fontSize: "0.875rem", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+            <div role="alert" style={{ background: "#fee2e2", border: "1px solid #fecaca", borderRadius: 8, padding: "0.65rem 1rem", color: "#991b1b", fontSize: "0.875rem", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
               {studentsError}
-              <button onClick={() => fetchStudents(page)} style={{ marginLeft: "1rem", padding: "0.25rem 0.75rem", borderRadius: 6, border: "1px solid #fecaca", background: "transparent", color: "#991b1b", cursor: "pointer", fontSize: "0.8rem" }}>Retry</button>
+              <button
+                onClick={() => fetchStudents(page, debouncedSearch, statusFilter, classFilter)}
+                style={{ marginLeft: "1rem", padding: "0.25rem 0.75rem", borderRadius: 6, border: "1px solid #fecaca", background: "transparent", color: "#991b1b", cursor: "pointer", fontSize: "0.8rem" }}
+              >
+                Retry
+              </button>
             </div>
           ) : (
-            <div className="table-wrap" aria-busy={studentsLoading}>
+            <div className="table-wrap" aria-busy={studentsLoading} aria-label="Student list">
               {studentsLoading ? (
                 <table className="dash-table" aria-label="Loading students">
                   <thead>
@@ -210,17 +256,21 @@ export default function Dashboard() {
                 <table className="dash-table">
                   <thead>
                     <tr>
-                      <th>Student ID</th>
-                      <th>Name</th>
-                      <th>Class</th>
-                      <th>Fee</th>
-                      <th>Status</th>
+                      <th scope="col">Student ID</th>
+                      <th scope="col">Name</th>
+                      <th scope="col">Class</th>
+                      <th scope="col">Fee</th>
+                      <th scope="col">Status</th>
                     </tr>
                   </thead>
                   <tbody>
-                    {filtered.length === 0 ? (
-                      <tr><td colSpan="5" style={{ textAlign: "center", padding: "2.5rem", color: "var(--muted)" }}>No students found.</td></tr>
-                    ) : filtered.map(s => {
+                    {students.length === 0 ? (
+                      <tr>
+                        <td colSpan="5" style={{ textAlign: "center", padding: "2.5rem", color: "var(--muted)" }}>
+                          No students found.
+                        </td>
+                      </tr>
+                    ) : students.map(s => {
                       const st = (s.status || "unpaid").toLowerCase();
                       const badge = STATUS_COLOR[st] || STATUS_COLOR.unpaid;
                       return (
@@ -242,12 +292,38 @@ export default function Dashboard() {
           )}
         </ErrorBoundary>
 
-        {/* Pagination */}
-        {pages > 1 && (
-          <div style={{ display: "flex", justifyContent: "flex-end", alignItems: "center", gap: "0.5rem", marginTop: "1rem", fontSize: "0.85rem" }}>
-            <button className="page-btn" disabled={page === 1} onClick={() => setPage(p => p - 1)}>← Prev</button>
-            <span style={{ color: "var(--muted)" }}>Page {page} of {pages}</span>
-            <button className="page-btn" disabled={page === pages} onClick={() => setPage(p => p + 1)}>Next →</button>
+        {/* Pagination — always visible when there are students */}
+        {total > 0 && (
+          <div className="pagination-bar">
+            {/* Page-range summary */}
+            <span style={{ color: "var(--muted)" }} aria-live="polite" aria-atomic="true">
+              {studentsLoading
+                ? "Loading…"
+                : `Showing ${rangeStart}–${rangeEnd} of ${total.toLocaleString()} students`}
+            </span>
+
+            {/* Previous / Next controls */}
+            <nav className="pagination-controls" aria-label="Student list pagination">
+              <button
+                className="page-btn"
+                disabled={page === 1 || studentsLoading}
+                onClick={() => setPage(p => p - 1)}
+                aria-label="Go to previous page"
+              >
+                ← Prev
+              </button>
+              <span style={{ color: "var(--muted)" }} aria-current="page">
+                Page {page} of {pages}
+              </span>
+              <button
+                className="page-btn"
+                disabled={page === pages || studentsLoading}
+                onClick={() => setPage(p => p + 1)}
+                aria-label="Go to next page"
+              >
+                Next →
+              </button>
+            </nav>
           </div>
         )}
       </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -17,8 +17,16 @@ api.interceptors.response.use(
   }
 );
 
-export const getStudents = (page = 1, limit = 50) =>
-  api.get("/students", { params: { page, limit } });
+export const getStudents = (page = 1, limit = 20, { search, status, className } = {}) =>
+  api.get("/students", {
+    params: {
+      page,
+      limit,
+      ...(search    && { search }),
+      ...(status    && status !== "all" && { status }),
+      ...(className && { class: className }),
+    },
+  });
 export const registerStudent = (data) => api.post("/students", data);
 export const getPaymentSummary = () => api.get("/payments/summary");
 export const getPaymentInstructions = (studentId) => api.get(`/payments/instructions/${studentId}`);

--- a/tests/auditLogPagination.test.js
+++ b/tests/auditLogPagination.test.js
@@ -1,0 +1,189 @@
+'use strict';
+
+/**
+ * #575 — GET /api/audit-logs pagination, filtering, and boundary cases.
+ * Tests the auditService.getAuditLogs function directly with a mocked AuditLog model.
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockLogs = [
+  { _id: 'id1', schoolId: 'SCH-1', action: 'student_create', result: 'success', createdAt: new Date('2026-01-01') },
+  { _id: 'id2', schoolId: 'SCH-1', action: 'fee_create',     result: 'failure', createdAt: new Date('2026-01-02') },
+  { _id: 'id3', schoolId: 'SCH-1', action: 'student_delete', result: 'success', createdAt: new Date('2026-01-03') },
+];
+
+let mockFind;
+let mockCount;
+
+jest.mock('../backend/src/models/auditLogModel', () => ({
+  find: (...args) => mockFind(...args),
+  countDocuments: (...args) => mockCount(...args),
+}));
+
+function makeChain(results) {
+  const chain = {
+    sort:  jest.fn().mockReturnThis(),
+    skip:  jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    lean:  jest.fn().mockResolvedValue(results),
+  };
+  return chain;
+}
+
+const { getAuditLogs } = require('../backend/src/services/auditService');
+
+beforeEach(() => {
+  mockFind  = jest.fn(() => makeChain(mockLogs));
+  mockCount = jest.fn().mockResolvedValue(mockLogs.length);
+});
+
+// ── Pagination envelope ───────────────────────────────────────────────────────
+
+describe('pagination envelope', () => {
+  test('returns logs, total, page, limit, and pages', async () => {
+    const result = await getAuditLogs({ schoolId: 'SCH-1', page: 1, limit: 2 });
+    expect(result).toHaveProperty('logs');
+    expect(result).toHaveProperty('total');
+    expect(result).toHaveProperty('page');
+    expect(result).toHaveProperty('limit');
+    expect(result).toHaveProperty('pages');
+    expect(Array.isArray(result.logs)).toBe(true);
+  });
+
+  test('page defaults to 1 and limit defaults to 50', async () => {
+    const result = await getAuditLogs({ schoolId: 'SCH-1' });
+    expect(result.page).toBe(1);
+    expect(result.limit).toBe(50);
+  });
+
+  test('totalPages is ceil(total / limit)', async () => {
+    mockCount.mockResolvedValue(125);
+    const result = await getAuditLogs({ schoolId: 'SCH-1', page: 1, limit: 50 });
+    expect(result.pages).toBe(3); // ceil(125/50) = 3
+  });
+
+  test('limit is capped at 200', async () => {
+    const result = await getAuditLogs({ schoolId: 'SCH-1', page: 1, limit: 999 });
+    expect(result.limit).toBe(200);
+    const chain = mockFind.mock.results[0].value;
+    expect(chain.limit).toHaveBeenCalledWith(200);
+  });
+
+  test('skip is (page - 1) * limit', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', page: 3, limit: 10 });
+    const chain = mockFind.mock.results[0].value;
+    expect(chain.skip).toHaveBeenCalledWith(20); // (3-1)*10
+  });
+
+  test('empty results return pages=1, not 0', async () => {
+    mockFind  = jest.fn(() => makeChain([]));
+    mockCount = jest.fn().mockResolvedValue(0);
+    const result = await getAuditLogs({ schoolId: 'SCH-1' });
+    expect(result.pages).toBe(1);
+    expect(result.total).toBe(0);
+    expect(result.logs).toHaveLength(0);
+  });
+});
+
+// ── Filtering ─────────────────────────────────────────────────────────────────
+
+describe('filtering', () => {
+  test('filters by action', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', action: 'student_create' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'student_create' }),
+    );
+  });
+
+  test('filters by targetType', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', targetType: 'payment' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({ targetType: 'payment' }),
+    );
+  });
+
+  test('filters by performedBy', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', performedBy: 'admin@school.edu' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({ performedBy: 'admin@school.edu' }),
+    );
+  });
+
+  test('filters by result (success)', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', result: 'success' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'success' }),
+    );
+  });
+
+  test('filters by result (failure)', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', result: 'failure' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({ result: 'failure' }),
+    );
+  });
+
+  test('filters by startDate', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', startDate: '2026-01-01' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdAt: expect.objectContaining({ $gte: expect.any(Date) }),
+      }),
+    );
+  });
+
+  test('filters by endDate', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', endDate: '2026-12-31' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdAt: expect.objectContaining({ $lte: expect.any(Date) }),
+      }),
+    );
+  });
+
+  test('filters by date range (both startDate and endDate)', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1', startDate: '2026-01-01', endDate: '2026-12-31' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({
+        createdAt: expect.objectContaining({ $gte: expect.any(Date), $lte: expect.any(Date) }),
+      }),
+    );
+  });
+
+  test('always scopes query to schoolId', async () => {
+    await getAuditLogs({ schoolId: 'SCH-99' });
+    expect(mockFind).toHaveBeenCalledWith(
+      expect.objectContaining({ schoolId: 'SCH-99' }),
+    );
+  });
+
+  test('omits optional filters when not provided', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1' });
+    const query = mockFind.mock.calls[0][0];
+    expect(query).not.toHaveProperty('action');
+    expect(query).not.toHaveProperty('targetType');
+    expect(query).not.toHaveProperty('performedBy');
+    expect(query).not.toHaveProperty('result');
+    expect(query).not.toHaveProperty('createdAt');
+  });
+});
+
+// ── Boundary cases ────────────────────────────────────────────────────────────
+
+describe('boundary cases', () => {
+  test('page beyond last page returns empty logs with correct total', async () => {
+    mockFind  = jest.fn(() => makeChain([]));
+    mockCount = jest.fn().mockResolvedValue(5);
+    const result = await getAuditLogs({ schoolId: 'SCH-1', page: 99, limit: 50 });
+    expect(result.logs).toHaveLength(0);
+    expect(result.total).toBe(5);
+    expect(result.page).toBe(99);
+  });
+
+  test('sorting is always by createdAt descending', async () => {
+    await getAuditLogs({ schoolId: 'SCH-1' });
+    const chain = mockFind.mock.results[0].value;
+    expect(chain.sort).toHaveBeenCalledWith({ createdAt: -1 });
+  });
+});

--- a/tests/generateStudentId.test.js
+++ b/tests/generateStudentId.test.js
@@ -23,7 +23,7 @@ describe('generateStudentId', () => {
 
   test('throws after exhausting all attempts', async () => {
     mockExists.mockResolvedValue(true);
-    await expect(generateStudentId(3)).rejects.toMatchObject({ code: 'INTERNAL_ERROR' });
+    await expect(generateStudentId(3)).rejects.toMatchObject({ code: 'STUDENT_ID_GENERATION_FAILED' });
     expect(mockExists).toHaveBeenCalledTimes(3);
   });
 

--- a/tests/paymentModelTransition.test.js
+++ b/tests/paymentModelTransition.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * #576 — paymentModel pre-save hook status-transition validation.
+ *
+ * Covers:
+ *   1. SUCCESS → DISPUTED is allowed (via save()).
+ *   2. FAILED  → SUCCESS is rejected with INVALID_TRANSITION.
+ *   3. PENDING → FAILED  is allowed.
+ *   4. SUBMITTED → FAILED is allowed.
+ *   5. New documents bypass the transition check.
+ *   6. No-op save (status unchanged) is allowed.
+ */
+
+// ── Capture the pre-save hook from the schema ─────────────────────────────────
+
+let preSaveHook = null;
+
+class MockSchema {
+  constructor() {
+    this.index  = jest.fn().mockReturnThis();
+    this.virtual = jest.fn().mockReturnValue({ get: jest.fn() });
+    this.pre  = jest.fn((event, fn) => {
+      if (event === 'save') preSaveHook = fn;
+    });
+    this.post = jest.fn();
+  }
+}
+MockSchema.Types = { Mixed: {} };
+
+jest.mock('mongoose', () => ({
+  Schema: MockSchema,
+  model: jest.fn().mockReturnValue({}),
+}));
+jest.mock('../backend/src/utils/softDelete', () => jest.fn());
+jest.mock('../backend/src/utils/memoEncryption', () => ({
+  encryptMemo: jest.fn(v => v),
+  decryptMemo: jest.fn(v => v),
+}));
+
+// Load the model so the schema and hooks are registered.
+require('../backend/src/models/paymentModel');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal Mongoose-like document for the pre-save hook.
+ *
+ * @param {string|null} originalStatus - Status stored in DB (null for new docs)
+ * @param {string}      newStatus      - Current (possibly modified) status
+ * @param {boolean}     isNew          - Whether this is an insert
+ */
+function makeDoc({ originalStatus, newStatus, isNew = false }) {
+  return {
+    isNew,
+    status: newStatus,
+    memo: null,
+    isModified: jest.fn((field) => field === 'status' && originalStatus !== newStatus),
+    $__: originalStatus !== null ? { savedState: { status: originalStatus } } : null,
+  };
+}
+
+/** Wrap the hook callback in a Promise so tests can use async/await. */
+function callHook(doc) {
+  return new Promise((resolve, reject) => {
+    preSaveHook.call(doc, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test('pre-save hook is registered', () => {
+  expect(preSaveHook).toBeInstanceOf(Function);
+});
+
+// 1. SUCCESS → DISPUTED
+test('SUCCESS → DISPUTED is allowed via save()', async () => {
+  const doc = makeDoc({ originalStatus: 'SUCCESS', newStatus: 'DISPUTED' });
+  await expect(callHook(doc)).resolves.toBeUndefined();
+});
+
+// 2. FAILED → SUCCESS
+test('FAILED → SUCCESS is rejected with code INVALID_TRANSITION', async () => {
+  const doc = makeDoc({ originalStatus: 'FAILED', newStatus: 'SUCCESS' });
+  await expect(callHook(doc)).rejects.toMatchObject({ code: 'INVALID_TRANSITION' });
+});
+
+// 3. PENDING → FAILED
+test('PENDING → FAILED is allowed via save()', async () => {
+  const doc = makeDoc({ originalStatus: 'PENDING', newStatus: 'FAILED' });
+  await expect(callHook(doc)).resolves.toBeUndefined();
+});
+
+// 4. SUBMITTED → FAILED
+test('SUBMITTED → FAILED is allowed via save()', async () => {
+  const doc = makeDoc({ originalStatus: 'SUBMITTED', newStatus: 'FAILED' });
+  await expect(callHook(doc)).resolves.toBeUndefined();
+});
+
+// 5. New document (insert) bypasses transition check
+test('new document is allowed through without transition check', async () => {
+  const doc = makeDoc({ originalStatus: null, newStatus: 'PENDING', isNew: true });
+  await expect(callHook(doc)).resolves.toBeUndefined();
+});
+
+// 6. No-op save (status unchanged)
+test('no-op save (status unchanged) is allowed', async () => {
+  const doc = makeDoc({ originalStatus: 'SUCCESS', newStatus: 'SUCCESS' });
+  await expect(callHook(doc)).resolves.toBeUndefined();
+});
+
+// Extra: other disallowed transitions
+test('SUCCESS → FAILED is rejected with code INVALID_TRANSITION', async () => {
+  const doc = makeDoc({ originalStatus: 'SUCCESS', newStatus: 'FAILED' });
+  await expect(callHook(doc)).rejects.toMatchObject({ code: 'INVALID_TRANSITION' });
+});
+
+test('DISPUTED → PENDING is rejected with code INVALID_TRANSITION', async () => {
+  const doc = makeDoc({ originalStatus: 'DISPUTED', newStatus: 'PENDING' });
+  await expect(callHook(doc)).rejects.toMatchObject({ code: 'INVALID_TRANSITION' });
+});


### PR DESCRIPTION
## Summary

This PR resolves four issues across backend and frontend, all authored by **Emyt24**.

---

### `#575` — Audit log `result` filter + complete pagination envelope

**Files:** `backend/src/services/auditService.js`, `backend/src/controllers/auditController.js`, `frontend/src/pages/audit-logs.jsx`, `tests/auditLogPagination.test.js`

- Added `result` (success / failure) as a supported filter in `getAuditLogs` — both the service and the controller now extract and apply it.
- Included `limit` in the paginated response envelope (`{ logs, total, page, limit, pages }`) so callers always know the effective page size.
- Fixed a subtle bug in the skip calculation: it now always uses the capped `actualLimit` (max 200) rather than the raw `limit` input.
- Empty result sets now return `pages: 1` instead of `pages: 0`.
- Added a **Result** filter dropdown (All / Success / Failure) to `audit-logs.jsx`.
- Added `aria-live`, `aria-label`, and `role="navigation"` to the audit log pagination bar.
- Added `tests/auditLogPagination.test.js` covering the full pagination envelope, all filter parameters, and boundary cases.

---

### `#576` — `paymentModel` pre-save hook allows `SUCCESS → DISPUTED`

**Files:** `backend/src/models/paymentModel.js`, `tests/paymentModelTransition.test.js`

- Replaced the blanket immutability guard with a `PAYMENT_STATUS_TRANSITIONS` table mirroring the controller's `ALLOWED_TRANSITIONS`:
  - `SUCCESS → DISPUTED` ✅  |  `PENDING → FAILED` ✅  |  `SUBMITTED → FAILED` ✅
  - All other transitions (e.g. `FAILED → SUCCESS`) ❌ rejected with `code: 'INVALID_TRANSITION'`
- Rules apply consistently via `save()` and `findOneAndUpdate()`.
- Added `tests/paymentModelTransition.test.js` with direct pre-save hook unit tests.

---

### `#577` — `generateStudentId` scoped uniqueness + correct error code

**Files:** `backend/src/utils/generateStudentId.js`, `backend/src/controllers/studentController.js`, `tests/generateStudentId.test.js`

- Updated signature to `generateStudentId(maxAttempts = 5, schoolId = null)`; existence check is now scoped to `{ schoolId, studentId }` matching the compound index.
- Changed error code from `ID_GENERATION_FAILED` → `STUDENT_ID_GENERATION_FAILED`.
- Added JSDoc documenting the `STU-XXXXXX` format (10 chars, ≤ 28-char Stellar memo limit).
- Updated `studentController` to pass `schoolId`; updated test to expect the new error code.

---

### `#578` — Dashboard server-side pagination, filters, ARIA, page-range summary

**Files:** `frontend/src/pages/dashboard.jsx`, `frontend/src/services/api.js`

- `PAGE_SIZE` changed from 10 → **20**.
- `getStudents` updated to forward `?search=`, `?status=`, `?class=` to the backend.
- Filtering moved from client-side to **server-side** — never more than `limit` records in memory.
- Added **Class** filter dropdown; debounced search (300 ms); page resets to 1 on any filter change.
- Added page-range summary: **"Showing 21–40 of 347 students"** (`aria-live="polite"`).
- Full accessibility pass: `<nav aria-label>`, `aria-label` on Prev/Next, `aria-current="page"`, `role="search"`, `scope="col"`.

---

Closes #575
Closes #576
Closes #577
Closes #578