### PR TITLE
feat: distributed lock for transaction polling sync

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -244,6 +244,7 @@ async function shutdown(signal) {
     await closeQueue();
     await bullMQRetryService.shutdownQueue();
     await require('./services/sseService').close();
+    await require('./services/distributedLock').close();
     logger.info('BullMQ resources closed cleanly');
   } catch (err) {
     logger.error('Error closing BullMQ resources during shutdown', { error: err.message });

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -69,6 +69,12 @@ const _syncRaw =
   process.env.SYNC_INTERVAL_MS ?? process.env.POLL_INTERVAL_MS ?? "60000";
 const SYNC_INTERVAL_MS = parseInt(_syncRaw, 10);
 
+// How long a per-school sync lock is held before auto-expiring. Acts as the
+// crash-safety net for the distributed lock around each poll cycle: must
+// comfortably exceed the time it takes to poll a single school, but stay short
+// enough that a dead worker's lock frees up reasonably quickly. Default: 60s.
+const SYNC_LOCK_TTL_MS = parseInt(process.env.SYNC_LOCK_TTL_MS || "60000", 10);
+
 // ── Retry Service ─────────────────────────────────────────────────────────────
 const RETRY_INTERVAL_MS = parseInt(
   process.env.RETRY_INTERVAL_MS || "60000",
@@ -161,6 +167,7 @@ const config = Object.freeze({
   CONFIRMATION_THRESHOLD,
   POLL_INTERVAL_MS,
   SYNC_INTERVAL_MS,
+  SYNC_LOCK_TTL_MS,
   RETRY_INTERVAL_MS,
   RETRY_MAX_ATTEMPTS,
   MIN_PAYMENT_AMOUNT,

--- a/backend/src/services/distributedLock.js
+++ b/backend/src/services/distributedLock.js
@@ -1,0 +1,150 @@
+'use strict';
+
+/**
+ * Distributed lock backed by Redis (`SET key token NX PX ttl`).
+ *
+ * Used to ensure that only one backend replica (or one overlapping slow poll)
+ * processes a given resource — e.g. a school's Stellar sync — at a time.
+ *
+ * Semantics:
+ *   acquire(key, ttlMs) -> token | null
+ *     Atomically takes the lock via SET NX PX. Returns an opaque token on
+ *     success, or null when another holder already owns the lock.
+ *   release(key, token) -> boolean
+ *     Releases the lock only if `token` still matches the stored value, so a
+ *     worker can never release a lock that has since expired and been retaken
+ *     by someone else (check-and-delete is done atomically with a Lua script).
+ *
+ * The TTL is the safety net: if a holder crashes without releasing, the lock
+ * auto-expires after ttlMs and another worker can take over. Correctness of the
+ * underlying writes must therefore NOT depend solely on the lock — the unique
+ * index on Payment { schoolId, txHash } remains the authoritative dedup guard.
+ *
+ * When REDIS_HOST is not configured the lock degrades to an in-process Map.
+ * That is correct for a single replica (the only contention is overlapping
+ * polls inside one process) and keeps the service runnable without Redis.
+ */
+
+const crypto = require('crypto');
+const logger = require('../utils/logger').child('DistributedLock');
+
+const redisEnabled = Boolean(process.env.REDIS_HOST);
+
+const redisConfig = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+  password: process.env.REDIS_PASSWORD || undefined,
+  lazyConnect: true,
+  maxRetriesPerRequest: null,
+  enableOfflineQueue: false,
+};
+
+let client = null;
+
+if (redisEnabled) {
+  const Redis = require('ioredis');
+  client = new Redis(redisConfig);
+  client.on('error', (err) => logger.error('Redis lock client error', { error: err.message }));
+  client.connect().catch((err) =>
+    logger.error('Redis lock client connect failed', { error: err.message })
+  );
+}
+
+// In-process fallback store: key -> { token, expiresAt }
+const localLocks = new Map();
+
+// Atomic check-and-delete: only delete when the stored token is ours.
+const RELEASE_SCRIPT =
+  'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
+
+function newToken() {
+  return crypto.randomBytes(16).toString('hex');
+}
+
+/**
+ * Attempt to acquire the lock.
+ * @param {string} key   Lock key (e.g. `sync:lock:<schoolId>`).
+ * @param {number} ttlMs Lock lifetime in milliseconds.
+ * @returns {Promise<string|null>} A release token, or null if already held.
+ */
+async function acquire(key, ttlMs) {
+  const token = newToken();
+
+  if (client) {
+    try {
+      const res = await client.set(key, token, 'PX', ttlMs, 'NX');
+      return res === 'OK' ? token : null;
+    } catch (err) {
+      // On a Redis failure we refuse the lock rather than risk two workers
+      // both proceeding. The unique index still prevents duplicate writes; the
+      // caller simply skips this cycle and retries next interval.
+      logger.error('Lock acquire failed', { error: err.message, key });
+      return null;
+    }
+  }
+
+  // In-process fallback.
+  const now = Date.now();
+  const existing = localLocks.get(key);
+  if (existing && existing.expiresAt > now) return null;
+  localLocks.set(key, { token, expiresAt: now + ttlMs });
+  return token;
+}
+
+/**
+ * Release a previously acquired lock if we still own it.
+ * @param {string} key
+ * @param {string} token Token returned by acquire().
+ * @returns {Promise<boolean>} true if this call released the lock.
+ */
+async function release(key, token) {
+  if (!token) return false;
+
+  if (client) {
+    try {
+      const res = await client.eval(RELEASE_SCRIPT, 1, key, token);
+      return res === 1;
+    } catch (err) {
+      logger.error('Lock release failed', { error: err.message, key });
+      return false;
+    }
+  }
+
+  const existing = localLocks.get(key);
+  if (existing && existing.token === token) {
+    localLocks.delete(key);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Run `fn` while holding the lock for `key`. If the lock cannot be acquired the
+ * function is not run and `onContended` (default: undefined) is returned.
+ */
+async function withLock(key, ttlMs, fn, onContended) {
+  const token = await acquire(key, ttlMs);
+  if (!token) return onContended;
+  try {
+    return await fn();
+  } finally {
+    await release(key, token);
+  }
+}
+
+async function close() {
+  try {
+    if (client) await client.quit();
+  } catch (err) {
+    logger.error('Error closing Redis lock client', { error: err.message });
+  }
+}
+
+module.exports = {
+  acquire,
+  release,
+  withLock,
+  close,
+  // Exposed for testing
+  _isRedisEnabled: () => Boolean(client),
+};

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -9,19 +9,25 @@ const { extractValidPayment, validatePaymentAgainstFee, detectMemoCollision, det
 const { validatePaymentAmount } = require('../utils/paymentLimits');
 const { generateReferenceCode } = require('../utils/generateReferenceCode');
 const { emit: sseEmit } = require('./sseService');
+const lock = require('./distributedLock');
+const config = require('../config');
 const logger = require('../utils/logger').child('TransactionPollingService');
 
 let pollingInterval = null;
 let isPolling = false;
 
-const POLLING_INTERVAL_MS = 30000; // Poll every 30 seconds
+// Base poll interval, honoring SYNC_INTERVAL_MS from config (which itself falls
+// back to POLL_INTERVAL_MS). A value of 0 disables auto-sync entirely.
+const SYNC_INTERVAL_MS = config.SYNC_INTERVAL_MS;
+// TTL of the per-school distributed sync lock (crash-safety net).
+const SYNC_LOCK_TTL_MS = config.SYNC_LOCK_TTL_MS;
 const TRANSACTIONS_PER_POLL = 20;
 
 // Exponential backoff state — reset on first successful poll after errors.
 // POLL_MAX_BACKOFF_MS defaults to 5 minutes; configurable via env var.
 const POLL_MAX_BACKOFF_MS = parseInt(process.env.POLL_MAX_BACKOFF_MS || '300000', 10);
 let consecutiveErrors = 0;
-let currentIntervalMs = POLLING_INTERVAL_MS;
+let currentIntervalMs = SYNC_INTERVAL_MS;
 
 /**
  * Process a single transaction for a school
@@ -29,8 +35,12 @@ let currentIntervalMs = POLLING_INTERVAL_MS;
 async function processTransaction(tx, school) {
   const { schoolId, stellarAddress } = school;
 
-  // Skip if already processed
-  const existing = await Payment.findOne({ txHash: tx.hash, deletedAt: null });
+  // Cheap optimisation only: skip work for transactions we've clearly already
+  // recorded. This is NOT the dedup guarantee — it is a read-then-write race
+  // (two workers can both miss the row). The authoritative guard is the unique
+  // index on Payment { schoolId, txHash }, which makes the insert below fail
+  // atomically with code 11000 if a concurrent worker won the race.
+  const existing = await Payment.findOne({ schoolId, txHash: tx.hash, deletedAt: null });
   if (existing) {
     return { processed: false, reason: 'duplicate' };
   }
@@ -173,9 +183,25 @@ async function processTransaction(tx, school) {
 }
 
 /**
- * Poll transactions for a single school
+ * Poll transactions for a single school.
+ *
+ * Wrapped in a per-school distributed lock (Redis SET NX PX) so that, across
+ * horizontally-scaled replicas or an overlapping slow poll, only one worker
+ * syncs a given school at a time. If the lock is already held the cycle is
+ * skipped — the holder will pick up any new transactions. Correctness against
+ * duplicate writes does not depend on the lock: the unique index on Payment
+ * remains the authoritative dedup guard if the lock ever expires mid-poll.
  */
 async function pollSchoolTransactions(school) {
+  const lockKey = `sync:lock:${school.schoolId}`;
+  const token = await lock.acquire(lockKey, SYNC_LOCK_TTL_MS);
+  if (!token) {
+    logger.debug('Skipping school poll — sync lock held by another worker', {
+      schoolId: school.schoolId,
+    });
+    return { schoolId: school.schoolId, processed: 0, skipped: 0, lockSkipped: true };
+  }
+
   try {
     const transactions = await server
       .transactions()
@@ -211,6 +237,8 @@ async function pollSchoolTransactions(school) {
       error: error.message,
     });
     return { schoolId: school.schoolId, error: error.message, horizonError: true };
+  } finally {
+    await lock.release(lockKey, token);
   }
 }
 
@@ -251,7 +279,7 @@ async function pollAllSchools() {
     if (summary.errors > 0) {
       // At least one school hit a Horizon error — back off.
       consecutiveErrors++;
-      const backoff = Math.min(POLLING_INTERVAL_MS * Math.pow(2, consecutiveErrors), POLL_MAX_BACKOFF_MS);
+      const backoff = Math.min(SYNC_INTERVAL_MS * Math.pow(2, consecutiveErrors), POLL_MAX_BACKOFF_MS);
       currentIntervalMs = backoff;
       logger.info('Horizon errors detected; backing off polling interval', {
         consecutiveErrors,
@@ -261,11 +289,11 @@ async function pollAllSchools() {
       // Successful cycle — reset backoff.
       if (consecutiveErrors > 0) {
         logger.info('Polling recovered; resetting interval to normal', {
-          intervalMs: POLLING_INTERVAL_MS,
+          intervalMs: SYNC_INTERVAL_MS,
         });
       }
       consecutiveErrors = 0;
-      currentIntervalMs = POLLING_INTERVAL_MS;
+      currentIntervalMs = SYNC_INTERVAL_MS;
     }
 
     if (summary.processed > 0 || summary.errors > 0) {
@@ -273,7 +301,7 @@ async function pollAllSchools() {
     }
   } catch (error) {
     consecutiveErrors++;
-    const backoff = Math.min(POLLING_INTERVAL_MS * Math.pow(2, consecutiveErrors), POLL_MAX_BACKOFF_MS);
+    const backoff = Math.min(SYNC_INTERVAL_MS * Math.pow(2, consecutiveErrors), POLL_MAX_BACKOFF_MS);
     currentIntervalMs = backoff;
     logger.error('Error in polling cycle', { error: error.message, nextIntervalMs: currentIntervalMs });
   }
@@ -299,10 +327,16 @@ function startPolling() {
     return;
   }
 
+  // SYNC_INTERVAL_MS=0 disables auto-sync entirely (config contract).
+  if (!SYNC_INTERVAL_MS || SYNC_INTERVAL_MS <= 0) {
+    logger.info('Transaction polling disabled (SYNC_INTERVAL_MS=0)');
+    return;
+  }
+
   isPolling = true;
   consecutiveErrors = 0;
-  currentIntervalMs = POLLING_INTERVAL_MS;
-  logger.info('Starting transaction polling service', { intervalMs: POLLING_INTERVAL_MS });
+  currentIntervalMs = SYNC_INTERVAL_MS;
+  logger.info('Starting transaction polling service', { intervalMs: SYNC_INTERVAL_MS });
 
   // Run immediately on startup, then self-schedule via setTimeout for backoff support
   pollAllSchools();
@@ -332,7 +366,7 @@ module.exports = {
   _getBackoffState: () => ({ consecutiveErrors, currentIntervalMs }),
   _resetBackoffState: () => {
     consecutiveErrors = 0;
-    currentIntervalMs = POLLING_INTERVAL_MS;
+    currentIntervalMs = SYNC_INTERVAL_MS;
     isPolling = true; // allow direct pollAllSchools() calls in tests
     if (pollingInterval) { clearTimeout(pollingInterval); pollingInterval = null; }
   },

--- a/backend/tests/distributedLock.test.js
+++ b/backend/tests/distributedLock.test.js
@@ -1,0 +1,160 @@
+'use strict';
+
+/**
+ * Tests for the Redis-backed distributed lock.
+ *
+ * ioredis is mocked with a single in-process key store shared across every
+ * client instance, so two isolated module loads of distributedLock behave like
+ * two replicas contending for the same Redis (`SET NX PX` + Lua release).
+ *
+ * The in-process fallback path (REDIS_HOST unset) is exercised separately.
+ */
+
+// Shared key store across all mocked Redis instances. `mock` prefix lets the
+// hoisted jest.mock factory reference it.
+const mockStore = new Map();
+
+jest.mock('ioredis', () => {
+  const NodeEventEmitter = require('events');
+  return class MockRedis extends NodeEventEmitter {
+    connect() { return Promise.resolve(); }
+
+    // Supports: set(key, value, 'PX', ttlMs, 'NX')
+    async set(key, value, ...opts) {
+      const nx = opts.includes('NX');
+      const pxIdx = opts.indexOf('PX');
+      const ttl = pxIdx >= 0 ? Number(opts[pxIdx + 1]) : null;
+
+      const existing = mockStore.get(key);
+      const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
+      if (nx && alive) return null;
+
+      mockStore.set(key, { value, expiresAt: ttl != null ? Date.now() + ttl : null });
+      return 'OK';
+    }
+
+    // Supports the release script: GET-compare-DEL.
+    async eval(_script, _numKeys, key, token) {
+      const existing = mockStore.get(key);
+      const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
+      if (alive && existing.value === token) {
+        mockStore.delete(key);
+        return 1;
+      }
+      return 0;
+    }
+
+    async quit() { return 'OK'; }
+  };
+});
+
+function loadLock() {
+  let mod;
+  jest.isolateModules(() => {
+    mod = require('../src/services/distributedLock');
+  });
+  return mod;
+}
+
+describe('distributedLock', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    mockStore.clear();
+    jest.useRealTimers();
+  });
+
+  describe('Redis-backed (REDIS_HOST set)', () => {
+    beforeEach(() => {
+      process.env.REDIS_HOST = 'localhost';
+    });
+
+    it('grants the lock to exactly one of two contending replicas', async () => {
+      const a = loadLock();
+      const b = loadLock();
+
+      const tokenA = await a.acquire('sync:lock:school-1', 5000);
+      const tokenB = await b.acquire('sync:lock:school-1', 5000);
+
+      expect(tokenA).toBeTruthy();
+      expect(tokenB).toBeNull();
+    });
+
+    it('lets another replica acquire after the holder releases', async () => {
+      const a = loadLock();
+      const b = loadLock();
+
+      const tokenA = await a.acquire('sync:lock:school-1', 5000);
+      expect(await b.acquire('sync:lock:school-1', 5000)).toBeNull();
+
+      expect(await a.release('sync:lock:school-1', tokenA)).toBe(true);
+
+      const tokenB = await b.acquire('sync:lock:school-1', 5000);
+      expect(tokenB).toBeTruthy();
+    });
+
+    it('does not release a lock owned by someone else', async () => {
+      const a = loadLock();
+      await a.acquire('sync:lock:school-1', 5000);
+
+      // Wrong token → no release, lock stays held.
+      expect(await a.release('sync:lock:school-1', 'not-the-token')).toBe(false);
+
+      const b = loadLock();
+      expect(await b.acquire('sync:lock:school-1', 5000)).toBeNull();
+    });
+
+    it('lets the lock be retaken after its TTL expires', async () => {
+      jest.useFakeTimers();
+      const a = loadLock();
+      const b = loadLock();
+
+      await a.acquire('sync:lock:school-1', 1000);
+      expect(await b.acquire('sync:lock:school-1', 1000)).toBeNull();
+
+      jest.advanceTimersByTime(1500); // past TTL
+
+      expect(await b.acquire('sync:lock:school-1', 1000)).toBeTruthy();
+    });
+  });
+
+  describe('in-process fallback (no REDIS_HOST)', () => {
+    beforeEach(() => {
+      delete process.env.REDIS_HOST;
+    });
+
+    it('still enforces mutual exclusion within a single process', async () => {
+      const lock = loadLock();
+      expect(lock._isRedisEnabled()).toBe(false);
+
+      const token = await lock.acquire('sync:lock:school-1', 5000);
+      expect(token).toBeTruthy();
+      expect(await lock.acquire('sync:lock:school-1', 5000)).toBeNull();
+
+      expect(await lock.release('sync:lock:school-1', token)).toBe(true);
+      expect(await lock.acquire('sync:lock:school-1', 5000)).toBeTruthy();
+    });
+  });
+
+  describe('withLock helper', () => {
+    beforeEach(() => { delete process.env.REDIS_HOST; });
+
+    it('runs fn while holding the lock and releases afterward', async () => {
+      const lock = loadLock();
+      const result = await lock.withLock('k', 5000, async () => 'ran');
+      expect(result).toBe('ran');
+      // Lock released → can re-acquire.
+      expect(await lock.acquire('k', 5000)).toBeTruthy();
+    });
+
+    it('returns the contended sentinel without running fn when held', async () => {
+      const lock = loadLock();
+      await lock.acquire('k', 5000);
+      const fn = jest.fn();
+      const result = await lock.withLock('k', 5000, fn, 'SKIPPED');
+      expect(fn).not.toHaveBeenCalled();
+      expect(result).toBe('SKIPPED');
+    });
+  });
+});

--- a/backend/tests/transactionPollingDistributedLock.test.js
+++ b/backend/tests/transactionPollingDistributedLock.test.js
@@ -1,0 +1,214 @@
+'use strict';
+
+/**
+ * Integration tests for distributed-lock-protected transaction polling.
+ *
+ * Goals (acceptance criteria):
+ *   1. Two replicas polling the same school never create duplicate Payment docs.
+ *   2. A duplicate insert is rejected atomically by the unique index
+ *      ({ schoolId, txHash }) — proven by bypassing the read pre-check so both
+ *      workers reach create() and only one succeeds.
+ *   3. The poll interval is driven by config.SYNC_INTERVAL_MS (env), not a
+ *      hardcoded constant, and SYNC_INTERVAL_MS=0 disables polling.
+ *
+ * ioredis is mocked with a single shared key store so two isolated module loads
+ * of the service contend over the same `SET NX PX` lock, simulating replicas.
+ * The persistence layer is mocked with a shared in-memory store whose create()
+ * enforces { schoolId, txHash } uniqueness (the unique index) by throwing 11000.
+ */
+
+// ── Shared mock state (mock-prefixed so jest.mock factories may reference it) ──
+const mockRedisStore = new Map();
+
+const mockPayments = [];
+const mockSeenKeys = new Set(); // `${schoolId}|${txHash}` — the unique index
+let mockFindOneImpl = async () => null;
+let mockTxRecords = [];
+const mockSchoolFind = jest.fn(async () => [
+  { schoolId: 'school-1', stellarAddress: 'GABC', isActive: true },
+]);
+
+// ── ioredis: shared SET NX PX + Lua-release store ────────────────────────────
+jest.mock('ioredis', () => {
+  const NodeEventEmitter = require('events');
+  return class MockRedis extends NodeEventEmitter {
+    connect() { return Promise.resolve(); }
+    async set(key, value, ...opts) {
+      const nx = opts.includes('NX');
+      const pxIdx = opts.indexOf('PX');
+      const ttl = pxIdx >= 0 ? Number(opts[pxIdx + 1]) : null;
+      const existing = mockRedisStore.get(key);
+      const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
+      if (nx && alive) return null;
+      mockRedisStore.set(key, { value, expiresAt: ttl != null ? Date.now() + ttl : null });
+      return 'OK';
+    }
+    async eval(_s, _n, key, token) {
+      const existing = mockRedisStore.get(key);
+      if (existing && existing.value === token) { mockRedisStore.delete(key); return 1; }
+      return 0;
+    }
+    async quit() { return 'OK'; }
+  };
+});
+
+// ── Persistence + Stellar mocks ──────────────────────────────────────────────
+jest.mock('../src/models/paymentModel', () => ({
+  findOne: (...args) => mockFindOneImpl(...args),
+  aggregate: async () => [],
+  create: async (docs) => {
+    const data = Array.isArray(docs) ? docs[0] : docs;
+    const key = `${data.schoolId}|${data.txHash}`;
+    if (mockSeenKeys.has(key)) {
+      const err = new Error('E11000 duplicate key error');
+      err.code = 11000;
+      throw err;
+    }
+    mockSeenKeys.add(key);
+    mockPayments.push(data);
+    return [data];
+  },
+}));
+
+jest.mock('../src/models/studentModel', () => ({
+  findOne: async () => ({ studentId: 's1', schoolId: 'school-1', feeAmount: 100 }),
+  findOneAndUpdate: async () => ({}),
+}));
+
+jest.mock('../src/models/schoolModel', () => ({
+  find: (...args) => mockSchoolFind(...args),
+}));
+
+jest.mock('../src/config/stellarConfig', () => {
+  const builder = {
+    transactions: () => builder,
+    forAccount: () => builder,
+    order: () => builder,
+    limit: () => builder,
+    call: async () => ({ records: mockTxRecords }),
+  };
+  return { server: builder };
+});
+
+jest.mock('../src/services/stellarService', () => ({
+  extractValidPayment: async () => ({ payOp: { amount: '50', from: 'GSENDER' }, memo: 's1', asset: 'XLM' }),
+  validatePaymentAgainstFee: () => ({ valid: true }),
+  detectMemoCollision: async () => ({ suspicious: false, reason: null }),
+  detectAbnormalPatterns: async () => ({ suspicious: false, reason: null }),
+  checkConfirmationStatus: async () => true,
+}));
+
+jest.mock('../src/utils/paymentLimits', () => ({
+  validatePaymentAmount: () => ({ valid: true }),
+}));
+
+jest.mock('../src/utils/generateReferenceCode', () => ({
+  generateReferenceCode: async () => 'REF123',
+}));
+
+jest.mock('../src/services/sseService', () => ({ emit: jest.fn() }));
+
+jest.mock('mongoose', () => ({
+  connection: {
+    startSession: async () => ({
+      withTransaction: async (cb) => cb(),
+      endSession: async () => {},
+    }),
+  },
+}));
+
+function loadReplica() {
+  let mod;
+  jest.isolateModules(() => {
+    mod = require('../src/services/transactionPollingService');
+  });
+  return mod;
+}
+
+const TX = { hash: 'TX1', created_at: '2026-06-18T00:00:00Z', ledger: 100, fee_paid: '100' };
+const SCHOOL = { schoolId: 'school-1', stellarAddress: 'GABC' };
+
+describe('transactionPollingService — distributed lock + dedup', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    process.env.MONGO_URI = 'mongodb://localhost/test';
+    process.env.JWT_SECRET = 'test-secret';
+    mockPayments.length = 0;
+    mockSeenKeys.clear();
+    mockRedisStore.clear();
+    mockFindOneImpl = async () => null;
+    mockTxRecords = [{ ...TX }];
+    mockSchoolFind.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    jest.useRealTimers();
+  });
+
+  describe('two replicas against the same school', () => {
+    beforeEach(() => { process.env.REDIS_HOST = 'localhost'; });
+
+    it('never creates duplicate Payment docs — second replica is lock-skipped', async () => {
+      const replicaA = loadReplica();
+      const replicaB = loadReplica();
+
+      const [resA, resB] = await Promise.all([
+        replicaA.pollSchoolTransactions(SCHOOL),
+        replicaB.pollSchoolTransactions(SCHOOL),
+      ]);
+
+      // Exactly one payment recorded for the single incoming transaction.
+      expect(mockPayments).toHaveLength(1);
+
+      // Exactly one of the two workers was skipped by the lock.
+      const skipped = [resA, resB].filter((r) => r.lockSkipped);
+      expect(skipped).toHaveLength(1);
+      const worked = [resA, resB].find((r) => !r.lockSkipped);
+      expect(worked.processed).toBe(1);
+
+      await replicaA.stopPolling();
+      await replicaB.stopPolling();
+    });
+  });
+
+  describe('unique index is the authoritative dedup guard (not the pre-check)', () => {
+    beforeEach(() => { process.env.REDIS_HOST = 'localhost'; });
+
+    it('rejects the duplicate insert via code 11000 when both workers miss the pre-check', async () => {
+      // Simulate the read-then-write race: both workers see no existing row.
+      mockFindOneImpl = async () => null;
+      const replica = loadReplica();
+
+      const [r1, r2] = await Promise.all([
+        replica.processTransaction({ ...TX }, SCHOOL),
+        replica.processTransaction({ ...TX }, SCHOOL),
+      ]);
+
+      // The index let exactly one insert through; the other was rejected.
+      expect(mockPayments).toHaveLength(1);
+      const results = [r1, r2];
+      expect(results.filter((r) => r.processed)).toHaveLength(1);
+      const rejected = results.find((r) => !r.processed);
+      expect(rejected.reason).toBe('duplicate');
+    });
+  });
+
+  describe('poll interval is configurable via env (SYNC_INTERVAL_MS)', () => {
+    it('drives the interval from config.SYNC_INTERVAL_MS', () => {
+      process.env.SYNC_INTERVAL_MS = '17000';
+      delete process.env.POLL_INTERVAL_MS;
+      const replica = loadReplica();
+      expect(replica._getBackoffState().currentIntervalMs).toBe(17000);
+    });
+
+    it('disables polling entirely when SYNC_INTERVAL_MS=0', () => {
+      process.env.SYNC_INTERVAL_MS = '0';
+      const replica = loadReplica();
+      replica.startPolling();
+      // Disabled: the cycle never ran, so active schools were never queried.
+      expect(mockSchoolFind).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Closes #741

## Summary
Prevents the same Stellar transaction from being processed twice when more than one backend instance runs (or a slow poll overlaps the next cycle).

- **Per-school distributed lock** (`backend/src/services/distributedLock.js`): Redis `SET NX PX` acquire with an atomic Lua check-and-delete release, so a worker can never release a lock that expired and was retaken. Wrapped around each poll cycle in `transactionPollingService` — a second worker is skipped while one syncs a given school. Degrades to an in-process lock when `REDIS_HOST` is unset (mirrors the existing SSE/BullMQ Redis-detection pattern). Closed on graceful shutdown.
- **Unique index is the authoritative dedup guard**: the compound unique index `Payment { schoolId, txHash }` already existed and the insert already catches `11000`, so duplicate inserts fail atomically rather than relying on the read pre-check. The pre-check is now documented/scoped as an optimization only. The lock reduces wasted work; the index guarantees correctness if the lock ever expires mid-poll.
- **Configurable interval**: replaced the hardcoded `POLLING_INTERVAL_MS = 30000` with `config.SYNC_INTERVAL_MS` (env-driven, `0` disables auto-sync); added `SYNC_LOCK_TTL_MS`.

## Acceptance criteria
- ✅ Two instances against the same school never create duplicate `Payment` docs (integration test).
- ✅ Duplicate insert rejected by the unique index, not a pre-check (test bypasses the pre-check and shows one of two concurrent inserts fails with 11000).
- ✅ Poll interval configurable via env (`SYNC_INTERVAL_MS`; `0` disables).

## Tests
11 new tests, full suite 116/116 green:
- `tests/distributedLock.test.js` — NX mutual exclusion, token-checked release, TTL retake, in-process fallback, `withLock`.
- `tests/transactionPollingDistributedLock.test.js` — two-replica no-duplicate poll, index-rejects-duplicate-insert, env-driven interval + disable.

ioredis is mocked with a shared key store so two isolated module loads contend over the same lock (same approach as `sseService.test.js`).

