### PR TITLE
fix: correct duplicate payment check and scope student lookup by scho…

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -468,6 +468,7 @@ async function verifyPayment(req, res, next) {
       result = await verifyTransaction(
         normalizedHash,
         req.school.stellarAddress,
+        req.schoolId,
       );
     } catch (stellarErr) {
       if (PERMANENT_FAIL_CODES.includes(stellarErr.code)) {

--- a/backend/src/services/retryService.js
+++ b/backend/src/services/retryService.js
@@ -124,6 +124,7 @@ async function processPendingVerifications() {
         const result = await verifyTransaction(
           item.txHash,
           school.stellarAddress,
+          item.schoolId,
         );
 
         if (!result) {

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -240,7 +240,7 @@ async function detectAbnormalPatterns(
  *   UNSUPPORTED_ASSET (400)   — asset not accepted
  *   AMOUNT_TOO_LOW/HIGH (400) — outside configured limits
  */
-async function verifyTransaction(txHash, walletAddress) {
+async function verifyTransaction(txHash, walletAddress, schoolId) {
   const tx = await withStellarRetry(
     () => server.transactions().transaction(txHash).call(),
     { label: "verifyTransaction" },
@@ -323,9 +323,8 @@ async function verifyTransaction(txHash, walletAddress) {
     throw err;
   }
 
-  // 6. Look up student to validate fee (student lookup is not school-scoped here
-  //    since memo = studentId; recordPayment caller passes schoolId explicitly)
-  const student = await Student.findOne({ studentId: memo });
+  // 6. Look up student to validate fee — scoped by schoolId to prevent cross-school data leakage
+  const student = await Student.findOne({ schoolId, studentId: memo });
   const feeAmount = student ? student.feeAmount : null;
 
   const feeValidation =

--- a/backend/src/services/transactionService.js
+++ b/backend/src/services/transactionService.js
@@ -11,13 +11,15 @@ const paymentEvents = require("../events/paymentEvents");
  * data must include schoolId.
  */
 async function savePayment(data) {
+  const lookupHash = data.txHash || data.transactionHash;
   const exists = await Payment.findOne({
-    transactionHash: data.transactionHash,
+    schoolId: data.schoolId,
+    txHash: lookupHash,
     deletedAt: null,
   });
   if (exists) {
     const err = new Error(
-      `Transaction ${data.transactionHash} has already been processed`,
+      `Transaction ${lookupHash} has already been processed`,
     );
     err.code = "DUPLICATE_TX";
     throw err;
@@ -32,18 +34,18 @@ async function savePayment(data) {
   } catch (e) {
     if (e.code === 11000) {
       const err = new Error(
-        `Transaction ${data.transactionHash} has already been processed`,
+        `Transaction ${lookupHash} has already been processed`,
       );
       err.code = "DUPLICATE_TX";
       logger.warn("Duplicate transaction rejected", {
-        txHash: data.transactionHash,
+        txHash: lookupHash,
         schoolId: data.schoolId,
       });
       throw err;
     }
     logger.error("Failed to record payment", {
       error: e.message,
-      txHash: data.transactionHash,
+      txHash: lookupHash,
       schoolId: data.schoolId,
     });
     throw e;


### PR DESCRIPTION


--- Issue #732: savePayment checks wrong field for duplicate detection ---

Root cause:
  savePayment() in transactionService.js was querying Payment.findOne()
  against the 'transactionHash' field. However, the verify flow stores
  payments with the field name 'txHash', and the unique compound index on
  the Payment model is { schoolId, txHash }. Because data.transactionHash
  is undefined in the verify flow, the findOne() always returned null,
  making the pre-insert duplicate guard completely inert. Only the MongoDB
  unique index caught duplicates, and only if the E11000 error arrived in
  the exact shape expected — otherwise it fell through to a generic 500.

Fix applied (backend/src/services/transactionService.js):
  - Introduced lookupHash = data.txHash || data.transactionHash so the guard works for both the verify flow (txHash) and the XDR submission flow (transactionHash).
  - Scoped the findOne() query by schoolId to match the unique index: Payment.findOne({ schoolId: data.schoolId, txHash: lookupHash })
  - Updated both the pre-insert error message and the E11000 catch block to reference lookupHash instead of data.transactionHash, so log output is always meaningful.

Closes #732

--- Issue #733: verifyTransaction performs student lookup without school scope ---

Root cause:
  verifyTransaction() in stellarService.js called
      Student.findOne({ studentId: memo })
  with no schoolId filter. In a multi-school deployment where two schools
  share a MongoDB instance and both have a student with the same studentId
  (e.g. 'STU001'), MongoDB returns whichever document it finds first. This
  means:
    1. Fee validation is non-deterministic — the wrong school's fee amount may be used, causing a valid payment to be accepted or rejected incorrectly.
    2. A parent can send 50 XLM to School A's wallet with memo STU001, and if School B's STU001 has feeAmount 50, the payment is recorded as valid for School A even though School A's STU001 owed 500 XLM. The sync path (syncPaymentsForSchool) already scoped its lookup correctly with { schoolId, studentId }, creating an inconsistency between the two code paths.

Fix applied across three files:

  backend/src/services/stellarService.js
    - Added schoolId as the third parameter to verifyTransaction(): async function verifyTransaction(txHash, walletAddress, schoolId)
    - Changed the student lookup to: Student.findOne({ schoolId, studentId: memo })
    - Updated the comment to reflect the intentional school-scoping.

  backend/src/controllers/paymentController.js
    - Updated the verifyTransaction() call in verifyPayment() to pass req.schoolId as the third argument: await verifyTransaction(normalizedHash, req.school.stellarAddress, req.schoolId)

  backend/src/services/retryService.js
    - Updated the verifyTransaction() call in processPendingVerifications() to pass item.schoolId as the third argument: await verifyTransaction(item.txHash, school.stellarAddress, item.schoolId) item.schoolId is already stored on the PendingVerification document when queueForRetry() is called, so no schema changes are needed.

