### PR TITLE
feat: scale SSE fan-out across replicas via Redis pub/sub

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -205,6 +205,14 @@ REDIS_HOST=localhost           # Required for durable job queues (BullMQ) and di
 REDIS_PORT=6379               # Redis port (default: 6379)
 REDIS_PASSWORD=               # Leave empty if Redis has no password
 
+# ── Server-Sent Events (real-time payment updates) ──────────────
+#   When REDIS_HOST is set, SSE emits are fanned out across all replicas via a
+#   Redis pub/sub channel (sse:<schoolId>) so an event confirmed on one replica
+#   reaches clients connected to any other. Without REDIS_HOST, SSE runs in
+#   single-process mode (correct for a single replica only).
+SSE_HEARTBEAT_MS=15000              # Keepalive comment interval per connection (default: 15s)
+SSE_MAX_CONNECTIONS_PER_SCHOOL=100  # Per-school connection cap to avoid fd exhaustion (default: 100)
+
 # Maximum retry attempts for failed transactions (default: 10)
 MAX_RETRY_ATTEMPTS=10
 

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -243,6 +243,7 @@ async function shutdown(signal) {
     await stopTxQueueWorker();
     await closeQueue();
     await bullMQRetryService.shutdownQueue();
+    await require('./services/sseService').close();
     logger.info('BullMQ resources closed cleanly');
   } catch (err) {
     logger.error('Error closing BullMQ resources during shutdown', { error: err.message });

--- a/backend/src/controllers/paymentAdminController.js
+++ b/backend/src/controllers/paymentAdminController.js
@@ -313,11 +313,15 @@ function streamPaymentEvents(req, res) {
   res.setHeader('Connection', 'keep-alive');
   res.flushHeaders();
 
-  const ping = setInterval(() => res.write(': ping\n\n'), 30000);
-  addClient(schoolId, res);
+  // addClient owns the per-connection heartbeat and enforces the per-school
+  // connection cap. A false return means the cap is reached — reject cleanly.
+  if (!addClient(schoolId, res)) {
+    res.write('event: error\ndata: {"error":"too_many_connections"}\n\n');
+    res.end();
+    return;
+  }
 
   req.on('close', () => {
-    clearInterval(ping);
     removeClient(schoolId, res);
   });
 }

--- a/backend/src/metrics/index.js
+++ b/backend/src/metrics/index.js
@@ -73,6 +73,36 @@ new client.Gauge({
   },
 });
 
+// sse_connected_clients / sse_active_schools — current SSE fan-out registry
+// size on this replica, read live from the SSE service on each scrape.
+new client.Gauge({
+  name: 'sse_connected_clients',
+  help: 'Number of currently connected SSE clients on this replica',
+  registers: [registry],
+  collect() {
+    try {
+      const { connections } = require('../services/sseService').getStats();
+      this.set(connections);
+    } catch (_) {
+      // SSE service not loaded — scrape still succeeds
+    }
+  },
+});
+
+new client.Gauge({
+  name: 'sse_active_schools',
+  help: 'Number of schools with at least one connected SSE client on this replica',
+  registers: [registry],
+  collect() {
+    try {
+      const { schools } = require('../services/sseService').getStats();
+      this.set(schools);
+    } catch (_) {
+      // SSE service not loaded — scrape still succeeds
+    }
+  },
+});
+
 // http_request_duration_seconds{method,route,status} — recorded per request
 // in the requestLogger middleware, which already captures these fields.
 const httpRequestDurationSeconds = new client.Histogram({

--- a/backend/src/services/sseService.js
+++ b/backend/src/services/sseService.js
@@ -1,22 +1,156 @@
 'use strict';
 
-// Map of schoolId -> Set of SSE response objects
+/**
+ * Server-Sent Events fan-out service.
+ *
+ * Each replica keeps a process-local registry of connected `res` objects
+ * (schoolId -> Set<res>). To make delivery correct across horizontally-scaled
+ * replicas (Docker compose / PM2 cluster), emits are routed through a Redis
+ * pub/sub channel `sse:<schoolId>`:
+ *
+ *   emit()  -> PUBLISH sse:<schoolId>                 (any replica)
+ *   each replica's subscriber receives the message -> fans out to its own
+ *   locally-connected clients for that school.
+ *
+ * A replica only subscribes to a school's channel while it holds at least one
+ * local connection for that school, and unsubscribes when the last one closes.
+ *
+ * When REDIS_HOST is not configured the service degrades to single-process
+ * mode: emit() fans out locally and cross-replica delivery is unavailable
+ * (correct for a single replica).
+ */
+
+const Redis = require('ioredis');
+const logger = require('../utils/logger').child('SSEService');
+
+// Map of schoolId -> Set of SSE response objects (process-local)
 const clients = new Map();
 
+const CHANNEL_PREFIX = 'sse:';
+const HEARTBEAT_MS = parseInt(process.env.SSE_HEARTBEAT_MS, 10) || 15000;
+const MAX_CONNECTIONS_PER_SCHOOL =
+  parseInt(process.env.SSE_MAX_CONNECTIONS_PER_SCHOOL, 10) || 100;
+
+// ── Redis pub/sub ───────────────────────────────────────────────────────────
+// Only enabled when REDIS_HOST is set (mirrors the BullMQ/rate-limit backend
+// selection). Two dedicated connections are required: a subscriber connection
+// cannot issue regular commands such as PUBLISH.
+const redisEnabled = Boolean(process.env.REDIS_HOST);
+
+const redisConfig = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+  password: process.env.REDIS_PASSWORD || undefined,
+  lazyConnect: true,
+  maxRetriesPerRequest: null,
+  enableOfflineQueue: false,
+};
+
+let publisher = null;
+let subscriber = null;
+
+if (redisEnabled) {
+  publisher = new Redis(redisConfig);
+  subscriber = new Redis(redisConfig);
+
+  for (const [name, conn] of [['publisher', publisher], ['subscriber', subscriber]]) {
+    conn.on('error', (err) => logger.error(`Redis ${name} error`, { error: err.message }));
+    conn.connect().catch((err) =>
+      logger.error(`Redis ${name} connect failed`, { error: err.message })
+    );
+  }
+
+  subscriber.on('message', (channel, message) => {
+    if (!channel.startsWith(CHANNEL_PREFIX)) return;
+    const schoolId = channel.slice(CHANNEL_PREFIX.length);
+    try {
+      const { event, data } = JSON.parse(message);
+      fanout(schoolId, event, data);
+    } catch (err) {
+      logger.error('Failed to handle SSE pub/sub message', { error: err.message, channel });
+    }
+  });
+}
+
+function subscribeSchool(schoolId) {
+  if (!subscriber) return;
+  subscriber
+    .subscribe(`${CHANNEL_PREFIX}${schoolId}`)
+    .catch((err) => logger.error('SSE subscribe failed', { error: err.message, schoolId }));
+}
+
+function unsubscribeSchool(schoolId) {
+  if (!subscriber) return;
+  subscriber
+    .unsubscribe(`${CHANNEL_PREFIX}${schoolId}`)
+    .catch((err) => logger.error('SSE unsubscribe failed', { error: err.message, schoolId }));
+}
+
+// ── Connection registry ──────────────────────────────────────────────────────
+
+/**
+ * Register a connected SSE client.
+ *
+ * Enforces SSE_MAX_CONNECTIONS_PER_SCHOOL to prevent file-descriptor
+ * exhaustion. Starts a per-connection heartbeat so idle proxies don't drop
+ * the connection.
+ *
+ * @returns {boolean} false if the per-school connection cap is reached and the
+ *                    caller should reject the connection.
+ */
 function addClient(schoolId, res) {
-  if (!clients.has(schoolId)) clients.set(schoolId, new Set());
-  clients.get(schoolId).add(res);
-  res.on('close', () => removeClient(schoolId, res));
+  let set = clients.get(schoolId);
+
+  if (set && set.size >= MAX_CONNECTIONS_PER_SCHOOL) {
+    logger.warn('SSE connection rejected — per-school cap reached', {
+      schoolId,
+      cap: MAX_CONNECTIONS_PER_SCHOOL,
+    });
+    return false;
+  }
+
+  if (!set) {
+    set = new Set();
+    clients.set(schoolId, set);
+    subscribeSchool(schoolId);
+  }
+  set.add(res);
+
+  // Per-connection heartbeat: a comment line keeps idle connections (and the
+  // proxies in front of them) alive without producing a client-visible event.
+  res._sseHeartbeat = setInterval(() => {
+    try {
+      res.write(': ping\n\n');
+    } catch {
+      removeClient(schoolId, res);
+    }
+  }, HEARTBEAT_MS);
+  if (typeof res._sseHeartbeat.unref === 'function') res._sseHeartbeat.unref();
+
+  return true;
 }
 
 function removeClient(schoolId, res) {
+  if (res._sseHeartbeat) {
+    clearInterval(res._sseHeartbeat);
+    res._sseHeartbeat = null;
+  }
+
   const set = clients.get(schoolId);
   if (!set) return;
   set.delete(res);
-  if (set.size === 0) clients.delete(schoolId);
+  if (set.size === 0) {
+    clients.delete(schoolId);
+    unsubscribeSchool(schoolId);
+  }
 }
 
-function emit(schoolId, event, data) {
+/**
+ * Write an event to every locally-connected client for a school.
+ * Invoked directly in single-process mode, and by the Redis subscriber
+ * callback when running multi-replica.
+ */
+function fanout(schoolId, event, data) {
   const set = clients.get(schoolId);
   if (!set || set.size === 0) return;
   const payload = `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
@@ -29,4 +163,59 @@ function emit(schoolId, event, data) {
   }
 }
 
-module.exports = { addClient, removeClient, emit };
+/**
+ * Emit an event to all SSE clients for a school, across every replica.
+ *
+ * With Redis enabled the event is published and every replica (including this
+ * one) fans out via its subscriber — so we must NOT also fan out locally here,
+ * or this replica would deliver twice.
+ */
+function emit(schoolId, event, data) {
+  if (publisher) {
+    publisher
+      .publish(`${CHANNEL_PREFIX}${schoolId}`, JSON.stringify({ event, data }))
+      .catch((err) => {
+        // Best-effort fallback so a transient publish failure still reaches
+        // clients on this replica.
+        logger.error('SSE publish failed — falling back to local fanout', {
+          error: err.message,
+          schoolId,
+        });
+        fanout(schoolId, event, data);
+      });
+    return;
+  }
+  fanout(schoolId, event, data);
+}
+
+/**
+ * Current connection counts for /metrics.
+ */
+function getStats() {
+  let connections = 0;
+  for (const set of clients.values()) connections += set.size;
+  return { schools: clients.size, connections };
+}
+
+/**
+ * Close Redis connections during graceful shutdown.
+ */
+async function close() {
+  try {
+    if (subscriber) await subscriber.quit();
+    if (publisher) await publisher.quit();
+  } catch (err) {
+    logger.error('Error closing SSE Redis connections', { error: err.message });
+  }
+}
+
+module.exports = {
+  addClient,
+  removeClient,
+  emit,
+  getStats,
+  close,
+  MAX_CONNECTIONS_PER_SCHOOL,
+  // Exposed for testing
+  _fanout: fanout,
+};

--- a/backend/tests/sseService.test.js
+++ b/backend/tests/sseService.test.js
@@ -1,0 +1,200 @@
+'use strict';
+
+/**
+ * Tests for the SSE fan-out service.
+ *
+ * Covers the horizontal-scaling guarantee (an emit on one replica reaches a
+ * client connected to another), the per-connection heartbeat, the per-school
+ * connection cap, and connection cleanup / metrics counting.
+ *
+ * ioredis is mocked with an in-process pub/sub bus shared across all client
+ * instances, so two isolated module loads behave like two replicas talking to
+ * the same Redis.
+ */
+
+const EventEmitter = require('events');
+
+// Shared bus across all mocked Redis instances. The `mock` prefix lets the
+// jest.mock factory (hoisted above imports) reference it.
+const mockBus = new EventEmitter();
+mockBus.setMaxListeners(0);
+
+jest.mock('ioredis', () => {
+  const NodeEventEmitter = require('events');
+  return class MockRedis extends NodeEventEmitter {
+    constructor() {
+      super();
+      this._channels = new Set();
+      this._onPublish = (channel, message) => {
+        if (this._channels.has(channel)) this.emit('message', channel, message);
+      };
+      mockBus.on('publish', this._onPublish);
+    }
+    connect() { return Promise.resolve(); }
+    async subscribe(ch) { this._channels.add(ch); }
+    async unsubscribe(ch) { this._channels.delete(ch); }
+    async publish(ch, msg) { mockBus.emit('publish', ch, msg); return 1; }
+    async quit() { mockBus.off('publish', this._onPublish); return 'OK'; }
+  };
+});
+
+function loadReplica() {
+  let mod;
+  jest.isolateModules(() => {
+    mod = require('../src/services/sseService');
+  });
+  return mod;
+}
+
+function mockRes() {
+  return { write: jest.fn(), end: jest.fn() };
+}
+
+// Let the publish->message->fanout chain settle (publish().catch is async).
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('sseService', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.useRealTimers();
+    mockBus.removeAllListeners('publish');
+  });
+
+  describe('cross-replica delivery (Redis pub/sub)', () => {
+    beforeEach(() => {
+      process.env.REDIS_HOST = 'localhost';
+    });
+
+    it('delivers an event emitted on replica A to a client on replica B', async () => {
+      const replicaA = loadReplica();
+      const replicaB = loadReplica();
+
+      const resA = mockRes();
+      const resB = mockRes();
+      expect(replicaA.addClient('school-1', resA)).toBe(true);
+      expect(replicaB.addClient('school-1', resB)).toBe(true);
+
+      replicaA.emit('school-1', 'payment', { txHash: 'abc', amount: 10 });
+      await flush();
+
+      const expected = `event: payment\ndata: ${JSON.stringify({ txHash: 'abc', amount: 10 })}\n\n`;
+      expect(resB.write).toHaveBeenCalledWith(expected);
+      // Delivered exactly once on the emitting replica too — no double fan-out.
+      expect(resA.write).toHaveBeenCalledWith(expected);
+      expect(resA.write.mock.calls.filter((c) => c[0] === expected)).toHaveLength(1);
+
+      replicaA.removeClient('school-1', resA);
+      replicaB.removeClient('school-1', resB);
+      await replicaA.close();
+      await replicaB.close();
+    });
+
+    it('does not deliver to clients of a different school', async () => {
+      const replica = loadReplica();
+      const res = mockRes();
+      replica.addClient('school-1', res);
+
+      replica.emit('school-2', 'payment', { txHash: 'xyz' });
+      await flush();
+
+      const dataWrites = res.write.mock.calls.filter((c) => c[0].startsWith('event:'));
+      expect(dataWrites).toHaveLength(0);
+      replica.removeClient('school-1', res);
+      await replica.close();
+    });
+  });
+
+  describe('heartbeat', () => {
+    it('writes a keepalive comment through a 60s idle period', () => {
+      jest.useFakeTimers();
+      delete process.env.REDIS_HOST; // single-process mode is fine for this
+      process.env.SSE_HEARTBEAT_MS = '15000';
+      const replica = loadReplica();
+
+      const res = mockRes();
+      replica.addClient('school-1', res);
+
+      jest.advanceTimersByTime(60000);
+
+      const pings = res.write.mock.calls.filter((c) => c[0] === ': ping\n\n');
+      expect(pings.length).toBeGreaterThanOrEqual(4);
+
+      replica.removeClient('school-1', res);
+    });
+
+    it('stops the heartbeat once the connection is removed', () => {
+      jest.useFakeTimers();
+      delete process.env.REDIS_HOST;
+      process.env.SSE_HEARTBEAT_MS = '15000';
+      const replica = loadReplica();
+
+      const res = mockRes();
+      replica.addClient('school-1', res);
+      replica.removeClient('school-1', res);
+
+      jest.advanceTimersByTime(60000);
+      expect(res.write).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('max-connections-per-school guard', () => {
+    it('rejects connections beyond the configured cap', () => {
+      delete process.env.REDIS_HOST;
+      process.env.SSE_MAX_CONNECTIONS_PER_SCHOOL = '2';
+      const replica = loadReplica();
+
+      const a = mockRes();
+      const b = mockRes();
+      expect(replica.addClient('school-1', a)).toBe(true);
+      expect(replica.addClient('school-1', b)).toBe(true);
+      expect(replica.addClient('school-1', mockRes())).toBe(false);
+
+      // A different school has its own independent budget.
+      const c = mockRes();
+      expect(replica.addClient('school-2', c)).toBe(true);
+
+      replica.removeClient('school-1', a);
+      replica.removeClient('school-1', b);
+      replica.removeClient('school-2', c);
+    });
+  });
+
+  describe('cleanup and metrics', () => {
+    it('counts active connections and clears them on removal', () => {
+      delete process.env.REDIS_HOST;
+      const replica = loadReplica();
+
+      const a = mockRes();
+      const b = mockRes();
+      replica.addClient('school-1', a);
+      replica.addClient('school-2', b);
+
+      expect(replica.getStats()).toEqual({ schools: 2, connections: 2 });
+
+      replica.removeClient('school-1', a);
+      expect(replica.getStats()).toEqual({ schools: 1, connections: 1 });
+
+      replica.removeClient('school-2', b);
+      expect(replica.getStats()).toEqual({ schools: 0, connections: 0 });
+    });
+
+    it('removes a client whose write throws (closed/errored connection)', () => {
+      delete process.env.REDIS_HOST;
+      const replica = loadReplica();
+
+      const good = mockRes();
+      const broken = mockRes();
+      broken.write = jest.fn(() => { throw new Error('EPIPE'); });
+
+      replica.addClient('school-1', good);
+      replica.addClient('school-1', broken);
+
+      replica.emit('school-1', 'payment', { txHash: 'h' });
+
+      expect(replica.getStats().connections).toBe(1);
+      replica.removeClient('school-1', good);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

Real-time payment updates are pushed to the UI over Server-Sent Events, but the client registry lived in a process-local `Map` (`schoolId -> Set<res>`). This only works for a single backend process. Once the API is scaled horizontally (multiple replicas behind compose/Docker, or PM2 cluster mode), a payment confirmed on replica A never reaches an SSE client connected to replica B — delivery becomes non-deterministic depending on which pod the browser landed on.

## Solution

Route SSE emits through a Redis pub/sub channel `sse:<schoolId>`:

- `emit()` publishes to `sse:<schoolId>`; every replica's subscriber receives the message and fans out to **its own** locally-connected `res` objects. Delivery is now independent of which replica emitted.
- The emitting replica delivers via its own subscriber rather than also writing locally, so there is no double-delivery.
- A replica subscribes to a school's channel only while it holds at least one local connection for that school, and unsubscribes when the last one closes.
- **Graceful degradation:** with no `REDIS_HOST`, the service falls back to direct local fan-out (correct for a single replica), mirroring the existing BullMQ / rate-limit backend selection.

## Reliability & resource hardening

- **Heartbeat:** per-connection `: ping` every `SSE_HEARTBEAT_MS` (default 15s) keeps idle connections alive through proxies. Replaces the controller's ad-hoc 30s ping.
- **Connection cap:** `SSE_MAX_CONNECTIONS_PER_SCHOOL` (default 100) rejects excess connections with an `error` event to prevent fd exhaustion.
- **Metrics:** new `sse_connected_clients` and `sse_active_schools` gauges in `/metrics`, read live on each scrape.
- **Shutdown:** Redis pub/sub connections are closed during graceful shutdown.

## Acceptance criteria

- [x] SSE events delivered regardless of which replica emitted them (verified with two isolated module instances over a shared mock Redis bus).
- [x] Heartbeat keeps connections alive through a 60s idle period.
- [x] Connections are cleaned up on close/error and counted in `/metrics`.

## Testing

New `tests/sseService.test.js` (7 tests): cross-replica delivery (exactly-once), cross-school isolation, heartbeat through 60s idle + stop-on-removal, per-school cap with independent budgets, connection counting/cleanup, and auto-removal of clients whose `write` throws. Full suite: **105/105 passing**.

## Notes

SSE remains the live-notification layer (at-most-once, no replay). Durability is already provided by the MongoDB-backed polling/reconciliation pipeline, so the UI self-corrects on reconnect. A Redis Streams replay buffer was intentionally left out of scope.

Closes #740 