### PR TITLE
fix(#666): add redactConfig utility to prevent secrets in logs

### DIFF
--- a/backend/src/utils/logger.js
+++ b/backend/src/utils/logger.js
@@ -150,7 +150,11 @@ const logger = {
   getLevel,
 };
 
+const { redactConfig, SENSITIVE_KEYS } = require('./redactConfig');
+
 module.exports = logger;
 module.exports.logger = logger;
 module.exports.setLevel = setLevel;
 module.exports.getLevel = getLevel;
+module.exports.redactConfig = redactConfig;
+module.exports.SENSITIVE_KEYS = SENSITIVE_KEYS;

--- a/backend/src/utils/redactConfig.js
+++ b/backend/src/utils/redactConfig.js
@@ -1,0 +1,41 @@
+'use strict';
+
+/**
+ * Redact sensitive fields from a config-like object before logging.
+ * Any key matching SENSITIVE_KEYS is replaced with '[REDACTED]'.
+ *
+ * This module has no external dependencies so it can be required in tests
+ * without mocking winston or any other backend-only package.
+ */
+
+const SENSITIVE_KEYS = new Set([
+  'JWT_SECRET',
+  'MEMO_ENCRYPTION_KEY',
+  'WEBHOOK_SECRET',
+  'MONGO_URI',
+  'MONGODB_URI',
+  'SMTP_PASS',
+  'REDIS_PASSWORD',
+]);
+
+/**
+ * Return a shallow copy of `cfg` with sensitive values replaced by '[REDACTED]'.
+ * Non-object inputs are returned unchanged.
+ *
+ * @param {object} cfg
+ * @returns {object}
+ */
+function redactConfig(cfg) {
+  if (!cfg || typeof cfg !== 'object') return cfg;
+  const safe = {};
+  for (const [key, value] of Object.entries(cfg)) {
+    if (SENSITIVE_KEYS.has(key)) {
+      safe[key] = value !== undefined ? '[REDACTED]' : undefined;
+    } else {
+      safe[key] = value;
+    }
+  }
+  return safe;
+}
+
+module.exports = { redactConfig, SENSITIVE_KEYS };


### PR DESCRIPTION
- Extract redactConfig() and SENSITIVE_KEYS into standalone backend/src/utils/redactConfig.js (no external deps)
- Re-export from logger.js so callers use require('./utils/logger')
- Redacts JWT_SECRET, MEMO_ENCRYPTION_KEY, WEBHOOK_SECRET, MONGO_URI, MONGODB_URI, SMTP_PASS, REDIS_PASSWORD

pr close #666 