### PR TITLE
feat: track audit log failures with metrics and health endpoint

### DIFF
--- a/backend/src/controllers/healthController.js
+++ b/backend/src/controllers/healthController.js
@@ -6,7 +6,7 @@ const config = require('../config');
 const { concurrentPaymentProcessor } = require('../services/concurrentPaymentProcessor');
 const { getReminderStatus } = require('../services/reminderService');
 const { getCachedRates } = require('../services/currencyConversionService');
-const logger = require('../utils/logger');
+const { getAuditHealth } = require('../services/auditService');
 
 const STELLAR_CHECK_TIMEOUT_MS = 3000; // 3 second timeout for Stellar health check
 
@@ -107,6 +107,7 @@ async function healthCheck(req, res) {
         available: priceFeedStatus.length > 0,
         rates: priceFeedStatus,
       },
+      auditLog: getAuditHealth(),
     },
   };
 

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -1,6 +1,23 @@
 'use strict';
 
 const AuditLog = require('../models/auditLogModel');
+const logger = require('../utils/logger');
+
+// In-process failure counter — reset on restart (acceptable for single-process deployments)
+let _auditFailureCount = 0;
+
+/** Returns the current audit log failure count and health status. */
+function getAuditHealth() {
+  return {
+    status: _auditFailureCount === 0 ? 'ok' : 'degraded',
+    recentFailures: _auditFailureCount,
+  };
+}
+
+/** Exposed for testing only. */
+function _resetAuditFailureCount() {
+  _auditFailureCount = 0;
+}
 
 /**
  * logAudit — creates an audit log entry for admin actions.
@@ -43,8 +60,9 @@ async function logAudit({
       userAgent,
     });
   } catch (err) {
-    // Log audit failures but don't block the main operation
-    console.error('[AuditService] Failed to create audit log:', err.message);
+    // Do NOT re-throw — audit failure must not break the primary operation
+    _auditFailureCount += 1;
+    logger.error('AUDIT_LOG_FAILURE', { err, schoolId, action });
   }
 }
 
@@ -121,4 +139,4 @@ async function getRecentAuditLogs(schoolId, limit = 10) {
     .lean();
 }
 
-module.exports = { logAudit, getAuditLogs, getRecentAuditLogs };
+module.exports = { logAudit, getAuditLogs, getRecentAuditLogs, getAuditHealth, _resetAuditFailureCount };

--- a/tests/auditLogFailure.test.js
+++ b/tests/auditLogFailure.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * #635 — auditService.logAudit failure tracking.
+ * Verifies that:
+ *  - failures are logged at error level with full details
+ *  - _auditFailureCount is incremented on each failure
+ *  - getAuditHealth() reflects the failure count
+ *  - the primary operation continues (no re-throw)
+ */
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+let mockCreate;
+
+jest.mock('../backend/src/models/auditLogModel', () => ({
+  create: (...args) => mockCreate(...args),
+}));
+
+const mockLoggerError = jest.fn();
+jest.mock('../backend/src/utils/logger', () => ({
+  error: (...args) => mockLoggerError(...args),
+}));
+
+// ── Subject ──────────────────────────────────────────────────────────────────
+
+const { logAudit, getAuditHealth, _resetAuditFailureCount } = require('../backend/src/services/auditService');
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+const ENTRY = {
+  schoolId: 'SCH-1',
+  action: 'student_create',
+  performedBy: 'admin@test.com',
+  targetId: 'STU001',
+  targetType: 'student',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetAuditFailureCount();
+});
+
+describe('logAudit — success path', () => {
+  test('creates audit log entry and does not increment failure count', async () => {
+    mockCreate = jest.fn().mockResolvedValue({});
+
+    await logAudit(ENTRY);
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).not.toHaveBeenCalled();
+    expect(getAuditHealth()).toEqual({ status: 'ok', recentFailures: 0 });
+  });
+});
+
+describe('logAudit — failure path', () => {
+  test('does not throw when AuditLog.create rejects', async () => {
+    mockCreate = jest.fn().mockRejectedValue(new Error('DB write failed'));
+
+    await expect(logAudit(ENTRY)).resolves.toBeUndefined();
+  });
+
+  test('logs error at error level with AUDIT_LOG_FAILURE message', async () => {
+    const dbError = new Error('connection lost');
+    mockCreate = jest.fn().mockRejectedValue(dbError);
+
+    await logAudit(ENTRY);
+
+    expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      'AUDIT_LOG_FAILURE',
+      expect.objectContaining({ err: dbError })
+    );
+  });
+
+  test('increments failure count on each failure', async () => {
+    mockCreate = jest.fn().mockRejectedValue(new Error('disk full'));
+
+    await logAudit(ENTRY);
+    await logAudit(ENTRY);
+
+    expect(getAuditHealth()).toEqual({ status: 'degraded', recentFailures: 2 });
+  });
+
+  test('getAuditHealth returns degraded after a failure', async () => {
+    mockCreate = jest.fn().mockRejectedValue(new Error('schema error'));
+
+    await logAudit(ENTRY);
+
+    const health = getAuditHealth();
+    expect(health.status).toBe('degraded');
+    expect(health.recentFailures).toBe(1);
+  });
+
+  test('primary operation continues — subsequent logAudit calls still execute', async () => {
+    mockCreate = jest.fn()
+      .mockRejectedValueOnce(new Error('transient error'))
+      .mockResolvedValue({});
+
+    await logAudit(ENTRY); // fails
+    await logAudit(ENTRY); // succeeds
+
+    expect(mockCreate).toHaveBeenCalledTimes(2);
+    expect(getAuditHealth().recentFailures).toBe(1);
+  });
+});
+
+describe('getAuditHealth', () => {
+  test('returns ok with 0 failures initially', () => {
+    expect(getAuditHealth()).toEqual({ status: 'ok', recentFailures: 0 });
+  });
+
+  test('_resetAuditFailureCount resets counter back to ok', async () => {
+    mockCreate = jest.fn().mockRejectedValue(new Error('err'));
+    await logAudit(ENTRY);
+    expect(getAuditHealth().status).toBe('degraded');
+
+    _resetAuditFailureCount();
+    expect(getAuditHealth()).toEqual({ status: 'ok', recentFailures: 0 });
+  });
+});


### PR DESCRIPTION
- Replace console.error with structured logger.error('AUDIT_LOG_FAILURE')
- Increment _auditFailureCount on each logAudit catch
- Export getAuditHealth() returning { status, recentFailures }
- Add checks.auditLog to GET /health response body
- Add 8 unit tests covering failure path, count, health status, and reset

Closes #635
Closes #634
Closes #637 
Closes #636  
