### PR TITLE
fix(#624,#625): add log rotation and skip reminders for paid students

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ node_modules/
 .env
 .env.local
 *.log
+logs/
 .next/
 dist/

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -16,6 +16,12 @@ MONGO_ROOT_PASSWORD=change_me_to_a_secure_password
 # Valid values: error | warn | info | debug (default: info)
 LOG_LEVEL=info
 
+# Maximum size of each rotating log file before rotation (default: 100m)
+LOG_MAX_SIZE=100m
+
+# Maximum age / number of rotated log files to keep (default: 14d)
+LOG_MAX_FILES=14d
+
 # ── Database Connection Pool ─────────────────────────────────────────────────
 # Maximum number of sockets in the connection pool (default: 20).
 # MONGODB_POOL_SIZE is the canonical variable; DB_MAX_POOL_SIZE is also accepted.

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -27,7 +27,9 @@
         "morgan": "^1.10.1",
         "multer": "^1.4.5-lts.1",
         "node-cache": "^5.1.2",
-        "nodemailer": "^6.9.0"
+        "nodemailer": "^6.9.0",
+        "winston": "3.19.0",
+        "winston-daily-rotate-file": "5.0.0"
       },
       "devDependencies": {
         "eslint": "^7.32.0",
@@ -667,6 +669,26 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.3",
@@ -1366,6 +1388,16 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@stellar/js-xdr": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@stellar/js-xdr/-/js-xdr-3.1.2.tgz",
@@ -1507,6 +1539,12 @@
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
       "license": "MIT"
     },
     "node_modules/@types/webidl-conversions": {
@@ -1810,6 +1848,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -2587,6 +2631,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2606,6 +2663,48 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -3091,6 +3190,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -4887,6 +4992,12 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -4921,6 +5032,15 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/file-stream-rotator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz",
+      "integrity": "sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "moment": "^2.29.1"
       }
     },
     "node_modules/fill-range": {
@@ -4987,6 +5107,12 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
@@ -6055,7 +6181,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7042,6 +7167,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7156,6 +7287,29 @@
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
       "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
+    },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -7343,6 +7497,15 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mongodb": {
@@ -7727,6 +7890,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -7847,6 +8019,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/onetime": {
@@ -8605,6 +8786,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -8974,6 +9164,15 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -9383,6 +9582,12 @@
         "node": "*"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -9482,6 +9687,15 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/tsconfig-paths": {
@@ -9939,6 +10153,88 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-daily-rotate-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/winston-daily-rotate-file/-/winston-daily-rotate-file-5.0.0.tgz",
+      "integrity": "sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==",
+      "license": "MIT",
+      "dependencies": {
+        "file-stream-rotator": "^0.6.1",
+        "object-hash": "^3.0.0",
+        "triple-beam": "^1.4.1",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "winston": "^3"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/word-wrap": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,7 +29,9 @@
     "morgan": "^1.10.1",
     "multer": "^1.4.5-lts.1",
     "node-cache": "^5.1.2",
-    "nodemailer": "^6.9.0"
+    "nodemailer": "^6.9.0",
+    "winston": "3.19.0",
+    "winston-daily-rotate-file": "5.0.0"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/backend/src/services/reminderService.js
+++ b/backend/src/services/reminderService.js
@@ -15,6 +15,7 @@
 
 const Student = require('../models/studentModel');
 const School  = require('../models/schoolModel');
+const Payment = require('../models/paymentModel');
 const { sendFeeReminder, verifySmtp } = require('./notificationService');
 const config = require('../config');
 const logger = require('../utils/logger').child('ReminderService');
@@ -121,13 +122,27 @@ async function processReminders() {
       summary.eligible++;
 
       try {
+        // Fresh balance check — skip if student has actually paid in full
+        const paymentAgg = await Payment.aggregate([
+          { $match: { schoolId: school.schoolId, studentId: student.studentId, deletedAt: null } },
+          { $group: { _id: null, totalPaid: { $sum: '$amount' } } },
+        ]);
+        const totalPaid = paymentAgg.length ? paymentAgg[0].totalPaid : 0;
+        const remainingBalance = Math.max(0, (student.feeAmount || 0) - totalPaid);
+
+        if (remainingBalance <= 0) {
+          summary.skipped++;
+          logger.debug('Skipping reminder — already paid', { studentId: student.studentId, schoolId: school.schoolId });
+          continue;
+        }
+
         const result = await sendFeeReminder({
           to:               student.parentEmail,
           studentName:      student.name,
           studentId:        student.studentId,
           className:        student.class,
           feeAmount:        student.feeAmount,
-          remainingBalance: student.remainingBalance,
+          remainingBalance,
           schoolName:       school.name,
           reminderCount:    (student.reminderCount || 0) + 1,
         });

--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -5,7 +5,43 @@
  *
  * Provides consistent logging with levels, timestamps, and context.
  * Supports runtime log level changes via setLevel() — no server restart needed.
+ *
+ * File transports use DailyRotateFile (winston-daily-rotate-file):
+ *   - logs/combined-%DATE%.log  — all levels
+ *   - logs/error-%DATE%.log     — errors only
+ * Rotation is controlled by LOG_MAX_SIZE (default: 100m) and
+ * LOG_MAX_FILES (default: 14d) environment variables.
  */
+
+const winston = require('winston');
+require('winston-daily-rotate-file');
+
+const _fileTransports = [
+  new winston.transports.DailyRotateFile({
+    filename:    'logs/combined-%DATE%.log',
+    datePattern: 'YYYY-MM-DD',
+    maxSize:     process.env.LOG_MAX_SIZE  || '100m',
+    maxFiles:    process.env.LOG_MAX_FILES || '14d',
+  }),
+  new winston.transports.DailyRotateFile({
+    filename:    'logs/error-%DATE%.log',
+    datePattern: 'YYYY-MM-DD',
+    level:       'error',
+    maxSize:     process.env.LOG_MAX_SIZE  || '100m',
+    maxFiles:    process.env.LOG_MAX_FILES || '14d',
+  }),
+];
+
+// Winston instance used solely for file rotation; console output is handled
+// by the existing structured logger below so the log format stays unchanged.
+const _winstonLogger = winston.createLogger({
+  level: 'debug',
+  format: winston.format.combine(
+    winston.format.timestamp(),
+    winston.format.json(),
+  ),
+  transports: _fileTransports,
+});
 
 const LOG_LEVELS = {
   ERROR: 0,
@@ -68,25 +104,33 @@ function formatMessage(level, message, ...args) {
 const logger = {
   error(message, ...args) {
     if (shouldLog('ERROR')) {
-      console.error(JSON.stringify(formatMessage('ERROR', message, ...args)));
+      const entry = formatMessage('ERROR', message, ...args);
+      console.error(JSON.stringify(entry));
+      _winstonLogger.error(message, entry);
     }
   },
 
   warn(message, ...args) {
     if (shouldLog('WARN')) {
-      console.warn(JSON.stringify(formatMessage('WARN', message, ...args)));
+      const entry = formatMessage('WARN', message, ...args);
+      console.warn(JSON.stringify(entry));
+      _winstonLogger.warn(message, entry);
     }
   },
 
   info(message, ...args) {
     if (shouldLog('INFO')) {
-      console.log(JSON.stringify(formatMessage('INFO', message, ...args)));
+      const entry = formatMessage('INFO', message, ...args);
+      console.log(JSON.stringify(entry));
+      _winstonLogger.info(message, entry);
     }
   },
 
   debug(message, ...args) {
     if (shouldLog('DEBUG')) {
-      console.log(JSON.stringify(formatMessage('DEBUG', message, ...args)));
+      const entry = formatMessage('DEBUG', message, ...args);
+      console.log(JSON.stringify(entry));
+      _winstonLogger.debug(message, entry);
     }
   },
 

--- a/tests/reminderService.test.js
+++ b/tests/reminderService.test.js
@@ -21,6 +21,7 @@ const mockSendMail = jest.fn();
 const mockFindByIdAndUpdate = jest.fn();
 const mockStudentFind = jest.fn();
 const mockSchoolFind = jest.fn();
+const mockPaymentAggregate = jest.fn();
 
 jest.mock('nodemailer', () => ({
   createTransport: jest.fn(() => ({
@@ -36,6 +37,10 @@ jest.mock('../backend/src/models/studentModel', () => ({
 
 jest.mock('../backend/src/models/schoolModel', () => ({
   find: mockSchoolFind,
+}));
+
+jest.mock('../backend/src/models/paymentModel', () => ({
+  aggregate: mockPaymentAggregate,
 }));
 
 jest.mock('../backend/src/utils/logger', () => {
@@ -75,6 +80,7 @@ describe('reminderService — SMTP verification', () => {
     mockFindByIdAndUpdate.mockReset();
     mockStudentFind.mockReset();
     mockSchoolFind.mockReset();
+    mockPaymentAggregate.mockReset();
   });
 
   test('aborts run and does not mutate students when SMTP verify fails', async () => {
@@ -94,6 +100,8 @@ describe('reminderService — SMTP verification', () => {
     mockVerify.mockResolvedValue(true);
     mockSchoolFind.mockReturnValue({ lean: () => Promise.resolve([SCHOOL]) });
     mockStudentFind.mockResolvedValue([makeStudent()]);
+    // Student has unpaid balance
+    mockPaymentAggregate.mockResolvedValue([{ totalPaid: 0 }]);
     mockSendMail.mockRejectedValue(new Error('connection refused'));
 
     const { processReminders } = require('../backend/src/services/reminderService');
@@ -108,6 +116,8 @@ describe('reminderService — SMTP verification', () => {
     mockVerify.mockResolvedValue(true);
     mockSchoolFind.mockReturnValue({ lean: () => Promise.resolve([SCHOOL]) });
     mockStudentFind.mockResolvedValue([makeStudent()]);
+    // Student has unpaid balance
+    mockPaymentAggregate.mockResolvedValue([{ totalPaid: 0 }]);
     mockSendMail.mockResolvedValue({ messageId: 'msg-123' });
     mockFindByIdAndUpdate.mockResolvedValue({});
 
@@ -136,5 +146,51 @@ describe('getReminderStatus', () => {
     expect(status).toHaveProperty('schedulerRunning');
     expect(status).toHaveProperty('lastRunAt');
     expect(status).toHaveProperty('lastRunSummary');
+  });
+});
+
+// ── Issue #625: skip reminders for already-paid students ──────────────────────
+
+describe('reminderService — balance check (issue #625)', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockVerify.mockReset();
+    mockSendMail.mockReset();
+    mockFindByIdAndUpdate.mockReset();
+    mockStudentFind.mockReset();
+    mockSchoolFind.mockReset();
+    mockPaymentAggregate.mockReset();
+  });
+
+  test('skips reminder when feePaid is false but remainingBalance === 0', async () => {
+    mockVerify.mockResolvedValue(true);
+    mockSchoolFind.mockReturnValue({ lean: () => Promise.resolve([SCHOOL]) });
+    // feePaid: false but totalPaid equals feeAmount
+    mockStudentFind.mockResolvedValue([makeStudent({ feeAmount: 250, feePaid: false })]);
+    mockPaymentAggregate.mockResolvedValue([{ totalPaid: 250 }]);
+
+    const { processReminders } = require('../backend/src/services/reminderService');
+    const summary = await processReminders();
+
+    expect(summary.sent).toBe(0);
+    expect(summary.skipped).toBeGreaterThanOrEqual(1);
+    expect(mockSendMail).not.toHaveBeenCalled();
+    expect(mockFindByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  test('sends reminder when feePaid is false and remainingBalance > 0', async () => {
+    mockVerify.mockResolvedValue(true);
+    mockSchoolFind.mockReturnValue({ lean: () => Promise.resolve([SCHOOL]) });
+    mockStudentFind.mockResolvedValue([makeStudent({ feeAmount: 250, feePaid: false })]);
+    // Only partial payment made
+    mockPaymentAggregate.mockResolvedValue([{ totalPaid: 100 }]);
+    mockSendMail.mockResolvedValue({ messageId: 'msg-456' });
+    mockFindByIdAndUpdate.mockResolvedValue({});
+
+    const { processReminders } = require('../backend/src/services/reminderService');
+    const summary = await processReminders();
+
+    expect(summary.sent).toBe(1);
+    expect(mockSendMail).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

Fixes two issues in a single PR.

### Closes #624 — Log rotation not configured

- Installed `winston@3.19.0` and `winston-daily-rotate-file@5.0.0` (exact versions)
- Added two `DailyRotateFile` transports to `logger.js`:
  - `logs/combined-%DATE%.log` — all levels
  - `logs/error-%DATE%.log` — errors only
  - Both use `datePattern: 'YYYY-MM-DD'`, `maxSize` from `LOG_MAX_SIZE` env (default `100m`), `maxFiles` from `LOG_MAX_FILES` env (default `14d`)
- Console output is unchanged; file transports are additive
- Added `LOG_MAX_SIZE=100m` and `LOG_MAX_FILES=14d` to `backend/.env.example`
- Added `logs/` to `.gitignore`

### Closes #625 — Reminder service sends reminders to already-paid students

- Added `Payment` model import to `reminderService.js`
- Before calling `sendFeeReminder`, runs a fresh `Payment.aggregate` to compute `totalPaid` from the payments collection
- If `remainingBalance <= 0`, increments `summary.skipped` and skips the reminder — regardless of the stale `feePaid` flag
- Passes the freshly computed `remainingBalance` to `sendFeeReminder`
- Added unit tests:
  - Student with `feePaid: false` but `totalPaid === feeAmount` → reminder skipped
  - Student with `feePaid: false` and partial payment → reminder sent

## Testing

```
npx jest --testPathPattern=tests/reminderService.test.js --forceExit
# 6 tests passed
```