### PR TITLE
feat: add /metrics endpoint with Prometheus instrumentation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -102,6 +102,12 @@ STELLAR_NETWORK=testnet
 # Supported values: XLM (default), USDC
 ACCEPTED_ASSET=XLM
 
+# ── Metrics ──────────────────────────────────────────────────
+# Bearer token required to scrape GET /metrics.
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# Set the same value in Prometheus's bearer_token field (see docker-compose.monitoring.yml).
+METRICS_TOKEN=change_me_to_a_secure_random_token
+
 # ── Authentication ───────────────────────────────────────────
 # Secret key for signing admin JWTs — MUST be changed before deploying.
 # Generate a real value with:

--- a/backend/package.json
+++ b/backend/package.json
@@ -28,7 +28,8 @@
     "multer": "^1.4.5-lts.1",
     "node-cache": "^5.1.2",
     "helmet": "^7.1.0",
-    "nodemailer": "^6.9.0"
+    "nodemailer": "^6.9.0",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -19,6 +19,7 @@ const receiptsRoutes = require('./routes/receiptsRoutes');
 const feeAdjustmentRoutes = require('./routes/feeAdjustmentRoutes');
 const adminRoutes = require('./routes/adminRoutes');
 const authRoutes = require('./routes/authRoutes');
+const metricsRoute = require('./routes/metricsRoute');
 
 const { registerPaymentSavedSubscribers } = require('./services/paymentSavedSubscribers');
 const { startPolling, stopPolling } = require('./services/transactionPollingService');
@@ -73,6 +74,10 @@ const concurrentMiddleware = createConcurrentRequestMiddleware({
   rateLimit: { windowMs: 60000, maxRequests: 100 },
   deduplicationTtlMs: 60000,
 });
+// ── Metrics ───────────────────────────────────────────────────────────────────
+// Mounted before the rate-limiter so Prometheus scrapes are never throttled.
+app.use('/metrics', metricsRoute);
+
 app.use(concurrentMiddleware.rateLimiter((req) => req.ip));
 app.use(concurrentMiddleware.requestQueue());
 

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -37,6 +37,7 @@ const {
 } = require("../services/currencyConversionService");
 const { withStellarRetry } = require("../utils/withStellarRetry");
 const { logAudit } = require("../services/auditService");
+const { syncDurationSeconds } = require("../metrics");
 
 // Permanent error codes that should NOT be retried
 const PERMANENT_FAIL_CODES = [
@@ -743,8 +744,10 @@ async function syncAllPayments(req, res, next) {
     return res.status(409).json({ error: "Sync already in progress", code: "SYNC_IN_PROGRESS" });
   }
   _syncLocks.add(schoolId);
+  const stopSyncTimer = syncDurationSeconds.startTimer();
   try {
     const summary = await syncPaymentsForSchool(req.school);
+    stopSyncTimer();
 
     // Audit log
     if (req.auditContext) {
@@ -789,6 +792,7 @@ async function syncAllPayments(req, res, next) {
         userAgent: req.auditContext.userAgent,
       });
     }
+    stopSyncTimer();
     next(wrapStellarError(err));
   } finally {
     _syncLocks.delete(schoolId);

--- a/backend/src/metrics/index.js
+++ b/backend/src/metrics/index.js
@@ -1,0 +1,86 @@
+'use strict';
+
+const client = require('prom-client');
+
+const registry = new client.Registry();
+
+client.collectDefaultMetrics({ register: registry });
+
+// payments_total{status} — queried live from MongoDB on each scrape so the
+// count is accurate even after a process restart (counters would reset to 0).
+new client.Gauge({
+  name: 'payments_total',
+  help: 'Number of payments grouped by status',
+  labelNames: ['status'],
+  registers: [registry],
+  async collect() {
+    try {
+      const Payment = require('../models/paymentModel');
+      const counts = await Payment.aggregate([
+        { $match: { deletedAt: null } },
+        { $group: { _id: '$status', count: { $sum: 1 } } },
+      ]);
+      this.reset();
+      for (const { _id, count } of counts) {
+        this.set({ status: _id }, count);
+      }
+    } catch (_) {
+      // DB may not be ready yet — scrape still succeeds with stale/zero values
+    }
+  },
+});
+
+// sync_duration_seconds — recorded per manual sync operation in paymentController
+const syncDurationSeconds = new client.Histogram({
+  name: 'sync_duration_seconds',
+  help: 'Duration of payment sync operations in seconds',
+  buckets: [0.5, 1, 2, 5, 10, 30, 60, 120],
+  registers: [registry],
+});
+
+// queue_depth{queue} — queried live from BullMQ on each scrape.
+// Tracks actionable (non-completed) jobs: waiting + active + delayed.
+new client.Gauge({
+  name: 'queue_depth',
+  help: 'Number of actionable jobs in each BullMQ queue (waiting + active + delayed)',
+  labelNames: ['queue'],
+  registers: [registry],
+  async collect() {
+    try {
+      const { getQueueStats, getDLQStats } = require('../queue/transactionRetryQueue');
+      const [retryResult, dlqResult] = await Promise.allSettled([
+        getQueueStats(),
+        getDLQStats(),
+      ]);
+
+      this.reset();
+
+      if (retryResult.status === 'fulfilled' && retryResult.value?.metrics) {
+        const m = retryResult.value.metrics;
+        this.set(
+          { queue: 'transaction-retry' },
+          (m.waiting || 0) + (m.active || 0) + (m.delayed || 0)
+        );
+      }
+
+      if (dlqResult.status === 'fulfilled' && dlqResult.value?.enabled) {
+        const m = dlqResult.value.metrics;
+        this.set({ queue: 'transaction-dead-letter' }, m.waiting || 0);
+      }
+    } catch (_) {
+      // Redis may not be configured — scrape still succeeds
+    }
+  },
+});
+
+// http_request_duration_seconds{method,route,status} — recorded per request
+// in the requestLogger middleware, which already captures these fields.
+const httpRequestDurationSeconds = new client.Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request duration in seconds',
+  labelNames: ['method', 'route', 'status'],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5],
+  registers: [registry],
+});
+
+module.exports = { registry, syncDurationSeconds, httpRequestDurationSeconds };

--- a/backend/src/middleware/metricsAuth.js
+++ b/backend/src/middleware/metricsAuth.js
@@ -1,0 +1,39 @@
+'use strict';
+
+// Constant-time string comparison to prevent timing-based token enumeration.
+const { timingSafeEqual } = require('crypto');
+
+function safeCompare(a, b) {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) return false;
+  return timingSafeEqual(bufA, bufB);
+}
+
+function metricsAuth(req, res, next) {
+  const token = process.env.METRICS_TOKEN;
+  if (!token) {
+    return res.status(500).set('Content-Type', 'text/plain').send(
+      '# METRICS_TOKEN is not configured — metrics endpoint is disabled.\n'
+    );
+  }
+
+  const authHeader = req.headers['authorization'];
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.set('WWW-Authenticate', 'Bearer realm="metrics"');
+    return res.status(401).set('Content-Type', 'text/plain').send(
+      '# Unauthorized: provide Authorization: Bearer <METRICS_TOKEN>\n'
+    );
+  }
+
+  const provided = authHeader.slice(7);
+  if (!safeCompare(provided, token)) {
+    return res.status(403).set('Content-Type', 'text/plain').send(
+      '# Forbidden: invalid metrics token.\n'
+    );
+  }
+
+  next();
+}
+
+module.exports = { metricsAuth };

--- a/backend/src/middleware/requestLogger.js
+++ b/backend/src/middleware/requestLogger.js
@@ -19,6 +19,7 @@
  */
 
 const { logger } = require('../utils/logger');
+const { httpRequestDurationSeconds } = require('../metrics');
 
 const DEFAULT_REDACT_FIELDS = ['txHash', 'studentId', 'memo', 'senderAddress'];
 
@@ -90,6 +91,14 @@ function requestLogger() {
         durationMs,
         ip,
       });
+
+      // Normalise to the matched route pattern (e.g. /api/payments/:id) so high-cardinality
+      // path parameters don't explode the label set. Falls back to the raw path on 404s.
+      const route = req.route ? req.baseUrl + req.route.path : req.path;
+      httpRequestDurationSeconds.observe(
+        { method: req.method, route, status: String(res.statusCode) },
+        durationMs / 1000
+      );
     });
 
     next();

--- a/backend/src/routes/metricsRoute.js
+++ b/backend/src/routes/metricsRoute.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const express = require('express');
+const { registry } = require('../metrics');
+const { metricsAuth } = require('../middleware/metricsAuth');
+
+const router = express.Router();
+
+router.get('/', metricsAuth, async (req, res, next) => {
+  try {
+    const output = await registry.metrics();
+    res.set('Content-Type', registry.contentType);
+    res.end(output);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,56 @@
+version: "3.8"
+
+# Local development monitoring stack — Prometheus + Grafana.
+#
+# Usage:
+#   1. Set METRICS_TOKEN in backend/.env (generate with: openssl rand -hex 32)
+#   2. Copy that token into monitoring/prometheus.yml under authorization.credentials
+#   3. docker compose -f docker-compose.monitoring.yml up -d
+#
+# Prometheus: http://localhost:9090
+# Grafana:    http://localhost:3001  (admin / admin — change on first login)
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.51.2
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+      - "--web.enable-lifecycle"
+    ports:
+      - "9090:9090"
+    # Allows the container to reach the backend running on the Docker host.
+    # On Linux, host-gateway resolves to the host machine's IP so that
+    # host.docker.internal works the same as on Mac/Windows Docker Desktop.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana:10.4.3
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_SERVER_ROOT_URL: "http://localhost:3001"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus
+    networks:
+      - monitoring
+
+networks:
+  monitoring:
+    driver: bridge
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,16 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: stellaredupay
+    metrics_path: /metrics
+    # Replace this with the value of METRICS_TOKEN from backend/.env
+    authorization:
+      type: Bearer
+      credentials: "change_me_to_a_secure_random_token"
+    static_configs:
+      # host.docker.internal resolves to the Docker host on Mac/Windows.
+      # On Linux it is mapped to host-gateway via extra_hosts in docker-compose.monitoring.yml.
+      - targets:
+          - "host.docker.internal:5000"


### PR DESCRIPTION
## Summary

- Adds `GET /metrics` endpoint returning Prometheus text format via `prom-client`, protected by a `METRICS_TOKEN` Bearer token
- Exposes four key metrics: `payments_total{status}`, `sync_duration_seconds`, `queue_depth{queue}`, and `http_request_duration_seconds{method,route,status}`
- Adds `docker-compose.monitoring.yml` with Prometheus and Grafana for local observability

## Changes

| File | What changed |
|---|---|
| `backend/src/metrics/index.js` | New — prom-client registry; `payments_total` and `queue_depth` query MongoDB/BullMQ live on each scrape so values survive restarts |
| `backend/src/middleware/metricsAuth.js` | New — timing-safe `METRICS_TOKEN` Bearer check |
| `backend/src/routes/metricsRoute.js` | New — `GET /metrics` route |
| `backend/src/app.js` | Mounts `/metrics` before the rate-limiter so Prometheus scrapes are never throttled |
| `backend/src/controllers/paymentController.js` | Wraps `syncPaymentsForSchool` with `syncDurationSeconds.startTimer()` on both success and error paths |
| `backend/src/middleware/requestLogger.js` | Records `http_request_duration_seconds` in existing `res.on('finish')` handler; normalises to route pattern to prevent label cardinality explosion |
| `backend/.env.example` | Documents `METRICS_TOKEN` with generation command |
| `docker-compose.monitoring.yml` | Prometheus + Grafana stack; uses `host-gateway` extra_hosts for Linux compatibility |
| `monitoring/prometheus.yml` | Scrape config targeting `host.docker.internal:5000` with bearer auth |
| `monitoring/grafana/provisioning/datasources/prometheus.yml` | Auto-provisions Prometheus as Grafana default datasource |

## Test plan

- [ ] `cd backend && npm install` picks up `prom-client`
- [ ] Set `METRICS_TOKEN=<random>` in `backend/.env`
- [ ] `GET /metrics` without a token returns `401`
- [ ] `GET /metrics` with a wrong token returns `403`
- [ ] `GET /metrics` with the correct `METRICS_TOKEN` returns `200` with `Content-Type: text/plain; version=0.0.4`
- [ ] Response includes `payments_total`, `sync_duration_seconds`, `queue_depth`, and `http_request_duration_seconds` metric families
- [ ] After triggering `POST /api/payments/sync`, `sync_duration_seconds_count` increments
- [ ] `docker compose -f docker-compose.monitoring.yml up -d` starts Prometheus (`:9090`) and Grafana (`:3001`)
- [ ] Prometheus target `stellaredupay` shows **UP** after setting the token in `monitoring/prometheus.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #661 