### PR TITLE
fix: resolves deactivated schools + Cache-Control,  feeAdjustmentEngine.js: warn when fee is clamped to zero, studentModel.js: text index on name + studentId, schoolModel.js: Stellar public key validation (already present)

### DIFF
--- a/backend/src/middleware/schoolContext.js
+++ b/backend/src/middleware/schoolContext.js
@@ -25,6 +25,7 @@ async function resolveSchool(req, res, next) {
     const schoolSlug = req.headers['x-school-slug'];
 
     if (!schoolId && !schoolSlug) {
+      res.set('Cache-Control', 'no-store');
       return res.status(400).json({
         error: 'School context is required. Provide X-School-ID or X-School-Slug header.',
         code: 'MISSING_SCHOOL_CONTEXT',
@@ -37,10 +38,10 @@ async function resolveSchool(req, res, next) {
     if (schoolId) {
       cacheKey = cache.KEYS.school ? cache.KEYS.school(schoolId) : `school:${schoolId}`;
       school = cache.get(cacheKey);
-      
+
       if (!school) {
-        school = await School.findOne({ schoolId, isActive: true }).lean();
-        if (school) {
+        school = await School.findOne({ schoolId }).lean();
+        if (school && school.isActive) {
           cache.set(cacheKey, school, cache.TTL.SCHOOL || 300);
         }
       }
@@ -48,19 +49,28 @@ async function resolveSchool(req, res, next) {
       const slug = schoolSlug.toLowerCase().trim();
       cacheKey = cache.KEYS.school ? cache.KEYS.school(slug) : `school:${slug}`;
       school = cache.get(cacheKey);
-      
+
       if (!school) {
-        school = await School.findOne({ slug, isActive: true }).lean();
-        if (school) {
+        school = await School.findOne({ slug }).lean();
+        if (school && school.isActive) {
           cache.set(cacheKey, school, cache.TTL.SCHOOL || 300);
         }
       }
     }
 
     if (!school) {
+      res.set('Cache-Control', 'no-store');
       return res.status(404).json({
-        error: 'School not found or inactive.',
-        code: 'SCHOOL_NOT_FOUND',
+        error: 'School not found.',
+        code: 'NOT_FOUND',
+      });
+    }
+
+    if (!school.isActive) {
+      res.set('Cache-Control', 'no-store');
+      return res.status(403).json({
+        error: 'School is deactivated.',
+        code: 'SCHOOL_INACTIVE',
       });
     }
 

--- a/backend/src/models/studentModel.js
+++ b/backend/src/models/studentModel.js
@@ -89,6 +89,7 @@ studentSchema.index({ schoolId: 1, feePaid: 1 });
 studentSchema.index({ studentId: 1, version: 1 });
 studentSchema.index({ feePaid: 1, class: 1 });
 studentSchema.index({ totalPaid: 1 });
+studentSchema.index({ name: 'text', studentId: 'text' });
 
 studentSchema.pre('save', function (next) {
   // Sync feeAmount with fees array for backward compatibility

--- a/backend/src/services/feeAdjustmentEngine.js
+++ b/backend/src/services/feeAdjustmentEngine.js
@@ -1,3 +1,7 @@
+'use strict';
+
+const logger = require('../utils/logger');
+
 /**
  * Dynamic Fee Adjustment Engine
  * 
@@ -111,6 +115,14 @@ class DynamicFeeAdjustmentEngine {
     }
 
     const finalFee = Math.max(0, currentFee); // Prevent negative fees
+
+    if (currentFee < 0) {
+      logger.warn({
+        msg: 'Fee clamped to 0 after adjustments',
+        studentId: context.studentId || null,
+        unclampedAmount: parseFloat(currentFee.toFixed(2)),
+      });
+    }
 
     return {
       baseFee: context.baseAmount,


### PR DESCRIPTION
## Summary

This PR resolves four issues: #583, #584, #585, and #586.

---

### #583 — schoolContext.js: 403 for deactivated schools + Cache-Control: no-store

**Problem:** The middleware queried with `isActive: true`, so inactive schools were indistinguishable from non-existent ones — both returned 404. CDNs could also cache these error responses.

**Changes (`backend/src/middleware/schoolContext.js`):**
- Removed `isActive: true` from the DB query so inactive schools can be detected separately
- Returns **403** with `code: SCHOOL_INACTIVE` when the school exists but is deactivated
- Returns **404** with `code: NOT_FOUND` when the school does not exist at all
- Added `Cache-Control: no-store` to all error responses (400, 403, 404) to prevent CDN caching
- Only caches the school document when it is active

---

### #584 — feeAdjustmentEngine.js: warn when fee is clamped to zero

**Problem:** Stacked discounts could produce a negative fee. The engine already clamped via `Math.max(0, currentFee)` but silently — operators had no visibility into misconfigured rule stacks.

**Changes (`backend/src/services/feeAdjustmentEngine.js`):**
- Added a `logger.warn` call when `currentFee < 0` before clamping, including `studentId` and the unclamped amount
- The clamping behaviour itself is unchanged; the fee is still floored at 0

---

### #585 — studentModel.js: text index on name + studentId

**Problem:** `GET /api/students?search=` used a regex query with no index, causing a full collection scan on large datasets.

**Changes (`backend/src/models/studentModel.js`):**
- Added `studentSchema.index({ name: 'text', studentId: 'text' })`
- All existing compound indexes are preserved

---

### #586 — schoolModel.js: Stellar public key validation (already present)

**Finding:** The `stellarAddress` field already had a custom Mongoose validator using `StrKey.isValidEd25519PublicKey` from `@stellar/stellar-sdk`. No code change was required.

---

Closes #583
Closes #584
Closes #585
Closes #586