### PR TITLE
fix: validate fee structure on student registration & add circuit bre…

### DIFF
--- a/backend/src/controllers/studentController.js
+++ b/backend/src/controllers/studentController.js
@@ -40,6 +40,14 @@ async function registerStudent(req, res, next) {
       class: className,
     });
 
+    // Always validate that a fee structure exists for the class (#663)
+    if (className) {
+      const feeStructure = await FeeStructure.findOne({ schoolId, className, deletedAt: null });
+      if (!feeStructure) {
+        return res.status(400).json({ error: `No fee structure found for class "${className}"`, code: 'FEE_STRUCTURE_NOT_FOUND' });
+      }
+    }
+
     let assignedFee = feeAmount;
     let assignedDeadline = null;
     if (assignedFee == null && className) {

--- a/backend/src/services/reminderService.js
+++ b/backend/src/services/reminderService.js
@@ -30,6 +30,13 @@ let _running = false;
 let _lastRunAt = null;
 let _lastRunSummary = null;
 
+// Circuit breaker state
+const CIRCUIT_FAILURE_THRESHOLD = 5;
+const CIRCUIT_HALF_OPEN_AFTER_MS = 10 * 60 * 1000; // 10 minutes
+let _circuitState = 'closed'; // 'closed' | 'open' | 'half-open'
+let _consecutiveFailures = 0;
+let _circuitOpenedAt = null;
+
 /**
  * Check if SMTP is properly configured
  */
@@ -118,6 +125,17 @@ async function processReminders() {
         continue;
       }
 
+      // Circuit breaker: check state before each send
+      if (_circuitState === 'open') {
+        if (Date.now() - _circuitOpenedAt >= CIRCUIT_HALF_OPEN_AFTER_MS) {
+          _circuitState = 'half-open';
+          logger.warn('Circuit half-open — testing email provider', { schoolId: school.schoolId });
+        } else {
+          summary.skipped++;
+          continue;
+        }
+      }
+
       summary.eligible++;
 
       try {
@@ -139,16 +157,36 @@ async function processReminders() {
             $inc: { reminderCount: 1 },
           });
           summary.sent++;
+          // Successful send — reset circuit
+          if (_circuitState !== 'closed') {
+            _circuitState = 'closed';
+            logger.warn('Circuit closed — email provider recovered');
+          }
+          _consecutiveFailures = 0;
         } else {
           summary.skipped++;
         }
       } catch (err) {
         summary.failed++;
+        _consecutiveFailures++;
         logger.error('Failed to send reminder', {
           studentId: student.studentId,
           schoolId:  school.schoolId,
           error:     err.message,
         });
+
+        if (_consecutiveFailures >= CIRCUIT_FAILURE_THRESHOLD && _circuitState === 'closed') {
+          _circuitState = 'open';
+          _circuitOpenedAt = Date.now();
+          logger.warn('Circuit opened — too many consecutive email failures', { consecutiveFailures: _consecutiveFailures });
+          break;
+        }
+        if (_circuitState === 'half-open') {
+          _circuitState = 'open';
+          _circuitOpenedAt = Date.now();
+          logger.warn('Circuit re-opened — email provider still failing');
+          break;
+        }
       }
     }
   }
@@ -208,6 +246,8 @@ function getReminderStatus() {
     schedulerRunning: _timer !== null,
     lastRunAt: _lastRunAt,
     lastRunSummary: _lastRunSummary,
+    circuitState: _circuitState,
+    consecutiveFailures: _consecutiveFailures,
   };
 }
 


### PR DESCRIPTION
…aker to reminder service

Closes #663 — POST /api/students does not validate class against existing fee structures Closes #662 — reminderService.scheduleReminders has no circuit breaker

──────────────────────────────────────────────────────────────── Issue #663 — Orphaned students due to missing fee structure check ──────────────────────────────────────────────────────────────── Problem:
  registerStudent in studentController.js only looked up the fee
  structure when no explicit feeAmount was provided in the request
  body. An admin could register a student with class: 'Grade 99'
  and an explicit feeAmount, even if no fee structure existed for
  that class. This produced orphaned students whose class had no
  corresponding fee structure, causing incorrect report totals and
  unexpected behaviour in getPaymentSummary.

Fix (studentController.js — registerStudent):
  Added an upfront validation block that always queries
  FeeStructure.findOne({ schoolId, className, deletedAt: null })
  before any fee assignment logic runs. If no fee structure is
  found for the given class, the handler returns immediately with:
    HTTP 400  { error: 'No fee structure found for class "..."',
                code:  'FEE_STRUCTURE_NOT_FOUND' }
  This check runs regardless of whether the caller supplied an
  explicit feeAmount, ensuring every registered student belongs to
  a class that has a defined fee structure.

──────────────────────────────────────────────────────────────── Issue #662 — No circuit breaker in reminderService ──────────────────────────────────────────────────────────────── Problem:
  processReminders iterated over all unpaid students and called
  sendFeeReminder for each one sequentially. If the email provider
  was down, every call would time out (~30 s), meaning 100 students
  could block the scheduler for ~50 minutes. There was no mechanism
  to detect a broken provider and abort early. The _running flag
  already prevented overlapping cron ticks, but the circuit breaker
  was entirely absent.

Fix (reminderService.js — processReminders):
  Added module-level circuit breaker state:
    _circuitState         — 'closed' | 'open' | 'half-open'
    _consecutiveFailures  — counter reset on every successful send
    _circuitOpenedAt      — timestamp when the circuit opened

  Behaviour:
  • CLOSED (normal): emails are sent; each success resets
    _consecutiveFailures to 0.
  • OPEN (tripped): after CIRCUIT_FAILURE_THRESHOLD (5) consecutive
    failures the circuit opens, _circuitOpenedAt is recorded, and
    a warn-level log is emitted. All remaining students in the
    current run are skipped (break out of the loop) to prevent
    further timeouts.
  • HALF-OPEN (recovery probe): once CIRCUIT_HALF_OPEN_AFTER_MS
    (10 minutes) has elapsed since the circuit opened, the next
    student triggers a single probe send. A success transitions
    back to CLOSED and logs the recovery. A failure re-opens the
    circuit and resets the timer.

  The existing _running flag (overlap lock) is unchanged and
  continues to prevent concurrent cron ticks.

  getReminderStatus() now also returns circuitState and
  consecutiveFailures for observability.