### PR TITLE
feat: add column count validation to CSV bulk import

### DIFF
--- a/backend/src/controllers/studentController.js
+++ b/backend/src/controllers/studentController.js
@@ -331,18 +331,28 @@ async function getPaymentSummary(req, res, next) {
 
 const CSV_MAX_SIZE_BYTES = parseInt(process.env.CSV_MAX_SIZE_BYTES, 10) || 5 * 1024 * 1024; // 5 MB
 const CSV_MAX_ROWS = parseInt(process.env.CSV_MAX_ROWS, 10) || 10000;
+const CSV_MAX_COLUMNS = parseInt(process.env.CSV_MAX_COLUMNS, 10) || 20;
 
 function parseCsvBuffer(buffer) {
   return new Promise((resolve, reject) => {
     const rows = [];
     const stream = Readable.from(buffer);
+    let lineNumber = 1;
     stream
       .pipe(csv())
       .on('data', (row) => {
+        lineNumber++;
         if (rows.length >= CSV_MAX_ROWS) {
           stream.destroy();
           const err = new Error(`CSV exceeds maximum row limit of ${CSV_MAX_ROWS}`);
           err.code = 'CSV_TOO_MANY_ROWS';
+          err.status = 400;
+          return reject(err);
+        }
+        if (Object.keys(row).length > CSV_MAX_COLUMNS) {
+          stream.destroy();
+          const err = new Error(`Row ${lineNumber} has too many columns. Max is ${CSV_MAX_COLUMNS}`);
+          err.code = 'CSV_INVALID_FORMAT';
           err.status = 400;
           return reject(err);
         }
@@ -677,4 +687,4 @@ async function reconcileStudent(req, res, next) {
   }
 }
 
-module.exports = { registerStudent, getAllStudents, getStudent, updateStudent, deleteStudent, getPaymentSummary, bulkImportStudents, getOverdueStudents, resetPayment, reconcileStudent };
+module.exports = { registerStudent, getAllStudents, getStudent, updateStudent, deleteStudent, getPaymentSummary, bulkImportStudents, getOverdueStudents, resetPayment, reconcileStudent, parseCsvBuffer };

--- a/backend/tests/test_csv_column_limits.js
+++ b/backend/tests/test_csv_column_limits.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const { parseCsvBuffer } = require('../src/controllers/studentController');
+
+async function testColumnLimits() {
+  console.log('Running CSV column limit tests...');
+
+  // Helper to create buffer
+  const createBuffer = (csvContent) => Buffer.from(csvContent);
+
+  const NL = String.fromCharCode(10);
+
+  // 1. Test 1 column (Pass)
+  const csv1 = 'header' + NL + 'value1';
+  try {
+    await parseCsvBuffer(createBuffer(csv1));
+    console.log('PASS: 1 column passed');
+  } catch (err) {
+    console.error('FAIL: 1 column should have passed', err);
+    process.exit(1);
+  }
+
+  // 2. Test 20 columns (Pass)
+  const csv20 = Array.from({length: 20}, (_, i) => `h${i}`).join(',') + NL +
+                Array.from({length: 20}, (_, i) => `v${i}`).join(',');
+  try {
+    await parseCsvBuffer(createBuffer(csv20));
+    console.log('PASS: 20 columns passed');
+  } catch (err) {
+    console.error('FAIL: 20 columns should have passed', err);
+    process.exit(1);
+  }
+
+  // 3. Test 21 columns (Fail)
+  const csv21 = Array.from({length: 21}, (_, i) => `h${i}`).join(',') + NL +
+                Array.from({length: 21}, (_, i) => `v${i}`).join(',');
+  try {
+    await parseCsvBuffer(createBuffer(csv21));
+    console.error('FAIL: 21 columns should have failed');
+    process.exit(1);
+  } catch (err) {
+    if (err.code === 'CSV_INVALID_FORMAT') {
+      console.log('PASS: 21 columns failed as expected:', err.message);
+    } else {
+      console.error('FAIL: Expected CSV_INVALID_FORMAT but got:', err.code, err.message);
+      process.exit(1);
+    }
+  }
+
+  console.log('All tests passed!');
+  process.exit(0);
+}
+
+testColumnLimits();


### PR DESCRIPTION
Add a column count validation during CSV parsing
 A CSV with thousands of columns per row would still pass the row count check. Parsing a row with 100,000 columns creates a very large JavaScript array, potentially exhausting heap memory.
closes #602 