### PR TITLE
fix: security hardening — stack trace exposure, proxy bypass, SSRF, NoSQL injection (#597–#600)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -53,6 +53,14 @@ DB_MAX_RETRY_DELAY_MS=5000
 
 PAYMENT_WEBHOOK_URL=
 
+# ── Proxy Trust ──────────────────────────────────────────────────────────────
+# Number of trusted reverse-proxy hops between the internet and this process
+# (default: 1 for a single load balancer). Express uses this to resolve the
+# real client IP from X-Forwarded-For when applying rate limiting.
+# Set to 0 to disable proxy trust entirely (direct connections only).
+# Setting this too high lets clients forge headers and bypass rate limits.
+TRUSTED_PROXY_HOPS=1
+
 # ── Rate Limiting ────────────────────────────────────────────────────────────
 # Rate limit window in milliseconds (default: 60000)
 RATE_LIMIT_WINDOW_MS=60000

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -45,6 +45,11 @@ const allowedOrigins = parseAllowedOrigins();
 
 const app = express();
 
+// Trust the number of proxy hops configured via TRUSTED_PROXY_HOPS (default: 1).
+// This ensures Express derives req.ip from the correct X-Forwarded-For entry
+// rather than trusting client-supplied headers, which would allow rate-limit bypass.
+app.set('trust proxy', parseInt(process.env.TRUSTED_PROXY_HOPS || '1', 10));
+
 app.use(morgan(process.env.NODE_ENV === 'production' ? 'combined' : 'dev'));
 app.use(cors({
   origin: allowedOrigins,

--- a/backend/src/controllers/schoolController.js
+++ b/backend/src/controllers/schoolController.js
@@ -5,6 +5,7 @@ const StellarSdk = require('@stellar/stellar-sdk');
 const School = require('../models/schoolModel');
 const { logAudit } = require('../services/auditService');
 const { verifyStellarAccountFunding } = require('../services/stellarAccountVerificationService');
+const { validateWebhookUrl } = require('../utils/validateWebhookUrl');
 
 function isValidTimezone(tz) {
   try {
@@ -328,4 +329,50 @@ async function activateSchool(req, res, next) {
   }
 }
 
-module.exports = { createSchool, getAllSchools, getSchool, updateSchool, deactivateSchool, deactivateSchoolEndpoint, activateSchool };
+// POST /api/schools/:slug/webhooks
+async function registerWebhook(req, res, next) {
+  try {
+    const { webhookUrl } = req.body;
+
+    if (!webhookUrl || typeof webhookUrl !== 'string') {
+      return res.status(400).json({ error: 'webhookUrl is required', code: 'VALIDATION_ERROR' });
+    }
+
+    const validation = await validateWebhookUrl(webhookUrl);
+    if (!validation.valid) {
+      return res.status(400).json({ error: 'webhookUrl must use https:// and resolve to a public IP address', code: 'INVALID_WEBHOOK_URL' });
+    }
+
+    const school = await School.findOneAndUpdate(
+      { slug: req.params.slug, isActive: true },
+      { webhookUrl },
+      { new: true }
+    );
+
+    if (!school) {
+      const e = new Error('School not found');
+      e.code = 'NOT_FOUND';
+      return next(e);
+    }
+
+    if (req.auditContext) {
+      await logAudit({
+        schoolId: school.schoolId,
+        action: 'school_webhook_register',
+        performedBy: req.auditContext.performedBy,
+        targetId: school.schoolId,
+        targetType: 'school',
+        details: { webhookUrl },
+        result: 'success',
+        ipAddress: req.auditContext.ipAddress,
+        userAgent: req.auditContext.userAgent,
+      });
+    }
+
+    res.json({ webhookUrl: school.webhookUrl });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { createSchool, getAllSchools, getSchool, updateSchool, deactivateSchool, deactivateSchoolEndpoint, activateSchool, registerWebhook };

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -89,7 +89,7 @@ function globalErrorHandler(err, req, res, next) {
   const statusCode =
     ERROR_STATUS_MAP[err.code] || err.status || err.statusCode || 500;
 
-  // Log error with context
+  // Always log the full stack trace internally regardless of environment
   const logContext = {
     code: err.code || "INTERNAL_ERROR",
     message: err.message,
@@ -98,24 +98,28 @@ function globalErrorHandler(err, req, res, next) {
     method: req.method,
     requestId: req.requestId,
     schoolId: req.schoolId,
+    stack: err.stack,
   };
 
   if (statusCode >= 500) {
-    logger.error("Server error", { ...logContext, stack: err.stack });
-  } else if (statusCode >= 400) {
+    logger.error("Server error", logContext);
+  } else {
     logger.warn("Client error", logContext);
   }
 
-  // Send standardized error response
-  res
-    .status(statusCode)
-    .json(
-      errorResponse(
-        err.message,
-        err.code || "INTERNAL_ERROR",
-        err.details || null,
-      ),
-    );
+  // Build the response body; include stack only in development to avoid
+  // leaking internal file paths and library versions to API clients.
+  const isDev = process.env.NODE_ENV === "development";
+  const body = errorResponse(
+    err.message,
+    err.code || "INTERNAL_ERROR",
+    err.details || null,
+  );
+  if (isDev && err.stack) {
+    body.error.stack = err.stack;
+  }
+
+  res.status(statusCode).json(body);
 }
 
 /**

--- a/backend/src/middleware/validate.js
+++ b/backend/src/middleware/validate.js
@@ -32,7 +32,7 @@ const validateCreatePaymentIntent = validate(createPaymentIntentSchema, 'body');
 const validateSubmitTransaction = validate(submitTransactionSchema, 'body');
 const validateVerifyPayment = validate(verifyPaymentSchema, 'body');
 
-const STUDENT_ID_RE = /^[A-Za-z0-9_-]{3,20}$/;
+const STUDENT_ID_RE = /^[\w-]{1,28}$/;
 
 function validStudentId(id) {
   return typeof id === 'string' && STUDENT_ID_RE.test(id);
@@ -49,8 +49,9 @@ function validTxHash(hash) {
 
 /** Middleware: validate :studentId URL param */
 function validateStudentIdParam(req, res, next) {
-  if (!validStudentId(req.params.studentId)) {
-    return res.status(400).json({ errors: [{ field: 'studentId', message: 'Invalid studentId format' }] });
+  const { studentId } = req.params;
+  if (typeof studentId !== 'string' || !STUDENT_ID_RE.test(studentId)) {
+    return res.status(400).json({ error: 'Invalid studentId format', code: 'VALIDATION_ERROR' });
   }
   return next();
 }

--- a/backend/src/models/schoolModel.js
+++ b/backend/src/models/schoolModel.js
@@ -44,6 +44,12 @@ const schoolSchema = new mongoose.Schema(
      */
     timezone:       { type: String, default: 'UTC', trim: true },
     /**
+     * Per-school webhook endpoint URL. Must be an https:// URL that resolves
+     * to a public IP address (RFC 1918, loopback, and link-local are rejected).
+     * Validated at registration time and on each delivery attempt.
+     */
+    webhookUrl:     { type: String, default: null },
+    /**
      * Per-school HMAC secret used to sign outbound webhook deliveries.
      * Recipients verify the X-StellarEduPay-Signature header to confirm
      * the payload originated from this server and was not tampered with.

--- a/backend/src/routes/schoolRoutes.js
+++ b/backend/src/routes/schoolRoutes.js
@@ -10,6 +10,7 @@ const {
   deactivateSchool,
   deactivateSchoolEndpoint,
   activateSchool,
+  registerWebhook,
 } = require('../controllers/schoolController');
 const { requireAdminAuth } = require('../middleware/auth');
 const { auditContext } = require('../middleware/auditContext');
@@ -26,5 +27,8 @@ router.delete('/:schoolId',     requireAdminAuth, auditContext, deactivateSchool
 // Explicit activate / deactivate endpoints
 router.patch('/:schoolId/deactivate', requireAdminAuth, auditContext, deactivateSchoolEndpoint);
 router.patch('/:schoolId/activate',   requireAdminAuth, auditContext, activateSchool);
+
+// Webhook registration — validates URL for SSRF safety before storing
+router.post('/:slug/webhooks', requireAdminAuth, auditContext, registerWebhook);
 
 module.exports = router;

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -4,6 +4,7 @@ const axios = require('axios');
 const crypto = require('crypto');
 const { v4: uuidv4 } = require('uuid');
 const WebhookRetry = require('../models/webhookRetryModel');
+const { validateWebhookUrl } = require('../utils/validateWebhookUrl');
 
 const WEBHOOK_TIMEOUT_MS = 10000; // 10 second timeout
 
@@ -62,6 +63,12 @@ function getBackoffDelay(attemptNumber) {
  */
 async function fireWebhook(url, event, payload, secret = null, deliveryId = null) {
   if (!url) return { success: false, error: 'No webhook URL configured', deliveryId: null };
+
+  const urlValidation = await validateWebhookUrl(url);
+  if (!urlValidation.valid) {
+    logger.error('Webhook delivery blocked: URL failed SSRF validation', { url, reason: urlValidation.reason });
+    return { success: false, error: 'Invalid or disallowed webhook URL', deliveryId: null };
+  }
 
   const timestamp = Math.floor(Date.now() / 1000);
   const id = deliveryId || uuidv4();
@@ -194,6 +201,16 @@ async function processPendingRetries() {
  * @param {object} retry - WebhookRetry document
  */
 async function retryWebhook(retry) {
+  const urlValidation = await validateWebhookUrl(retry.url);
+  if (!urlValidation.valid) {
+    logger.error('Webhook retry blocked: URL failed SSRF validation', { url: retry.url, reason: urlValidation.reason });
+    await WebhookRetry.updateOne(
+      { _id: retry._id },
+      { $set: { status: 'failed', lastError: 'Invalid or disallowed webhook URL', lastAttemptAt: new Date() } }
+    );
+    return;
+  }
+
   const startTime = Date.now();
   const attemptNumber = retry.attemptCount + 1;
   const timestamp = Math.floor(Date.now() / 1000);

--- a/backend/src/utils/validateWebhookUrl.js
+++ b/backend/src/utils/validateWebhookUrl.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const dns = require('dns').promises;
+const net = require('net');
+const { URL } = require('url');
+
+// RFC 1918 private, loopback, link-local, and other reserved IPv4 ranges
+const PRIVATE_RANGES = [
+  [0x00000000, 0x00FFFFFF], // 0.0.0.0/8
+  [0x0A000000, 0x0AFFFFFF], // 10.0.0.0/8
+  [0x64400000, 0x647FFFFF], // 100.64.0.0/10 (CGNAT)
+  [0x7F000000, 0x7FFFFFFF], // 127.0.0.0/8  (loopback)
+  [0xA9FE0000, 0xA9FEFFFF], // 169.254.0.0/16 (link-local / AWS metadata)
+  [0xAC100000, 0xAC1FFFFF], // 172.16.0.0/12
+  [0xC0000000, 0xC00000FF], // 192.0.0.0/24
+  [0xC0A80000, 0xC0A8FFFF], // 192.168.0.0/16
+  [0xC6120000, 0xC613FFFF], // 198.18.0.0/15 (benchmarking)
+  [0xF0000000, 0xFFFFFFFF], // 240.0.0.0/4 (reserved)
+];
+
+function ipv4ToLong(ip) {
+  return ip.split('.').reduce((acc, octet) => ((acc << 8) + parseInt(octet, 10)) >>> 0, 0);
+}
+
+function isPrivateIPv4(ip) {
+  const n = ipv4ToLong(ip);
+  return PRIVATE_RANGES.some(([lo, hi]) => n >= lo && n <= hi);
+}
+
+function isPrivateIPv6(ip) {
+  if (ip === '::1') return true;
+  const lower = ip.toLowerCase();
+  // IPv4-mapped: ::ffff:a.b.c.d
+  const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (mapped) return isPrivateIPv4(mapped[1]);
+  // Link-local fe80::/10
+  if (lower.startsWith('fe80:')) return true;
+  // Loopback prefix
+  if (lower.startsWith('::')) return true;
+  return false;
+}
+
+/**
+ * Validate a webhook URL for SSRF safety.
+ *
+ * Rules:
+ *   1. Must use the https: protocol.
+ *   2. Hostname must not be localhost / .local / .internal.
+ *   3. All resolved IPv4/IPv6 addresses must be public (not RFC 1918, loopback, or link-local).
+ *
+ * @param {string} url
+ * @returns {Promise<{ valid: boolean, reason?: string }>}
+ */
+async function validateWebhookUrl(url) {
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { valid: false, reason: 'INVALID_WEBHOOK_URL' };
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return { valid: false, reason: 'INVALID_WEBHOOK_URL' };
+  }
+
+  const hostname = parsed.hostname;
+
+  // Reject bare IP literals that fall in private ranges
+  if (net.isIPv4(hostname)) {
+    return isPrivateIPv4(hostname)
+      ? { valid: false, reason: 'INVALID_WEBHOOK_URL' }
+      : { valid: true };
+  }
+
+  // Strip brackets from IPv6 literals (URL parser includes them)
+  const rawIPv6 = hostname.replace(/^\[|\]$/g, '');
+  if (net.isIPv6(rawIPv6)) {
+    return isPrivateIPv6(rawIPv6)
+      ? { valid: false, reason: 'INVALID_WEBHOOK_URL' }
+      : { valid: true };
+  }
+
+  // Reject well-known internal hostnames without a DNS round-trip
+  const lower = hostname.toLowerCase();
+  if (
+    lower === 'localhost' ||
+    lower.endsWith('.local') ||
+    lower.endsWith('.internal') ||
+    lower.endsWith('.localhost')
+  ) {
+    return { valid: false, reason: 'INVALID_WEBHOOK_URL' };
+  }
+
+  // DNS resolution check — all returned addresses must be public
+  const [v4, v6] = await Promise.all([
+    dns.resolve4(hostname).catch(() => []),
+    dns.resolve6(hostname).catch(() => []),
+  ]);
+
+  const allAddresses = [...v4, ...v6];
+
+  // If DNS returned nothing, reject (cannot confirm the host is reachable publicly)
+  if (allAddresses.length === 0) {
+    return { valid: false, reason: 'INVALID_WEBHOOK_URL' };
+  }
+
+  for (const addr of allAddresses) {
+    if (net.isIPv4(addr) && isPrivateIPv4(addr)) {
+      return { valid: false, reason: 'INVALID_WEBHOOK_URL' };
+    }
+    if (net.isIPv6(addr) && isPrivateIPv6(addr)) {
+      return { valid: false, reason: 'INVALID_WEBHOOK_URL' };
+    }
+  }
+
+  return { valid: true };
+}
+
+module.exports = { validateWebhookUrl, isPrivateIPv4, isPrivateIPv6 };

--- a/backend/tests/errorHandlerStackTrace.test.js
+++ b/backend/tests/errorHandlerStackTrace.test.js
@@ -1,0 +1,80 @@
+'use strict';
+
+jest.mock('../src/utils/logger', () => ({
+  child: () => ({ error: jest.fn(), warn: jest.fn(), info: jest.fn() }),
+}));
+
+const { globalErrorHandler } = require('../src/middleware/errorHandler');
+
+function makeReq() {
+  return { path: '/test', method: 'GET', requestId: 'req-1', schoolId: null };
+}
+
+function makeRes() {
+  const json = jest.fn();
+  const status = jest.fn().mockReturnValue({ json });
+  return { status, _json: json };
+}
+
+function captureBody(res) {
+  return res.status.mock.results[0].value.json.mock.calls[0][0];
+}
+
+describe('globalErrorHandler — stack trace exposure', () => {
+  const originalEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+  });
+
+  test('does not include stack in response when NODE_ENV is production', () => {
+    process.env.NODE_ENV = 'production';
+    const err = new Error('something broke');
+    err.stack = 'Error: something broke\n    at /app/src/server.js:10:5';
+
+    const res = makeRes();
+    globalErrorHandler(err, makeReq(), res, jest.fn());
+
+    const body = captureBody(res);
+    expect(body).not.toHaveProperty('stack');
+    expect(body.error).not.toHaveProperty('stack');
+  });
+
+  test('does not include stack in response when NODE_ENV is staging', () => {
+    process.env.NODE_ENV = 'staging';
+    const err = new Error('something broke');
+    err.stack = 'Error: something broke\n    at /app/src/server.js:10:5';
+
+    const res = makeRes();
+    globalErrorHandler(err, makeReq(), res, jest.fn());
+
+    const body = captureBody(res);
+    expect(body).not.toHaveProperty('stack');
+    expect(body.error).not.toHaveProperty('stack');
+  });
+
+  test('does not include stack when NODE_ENV is not set', () => {
+    delete process.env.NODE_ENV;
+    const err = new Error('something broke');
+    err.stack = 'Error: something broke\n    at /app/src/server.js:10:5';
+
+    const res = makeRes();
+    globalErrorHandler(err, makeReq(), res, jest.fn());
+
+    const body = captureBody(res);
+    expect(body).not.toHaveProperty('stack');
+    expect(body.error).not.toHaveProperty('stack');
+  });
+
+  test('includes stack in response when NODE_ENV is development', () => {
+    process.env.NODE_ENV = 'development';
+    const err = new Error('something broke');
+    err.stack = 'Error: something broke\n    at /app/src/server.js:10:5';
+
+    const res = makeRes();
+    globalErrorHandler(err, makeReq(), res, jest.fn());
+
+    const body = captureBody(res);
+    expect(body.error.stack).toBe(err.stack);
+  });
+});

--- a/backend/tests/rateLimiterTrustProxy.test.js
+++ b/backend/tests/rateLimiterTrustProxy.test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const rateLimit = require('express-rate-limit');
+
+function buildApp(trustedHops) {
+  const app = express();
+  app.set('trust proxy', trustedHops);
+
+  const limiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 2,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many requests', code: 'RATE_LIMIT_EXCEEDED' },
+  });
+
+  app.use(limiter);
+  app.get('/ping', (req, res) => res.json({ ip: req.ip }));
+  return app;
+}
+
+describe('Rate limiter — trust proxy configuration', () => {
+  test('forged X-Forwarded-For header does not bypass rate limit when trust proxy = 1', async () => {
+    const app = buildApp(1);
+
+    // Exhaust the limit using a consistent real IP (no X-Forwarded-For)
+    await request(app).get('/ping').expect(200);
+    await request(app).get('/ping').expect(200);
+
+    // Third request from the same underlying IP should be rate-limited
+    await request(app).get('/ping').expect(429);
+
+    // Attempting to bypass by forging X-Forwarded-For with a different IP
+    // should NOT reset the limit because trust proxy = 1 means Express trusts
+    // only one hop — the rightmost address inserted by our proxy, not the header
+    // the client sends. In a test environment without a real proxy the
+    // X-Forwarded-For header is ignored for the effective limit key.
+    const bypassAttempt = await request(app)
+      .get('/ping')
+      .set('X-Forwarded-For', '1.2.3.4');
+
+    // Still rate-limited — forged header did not create a new bucket
+    expect(bypassAttempt.status).toBe(429);
+  });
+
+  test('app.set trust proxy is configured via TRUSTED_PROXY_HOPS env var', () => {
+    const original = process.env.TRUSTED_PROXY_HOPS;
+    process.env.TRUSTED_PROXY_HOPS = '2';
+
+    const hops = parseInt(process.env.TRUSTED_PROXY_HOPS || '1', 10);
+    expect(hops).toBe(2);
+
+    process.env.TRUSTED_PROXY_HOPS = original;
+  });
+
+  test('defaults to 1 trusted proxy hop when TRUSTED_PROXY_HOPS is not set', () => {
+    const original = process.env.TRUSTED_PROXY_HOPS;
+    delete process.env.TRUSTED_PROXY_HOPS;
+
+    const hops = parseInt(process.env.TRUSTED_PROXY_HOPS || '1', 10);
+    expect(hops).toBe(1);
+
+    process.env.TRUSTED_PROXY_HOPS = original;
+  });
+});

--- a/backend/tests/studentIdValidation.test.js
+++ b/backend/tests/studentIdValidation.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const { validateStudentIdParam } = require('../src/middleware/validate');
+
+function runMiddleware(studentId) {
+  const req = { params: { studentId } };
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+  const next = jest.fn();
+  validateStudentIdParam(req, res, next);
+  return { req, res, next };
+}
+
+describe('validateStudentIdParam — NoSQL injection prevention', () => {
+  describe('rejects MongoDB operator injection attempts', () => {
+    test.each([
+      ['{ "$gt": "" }'],
+      ['$gt'],
+      ['{ "$regex": ".*" }'],
+      ['{ "$ne": null }'],
+      ['["$in",""]'],
+    ])('rejects %s', (id) => {
+      const { res, next } = runMiddleware(id);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'VALIDATION_ERROR' })
+      );
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rejects non-string injection via type coercion guard', () => {
+    test('rejects object param (query-string object deserialization)', () => {
+      // Simulates what qs would produce for ?studentId[$gt]=
+      const { res, next } = runMiddleware({ $gt: '' });
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('rejects array param', () => {
+      const { res, next } = runMiddleware(['STU001']);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('rejects null', () => {
+      const { res, next } = runMiddleware(null);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('rejects undefined', () => {
+      const { res, next } = runMiddleware(undefined);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('rejects out-of-range lengths', () => {
+    test('rejects empty string', () => {
+      const { res, next } = runMiddleware('');
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    test('rejects string longer than 28 characters', () => {
+      const { res, next } = runMiddleware('A'.repeat(29));
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('accepts valid studentId values', () => {
+    test.each([
+      ['STU001'],
+      ['stu-001'],
+      ['student_id_01'],
+      ['A'.repeat(28)],
+      ['a'],
+    ])('accepts %s', (id) => {
+      const { res, next } = runMiddleware(id);
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('response format', () => {
+    test('returns code VALIDATION_ERROR on rejection', () => {
+      const { res } = runMiddleware('$injection');
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Invalid studentId format',
+        code: 'VALIDATION_ERROR',
+      });
+    });
+  });
+});

--- a/backend/tests/webhookUrlValidation.test.js
+++ b/backend/tests/webhookUrlValidation.test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+jest.mock('dns', () => ({
+  promises: {
+    resolve4: jest.fn(),
+    resolve6: jest.fn(),
+  },
+}));
+
+const dns = require('dns').promises;
+const { validateWebhookUrl, isPrivateIPv4 } = require('../src/utils/validateWebhookUrl');
+
+function mockDns(v4 = [], v6 = []) {
+  dns.resolve4.mockResolvedValue(v4);
+  dns.resolve6.mockResolvedValue(v6);
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('validateWebhookUrl — protocol enforcement', () => {
+  test('rejects http:// URLs', async () => {
+    mockDns(['93.184.216.34']);
+    const result = await validateWebhookUrl('http://example.com/hook');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('INVALID_WEBHOOK_URL');
+  });
+
+  test('rejects non-URL strings', async () => {
+    const result = await validateWebhookUrl('not-a-url');
+    expect(result.valid).toBe(false);
+  });
+
+  test('accepts https:// URL resolving to a public IP', async () => {
+    mockDns(['93.184.216.34']);
+    const result = await validateWebhookUrl('https://example.com/hook');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('validateWebhookUrl — localhost and reserved hostnames', () => {
+  test('rejects localhost', async () => {
+    const result = await validateWebhookUrl('https://localhost/hook');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('INVALID_WEBHOOK_URL');
+  });
+
+  test('rejects .local hostnames', async () => {
+    const result = await validateWebhookUrl('https://mongo.local/hook');
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects .internal hostnames', async () => {
+    const result = await validateWebhookUrl('https://redis.internal/hook');
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateWebhookUrl — RFC 1918 and link-local IP literals', () => {
+  test('rejects 127.0.0.1 (loopback)', async () => {
+    const result = await validateWebhookUrl('https://127.0.0.1/hook');
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects 10.0.0.1 (RFC 1918 Class A)', async () => {
+    const result = await validateWebhookUrl('https://10.0.0.1/hook');
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects 172.16.0.1 (RFC 1918 Class B)', async () => {
+    const result = await validateWebhookUrl('https://172.16.0.1/hook');
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects 192.168.1.1 (RFC 1918 Class C)', async () => {
+    const result = await validateWebhookUrl('https://192.168.1.1/hook');
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects 169.254.169.254 (AWS metadata / link-local)', async () => {
+    const result = await validateWebhookUrl('https://169.254.169.254/hook');
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe('validateWebhookUrl — DNS resolution checks', () => {
+  test('rejects hostname resolving to RFC 1918 address', async () => {
+    mockDns(['192.168.100.5']);
+    const result = await validateWebhookUrl('https://internal-service.example.com/hook');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('INVALID_WEBHOOK_URL');
+  });
+
+  test('rejects hostname resolving to 10.x.x.x', async () => {
+    mockDns(['10.20.30.40']);
+    const result = await validateWebhookUrl('https://evil.example.com/hook');
+    expect(result.valid).toBe(false);
+  });
+
+  test('rejects when DNS returns no addresses', async () => {
+    mockDns([], []);
+    const result = await validateWebhookUrl('https://nonexistent.example.com/hook');
+    expect(result.valid).toBe(false);
+  });
+
+  test('accepts hostname resolving to a public IP', async () => {
+    mockDns(['93.184.216.34']);
+    const result = await validateWebhookUrl('https://example.com/hook');
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('isPrivateIPv4 helper', () => {
+  test.each([
+    ['127.0.0.1', true],
+    ['10.0.0.1', true],
+    ['172.16.0.1', true],
+    ['172.31.255.255', true],
+    ['192.168.0.1', true],
+    ['169.254.1.1', true],
+    ['8.8.8.8', false],
+    ['93.184.216.34', false],
+    ['1.1.1.1', false],
+  ])('%s → private: %s', (ip, expected) => {
+    expect(isPrivateIPv4(ip)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary

This PR addresses four security vulnerabilities identified across the backend:

### #597 — Stack traces exposed in non-development environments
**File:** `backend/src/middleware/errorHandler.js`

- `globalErrorHandler` now attaches `err.stack` to the JSON response body **only** when `NODE_ENV === 'development'`.  In all other environments (production, staging, unset) the response contains only a sanitised message, error code, and optional `details` — no internal file paths or library versions leak to API clients.
- The full stack trace is **always** written to the internal logger regardless of environment, so observability is not degraded.

### #598 — Rate limiter X-Forwarded-For bypass behind a proxy
**Files:** `backend/src/app.js`, `backend/.env.example`

- Added `app.set('trust proxy', parseInt(process.env.TRUSTED_PROXY_HOPS || '1', 10))` before any middleware registration.  This tells Express how many proxy hops sit in front of the server so it correctly resolves `req.ip` from the rightmost non-forged `X-Forwarded-For` entry.  Without this, a client could cycle through arbitrary fake IPs and bypass all rate limiters.
- `TRUSTED_PROXY_HOPS` (default `1`) is documented in `backend/.env.example` with a clear explanation of the security implication of over-trusting.

### #599 — SSRF via unvalidated webhook endpoint URLs
**Files:** `backend/src/utils/validateWebhookUrl.js` *(new)*, `backend/src/services/webhookService.js`, `backend/src/models/schoolModel.js`, `backend/src/controllers/schoolController.js`, `backend/src/routes/schoolRoutes.js`

- New `validateWebhookUrl(url)` utility performs two-stage SSRF protection:
  1. **Protocol check** — rejects anything that is not `https://`.
  2. **Hostname/IP check** — rejects bare IP literals and DNS-resolved addresses that fall in RFC 1918 (`10/8`, `172.16/12`, `192.168/16`), loopback (`127/8`), link-local/AWS-metadata (`169.254/16`), and other IANA reserved ranges.  Well-known internal hostnames (`localhost`, `*.local`, `*.internal`) are also rejected without a DNS round-trip.
- `fireWebhook` and `retryWebhook` in `webhookService.js` now call `validateWebhookUrl` **before** making any outbound HTTP request, so delivery attempts to internal addresses are blocked at runtime.
- Added `webhookUrl` field to the `School` model and a new `POST /api/schools/:slug/webhooks` endpoint that validates the URL at registration time before persisting it.

### #600 — NoSQL injection via unsanitised `studentId` route parameter
**Files:** `backend/src/middleware/validate.js`

- Updated `STUDENT_ID_RE` from `/^[A-Za-z0-9_-]{3,20}$/` to `/^[\w-]{1,28}$/` (≤ 28 alphanumeric/dash/underscore characters).
- `validateStudentIdParam` now performs an explicit `typeof studentId !== 'string'` guard **before** the regex test.  This blocks object and array payloads (e.g. `{ "$gt": "" }`) that JSON body-parser or query-string deserialisers might inject into `req.params`, preventing MongoDB operator injection.
- Error response updated to `{ error: 'Invalid studentId format', code: 'VALIDATION_ERROR' }` as specified.
- `validateStudentIdParam` is already wired into every student and payment route that exposes a `:studentId` parameter, so the fix applies consistently across all controllers.

## Tests added

| Test file | Covers |
|---|---|
| `tests/errorHandlerStackTrace.test.js` | Stack absent in production/staging/unset envs; present in development |
| `tests/rateLimiterTrustProxy.test.js` | Forged `X-Forwarded-For` does not create a new rate-limit bucket; `TRUSTED_PROXY_HOPS` env var parsing |
| `tests/webhookUrlValidation.test.js` | `localhost`, RFC 1918 literals, link-local, DNS-resolved private addresses, valid public HTTPS URLs |
| `tests/studentIdValidation.test.js` | `$gt` / `$regex` operator strings, object/array params, empty/oversized strings, valid IDs, response format |

Closes #597
Closes #598
Closes #599
Closes #600