### PR TITLE
fix: improve ErrorBoundary fallback UI with recovery actions

### DIFF
--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,25 +1,81 @@
 import { Component } from "react";
 
 export default class ErrorBoundary extends Component {
-  state = { hasError: false };
+  state = { hasError: false, error: null };
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
   }
 
   componentDidCatch(error, info) {
-    console.error("Unhandled error:", error, info.componentStack);
+    console.error("Unhandled render error:", error, info.componentStack);
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{ padding: "2rem", textAlign: "center" }}>
-          <h2>Something went wrong.</h2>
-          <p>An unexpected error occurred. Please try again.</p>
-          <button onClick={() => this.setState({ hasError: false })}>Retry</button>
-          <br />
-          <a href="/">Go to Home</a>
+        <div style={{
+          minHeight: "60vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "1rem",
+          padding: "2rem",
+          textAlign: "center",
+          fontFamily: "Inter, sans-serif",
+          color: "var(--text, #0f172a)",
+        }}>
+          <div style={{ fontSize: "3rem" }}>⚠️</div>
+          <h2 style={{ margin: 0, fontSize: "1.5rem", fontWeight: 700 }}>Something went wrong</h2>
+          <p style={{ margin: 0, color: "var(--text-muted, #64748b)", maxWidth: "360px" }}>
+            An unexpected error occurred. You can try reloading the page or go back to safety.
+          </p>
+          <div style={{ display: "flex", gap: "0.75rem", flexWrap: "wrap", justifyContent: "center" }}>
+            <button
+              onClick={() => window.location.reload()}
+              style={{
+                padding: "0.5rem 1.25rem",
+                borderRadius: "8px",
+                border: "none",
+                background: "var(--grad-brand, #6366f1)",
+                color: "#fff",
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              Reload page
+            </button>
+            <button
+              onClick={() => { window.history.back(); this.setState({ hasError: false, error: null }); }}
+              style={{
+                padding: "0.5rem 1.25rem",
+                borderRadius: "8px",
+                border: "1px solid var(--border, #e7e9f3)",
+                background: "var(--card-bg, #fff)",
+                color: "var(--text, #0f172a)",
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              Go back
+            </button>
+            <a
+              href="/"
+              style={{
+                padding: "0.5rem 1.25rem",
+                borderRadius: "8px",
+                border: "1px solid var(--border, #e7e9f3)",
+                background: "var(--card-bg, #fff)",
+                color: "var(--text, #0f172a)",
+                fontWeight: 600,
+                textDecoration: "none",
+                lineHeight: "1.5",
+              }}
+            >
+              Go home
+            </a>
+          </div>
         </div>
       );
     }


### PR DESCRIPTION
Closes #769  fix: improve ErrorBoundary fallback UI

## Summary

Improved the `ErrorBoundary` fallback so render errors show a recoverable UI instead of a blank screen.

`_app.jsx` already wrapped the page tree in `<ErrorBoundary>` — no change needed there.

## Changes

**`frontend/src/components/ErrorBoundary.jsx`**
- Replaced bare inline-styled fallback with one that uses the app's CSS design tokens (`--text`, `--text-muted`, `--card-bg`, `--border`, `--grad-brand`)
- Replaced "Retry" (reset React state only) with **Reload page** (`window.location.reload()`) — more reliable when the component itself is broken
- Added **Go back** (`history.back()` + resets error state)
- Kept **Go home** (`/`) link
- Stored caught `error` in state for easier debugging

## Acceptance criteria

| Criteria | Status |
|---|---|
| A thrown render error shows the fallback UI, not a blank page | ✅ `ErrorBoundary` wraps the full page tree in `_app.jsx` |
| Fallback offers a way to recover (reload / go home) | ✅ Reload page · Go back · Go home |
