### PR TITLE
feat(stellar): horizon failover, circuit breaker, health+metrics surf…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -121,6 +121,21 @@ STELLAR_NETWORK=testnet
 # STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 # STELLAR_HORIZON_URL=https://horizon.stellar.org
 
+# Optional: comma-separated, priority-ordered list of Horizon URLs for HA failover.
+# When set, STELLAR_HORIZON_URLS takes precedence over STELLAR_HORIZON_URL.
+# The first reachable URL with a closed circuit breaker is used.
+# Example (testnet primary + SDF fallback):
+# STELLAR_HORIZON_URLS=https://horizon-testnet.stellar.org,https://horizon.stellar.org
+STELLAR_HORIZON_URLS=
+
+# ── Horizon Circuit Breaker ───────────────────────────────────────────────────
+# Open circuit after this many consecutive failures per endpoint (default: 5)
+CB_FAILURE_THRESHOLD=5
+# Time (ms) before an open circuit transitions to half-open for probe (default: 30000)
+CB_RESET_TIMEOUT_MS=30000
+# Consecutive probe successes needed to close the circuit (default: 2)
+CB_HALF_OPEN_SUCCESS_THRESHOLD=2
+
 # Optional: USDC issuer address (defaults to well-known testnet/mainnet issuer)
 # USDC_ISSUER=G...
 

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -44,6 +44,13 @@ const HORIZON_URL =
   process.env.HORIZON_URL ||
   "https://horizon.stellar.org";
 
+// Comma-separated, priority-ordered list of Horizon URLs for failover.
+// When set, the HorizonFailoverClient will try each URL in order.
+// Falls back to HORIZON_URL (single-endpoint mode) when not set.
+const STELLAR_HORIZON_URLS = process.env.STELLAR_HORIZON_URLS
+  ? process.env.STELLAR_HORIZON_URLS.split(',').map((u) => u.trim()).filter(Boolean)
+  : [HORIZON_URL];
+
 // Optional — only used by the migration script to seed the default school
 const SCHOOL_WALLET_ADDRESS = process.env.SCHOOL_WALLET_ADDRESS || null;
 
@@ -161,6 +168,7 @@ const config = Object.freeze({
   STELLAR_NETWORK,
   IS_TESTNET,
   HORIZON_URL,
+  STELLAR_HORIZON_URLS,
   SCHOOL_WALLET_ADDRESS,
   USDC_ISSUER,
   ACCEPTED_ASSET,

--- a/backend/src/config/stellarConfig.js
+++ b/backend/src/config/stellarConfig.js
@@ -2,12 +2,21 @@
 
 const StellarSdk = require('@stellar/stellar-sdk');
 const config = require('./index');
+const { getInstance: getFailoverClient } = require('../services/horizonFailoverClient');
 
-const horizonUrl = process.env.STELLAR_HORIZON_URL || config.HORIZON_URL;
+// The failover client manages a prioritized list of Horizon URLs, a circuit
+// breaker per endpoint, and health-aware failover.  Callers that need to make
+// Horizon calls should prefer `horizonClient.call(server => server.xyz())`
+// so failover is automatic.  The `.server` property is kept for backward
+// compatibility with code that still accesses `server` directly.
+const horizonClient = getFailoverClient();
 
-const server = new StellarSdk.Horizon.Server(horizonUrl, {
-  timeout: config.STELLAR_TIMEOUT_MS,
-});
+/**
+ * Backward-compatible `server` export.
+ * Points to the currently active Horizon.Server instance.
+ * Use `horizonClient.call(fn)` for failover-aware calls.
+ */
+const server = horizonClient.server;
 
 const networkPassphrase = config.IS_TESTNET
   ? StellarSdk.Networks.TESTNET
@@ -81,6 +90,7 @@ const CONFIRMATION_THRESHOLD = config.CONFIRMATION_THRESHOLD;
 
 module.exports = {
   server,
+  horizonClient,
   networkPassphrase,
   SCHOOL_WALLET,
   StellarSdk,

--- a/backend/src/controllers/healthController.js
+++ b/backend/src/controllers/healthController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const database = require('../config/database');
-const { server } = require('../config/stellarConfig');
+const { horizonClient } = require('../config/stellarConfig');
 const config = require('../config');
 const { concurrentPaymentProcessor } = require('../services/concurrentPaymentProcessor');
 const { getReminderStatus } = require('../services/reminderService');
@@ -17,10 +17,25 @@ async function checkStellar() {
     const timeoutPromise = new Promise((_, reject) =>
       setTimeout(() => reject(new Error(`Horizon did not respond within ${STELLAR_CHECK_TIMEOUT_MS}ms`)), STELLAR_CHECK_TIMEOUT_MS)
     );
-    await Promise.race([server.ledgers().limit(1).call(), timeoutPromise]);
-    return { status: 'ok', latencyMs: Date.now() - start };
+    // Use horizonClient.call() so the health probe itself benefits from failover
+    await Promise.race([
+      horizonClient.call((server) => server.ledgers().limit(1).call()),
+      timeoutPromise,
+    ]);
+    return {
+      status: 'ok',
+      latencyMs: Date.now() - start,
+      activeUrl: horizonClient.activeUrl,
+      endpoints: horizonClient.getCircuitBreakerStatus(),
+    };
   } catch (err) {
-    return { status: 'unreachable', error: err.message, latencyMs: Date.now() - start };
+    return {
+      status: 'unreachable',
+      error: err.message,
+      latencyMs: Date.now() - start,
+      activeUrl: horizonClient.activeUrl,
+      endpoints: horizonClient.getCircuitBreakerStatus(),
+    };
   }
 }
 
@@ -92,7 +107,9 @@ async function healthCheck(req, res) {
         ...(stellar.latencyMs !== undefined && { latency_ms: stellar.latencyMs }),
         ...(stellar.error && { error: stellar.error }),
         network: config.STELLAR_NETWORK,
-        horizonUrl: config.HORIZON_URL,
+        horizonUrl: stellar.activeUrl || config.HORIZON_URL,
+        activeEndpoint: stellar.activeUrl || config.HORIZON_URL,
+        endpoints: stellar.endpoints || [],
       },
       paymentProcessor: {
         queueDepth,

--- a/backend/src/services/horizonFailoverClient.js
+++ b/backend/src/services/horizonFailoverClient.js
@@ -1,0 +1,403 @@
+'use strict';
+
+/**
+ * HorizonFailoverClient
+ *
+ * Wraps the Stellar Horizon.Server SDK with:
+ *   - A prioritized list of Horizon URLs (STELLAR_HORIZON_URLS env var, or
+ *     fall back to the single STELLAR_HORIZON_URL / HORIZON_URL).
+ *   - Health-aware failover: on each call failure the client tries the next
+ *     URL in the list before giving up.
+ *   - A per-endpoint circuit breaker: after CB_FAILURE_THRESHOLD consecutive
+ *     5xx/429 responses (or network errors) the circuit opens and that
+ *     endpoint is skipped for CB_RESET_TIMEOUT_MS.  It then enters HALF-OPEN,
+ *     allowing one probe request.  Two consecutive probe successes close it.
+ *   - All existing exponential-backoff behaviour in withStellarRetry is
+ *     preserved: this layer sits above it and provides endpoint selection.
+ *   - Prometheus counters/gauges for: failover events, circuit state changes,
+ *     and the currently active endpoint index.
+ *
+ * Environment variables:
+ *   STELLAR_HORIZON_URLS          Comma-separated, priority-ordered list of
+ *                                 Horizon base URLs.  Falls back to
+ *                                 STELLAR_HORIZON_URL / HORIZON_URL.
+ *   CB_FAILURE_THRESHOLD          Consecutive failures before CB opens   (5)
+ *   CB_RESET_TIMEOUT_MS           Time CB stays open before half-open  (30000)
+ *   CB_HALF_OPEN_SUCCESS_THRESHOLD Probe successes needed to close CB    (2)
+ *
+ * @module horizonFailoverClient
+ */
+
+const StellarSdk = require('@stellar/stellar-sdk');
+const config = require('../config');
+const logger = require('../utils/logger');
+// metrics is required lazily inside _ensureMetrics() to avoid a circular
+// dependency: horizonFailoverClient → metrics → stellarConfig → horizonFailoverClient
+
+// ── Circuit-breaker states ────────────────────────────────────────────────────
+const CB_STATE = Object.freeze({ CLOSED: 'closed', OPEN: 'open', HALF_OPEN: 'half_open' });
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+const CB_FAILURE_THRESHOLD = parseInt(process.env.CB_FAILURE_THRESHOLD, 10) || 5;
+const CB_RESET_TIMEOUT_MS = parseInt(process.env.CB_RESET_TIMEOUT_MS, 10) || 30_000;
+const CB_HALF_OPEN_SUCCESS_THRESHOLD =
+  parseInt(process.env.CB_HALF_OPEN_SUCCESS_THRESHOLD, 10) || 2;
+
+// ── Prometheus metrics (lazily registered so they survive jest module resets) ─
+let _horizonFailovers;
+let _horizonCbTransitions;
+let _horizonActiveEndpoint;
+let _horizonCbState;
+
+function _ensureMetrics() {
+  let metrics;
+  try {
+    metrics = require('../metrics');
+  } catch (_) {
+    return; // metrics not available (tests or early boot)
+  }
+  if (!metrics) return;
+  const { registry } = metrics;
+  const client = require('prom-client');
+
+  if (!_horizonFailovers) {
+    _horizonFailovers = new client.Counter({
+      name: 'horizon_failover_total',
+      help: 'Total number of Horizon endpoint failover events',
+      labelNames: ['from_url', 'to_url'],
+      registers: [registry],
+    });
+  }
+  if (!_horizonCbTransitions) {
+    _horizonCbTransitions = new client.Counter({
+      name: 'horizon_circuit_breaker_transitions_total',
+      help: 'Number of circuit-breaker state transitions per Horizon endpoint',
+      labelNames: ['url', 'from_state', 'to_state'],
+      registers: [registry],
+    });
+  }
+  if (!_horizonActiveEndpoint) {
+    _horizonActiveEndpoint = new client.Gauge({
+      name: 'horizon_active_endpoint_index',
+      help: 'Index (0-based) of the currently active Horizon endpoint in the priority list',
+      registers: [registry],
+    });
+  }
+  if (!_horizonCbState) {
+    _horizonCbState = new client.Gauge({
+      name: 'horizon_circuit_breaker_state',
+      help: 'Circuit-breaker state per Horizon endpoint: 0=closed 1=open 2=half_open',
+      labelNames: ['url'],
+      registers: [registry],
+    });
+  }
+}
+
+function _cbStateNum(state) {
+  if (state === CB_STATE.CLOSED) return 0;
+  if (state === CB_STATE.OPEN) return 1;
+  return 2;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Parse the comma-separated STELLAR_HORIZON_URLS env var.
+ * Falls back to the single-URL config value so existing deployments continue
+ * working without any env change.
+ * @returns {string[]} Non-empty, deduplicated list of Horizon base URLs.
+ */
+function resolveHorizonUrls() {
+  const raw = process.env.STELLAR_HORIZON_URLS;
+  if (raw && raw.trim()) {
+    const urls = raw
+      .split(',')
+      .map((u) => u.trim())
+      .filter(Boolean);
+    if (urls.length > 0) return urls;
+  }
+  // Single-URL fallback
+  return [
+    process.env.STELLAR_HORIZON_URL ||
+      process.env.HORIZON_URL ||
+      config.HORIZON_URL ||
+      'https://horizon.stellar.org',
+  ];
+}
+
+function isTransientFailure(err) {
+  const status =
+    err.response?.status ||
+    err.response?.statusCode ||
+    err.status ||
+    err.statusCode;
+  if (status === 429 || (status >= 500 && status < 600)) return true;
+  const NETWORK_CODES = ['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND', 'EAI_AGAIN'];
+  if (NETWORK_CODES.includes(err.code)) return true;
+  if (/timeout|network|socket hang up/i.test(err.message || '')) return true;
+  return false;
+}
+
+// ── CircuitBreaker ────────────────────────────────────────────────────────────
+
+class CircuitBreaker {
+  constructor(url) {
+    this.url = url;
+    this.state = CB_STATE.CLOSED;
+    this.failures = 0;
+    this.halfOpenSuccesses = 0;
+    this.openedAt = null;
+  }
+
+  isAvailable() {
+    if (this.state === CB_STATE.CLOSED || this.state === CB_STATE.HALF_OPEN) return true;
+    if (this.state === CB_STATE.OPEN) {
+      if (Date.now() - this.openedAt >= CB_RESET_TIMEOUT_MS) {
+        this._transition(CB_STATE.HALF_OPEN);
+        return true;
+      }
+      return false;
+    }
+    return true;
+  }
+
+  recordSuccess() {
+    if (this.state === CB_STATE.HALF_OPEN) {
+      this.halfOpenSuccesses++;
+      if (this.halfOpenSuccesses >= CB_HALF_OPEN_SUCCESS_THRESHOLD) {
+        this.failures = 0;
+        this.halfOpenSuccesses = 0;
+        this._transition(CB_STATE.CLOSED);
+      }
+    } else {
+      this.failures = 0;
+    }
+  }
+
+  recordFailure() {
+    this.failures++;
+    this.halfOpenSuccesses = 0;
+    if (this.state === CB_STATE.HALF_OPEN || this.failures >= CB_FAILURE_THRESHOLD) {
+      this.openedAt = Date.now();
+      this._transition(CB_STATE.OPEN);
+    }
+  }
+
+  _transition(newState) {
+    if (newState === this.state) return;
+    const prev = this.state;
+    this.state = newState;
+    logger.info(
+      `[HorizonFailoverClient] CB ${prev} → ${newState} for ${this.url}` +
+        (newState === CB_STATE.OPEN ? ` (resets in ${CB_RESET_TIMEOUT_MS}ms)` : ''),
+    );
+    try {
+      _ensureMetrics();
+      if (_horizonCbTransitions) _horizonCbTransitions.inc({ url: this.url, from_state: prev, to_state: newState });
+      if (_horizonCbState) _horizonCbState.set({ url: this.url }, _cbStateNum(newState));
+    } catch (_) { /* metrics optional */ }
+  }
+
+  getState() { return this.state; }
+}
+
+// ── HorizonFailoverClient ─────────────────────────────────────────────────────
+
+class HorizonFailoverClient {
+  /**
+   * @param {object} [opts]
+   * @param {string[]} [opts.urls]          Override URL list (useful in tests)
+   * @param {number}   [opts.timeoutMs]     Per-request timeout passed to Horizon.Server
+   */
+  constructor(opts = {}) {
+    this._urls = opts.urls || resolveHorizonUrls();
+    if (this._urls.length === 0) throw new Error('[HorizonFailoverClient] No Horizon URLs configured');
+
+    this._timeoutMs = opts.timeoutMs || config.STELLAR_TIMEOUT_MS || 10_000;
+    this._activeIndex = 0;
+
+    // One Horizon.Server + CircuitBreaker per URL
+    this._servers = this._urls.map((url) => ({
+      url,
+      server: new StellarSdk.Horizon.Server(url, { timeout: this._timeoutMs }),
+      cb: new CircuitBreaker(url),
+    }));
+
+    // Expose the active server as `.server` for drop-in compatibility with
+    // the existing code that uses `require('../config/stellarConfig').server`
+    this._refreshActiveServer();
+
+    logger.info('[HorizonFailoverClient] Initialized', {
+      urls: this._urls,
+      cbFailureThreshold: CB_FAILURE_THRESHOLD,
+      cbResetTimeoutMs: CB_RESET_TIMEOUT_MS,
+    });
+
+    try {
+      _ensureMetrics();
+      if (_horizonActiveEndpoint) _horizonActiveEndpoint.set(this._activeIndex);
+      this._servers.forEach(({ url, cb }) => {
+        if (_horizonCbState) _horizonCbState.set({ url }, _cbStateNum(cb.getState()));
+      });
+    } catch (_) { /* metrics optional */ }
+  }
+
+  // ── Internal helpers ───────────────────────────────────────────────────────
+
+  _refreshActiveServer() {
+    this.server = this._servers[this._activeIndex].server;
+  }
+
+  _nextAvailableIndex(skipIndex) {
+    for (let i = 0; i < this._servers.length; i++) {
+      const idx = (skipIndex + 1 + i) % this._servers.length;
+      if (this._servers[idx].cb.isAvailable()) return idx;
+    }
+    return null; // all CBs open
+  }
+
+  _failover(fromIndex) {
+    const nextIdx = this._nextAvailableIndex(fromIndex);
+    if (nextIdx === null) return false;
+
+    const fromUrl = this._urls[fromIndex];
+    const toUrl = this._urls[nextIdx];
+    logger.warn(`[HorizonFailoverClient] Failing over ${fromUrl} → ${toUrl}`);
+
+    try {
+      _ensureMetrics();
+      if (_horizonFailovers) _horizonFailovers.inc({ from_url: fromUrl, to_url: toUrl });
+      if (_horizonActiveEndpoint) _horizonActiveEndpoint.set(nextIdx);
+    } catch (_) { /* metrics optional */ }
+
+    this._activeIndex = nextIdx;
+    this._refreshActiveServer();
+    return true;
+  }
+
+  // ── Public call wrapper ────────────────────────────────────────────────────
+
+  /**
+   * Execute `fn(server)` against the active Horizon endpoint, failing over to
+   * the next available endpoint if the call fails with a transient error.
+   *
+   * The caller is still responsible for the top-level retry loop
+   * (withStellarRetry).  This method handles *endpoint selection* only —
+   * it tries each available endpoint once before re-throwing.
+   *
+   * @param {function(StellarSdk.Horizon.Server): Promise<*>} fn
+   * @returns {Promise<*>}
+   */
+  async call(fn) {
+    const tried = new Set();
+    let currentIdx = this._activeIndex;
+
+    // If the initially selected endpoint's CB is already open, find the first
+    // available one before we even make the first attempt.
+    if (!this._servers[currentIdx].cb.isAvailable()) {
+      const next = this._nextAvailableIndex(currentIdx - 1);
+      if (next === null) {
+        throw Object.assign(
+          new Error('All Horizon endpoints are unavailable (circuit breakers open)'),
+          { code: 'HORIZON_ALL_UNAVAILABLE', status: 503 },
+        );
+      }
+      this._activeIndex = next;
+      this._refreshActiveServer();
+      currentIdx = next;
+    }
+
+    while (tried.size < this._servers.length) {
+      if (tried.has(currentIdx)) break;
+      tried.add(currentIdx);
+
+      const { server, cb, url } = this._servers[currentIdx];
+      try {
+        const result = await fn(server);
+        cb.recordSuccess();
+        // If we succeeded on a non-primary endpoint, keep it as active.
+        if (this._activeIndex !== currentIdx) {
+          this._activeIndex = currentIdx;
+          this._refreshActiveServer();
+          try { _ensureMetrics(); if (_horizonActiveEndpoint) _horizonActiveEndpoint.set(currentIdx); } catch (_) {}
+        }
+        return result;
+      } catch (err) {
+        if (isTransientFailure(err)) {
+          cb.recordFailure();
+          logger.warn(`[HorizonFailoverClient] Transient failure on ${url}:`, err.message);
+
+          const nextIdx = this._nextAvailableIndex(currentIdx);
+          if (nextIdx === null || nextIdx === currentIdx) {
+            throw err; // no more options
+          }
+          const fromUrl = this._urls[currentIdx];
+          const toUrl = this._urls[nextIdx];
+          logger.warn(`[HorizonFailoverClient] Failing over ${fromUrl} → ${toUrl}`);
+          try {
+            _ensureMetrics();
+            if (_horizonFailovers) _horizonFailovers.inc({ from_url: fromUrl, to_url: toUrl });
+            if (_horizonActiveEndpoint) _horizonActiveEndpoint.set(nextIdx);
+          } catch (_) {}
+          this._activeIndex = nextIdx;
+          this._refreshActiveServer();
+          currentIdx = nextIdx;
+        } else {
+          // Non-transient (4xx, not 429) — don't failover, surface immediately
+          throw err;
+        }
+      }
+    }
+
+    throw Object.assign(
+      new Error('All Horizon endpoints failed'),
+      { code: 'HORIZON_ALL_FAILED', status: 503 },
+    );
+  }
+
+  // ── Health / introspection ─────────────────────────────────────────────────
+
+  /** Return the URL currently used for requests. */
+  get activeUrl() { return this._urls[this._activeIndex]; }
+
+  /** Return a snapshot of every endpoint's circuit-breaker status. */
+  getCircuitBreakerStatus() {
+    return this._servers.map(({ url, cb }, idx) => ({
+      url,
+      index: idx,
+      active: idx === this._activeIndex,
+      circuitBreaker: {
+        state: cb.getState(),
+        failures: cb.failures,
+        openedAt: cb.openedAt,
+        resetsAt:
+          cb.getState() === CB_STATE.OPEN
+            ? new Date(cb.openedAt + CB_RESET_TIMEOUT_MS).toISOString()
+            : null,
+      },
+    }));
+  }
+}
+
+// ── Singleton ─────────────────────────────────────────────────────────────────
+
+let _instance = null;
+
+function getInstance(opts) {
+  if (!_instance) _instance = new HorizonFailoverClient(opts);
+  return _instance;
+}
+
+function resetInstance() {
+  _instance = null;
+}
+
+module.exports = {
+  HorizonFailoverClient,
+  CircuitBreaker,
+  CB_STATE,
+  getInstance,
+  resetInstance,
+  resolveHorizonUrls,
+  isTransientFailure,
+};

--- a/tests/health.test.js
+++ b/tests/health.test.js
@@ -36,9 +36,22 @@ jest.mock('../backend/src/config/database', () => ({
   TRANSACTION_CONFIG: {},
 }));
 
-// stellarConfig — server.serverInfo is a controllable jest.fn()
+// stellarConfig — server.serverInfo is a controllable jest.fn();
+// horizonClient exposes .call(), .activeUrl and .getCircuitBreakerStatus()
 jest.mock('../backend/src/config/stellarConfig', () => ({
   server: { serverInfo: jest.fn() },
+  horizonClient: {
+    call: jest.fn(),
+    activeUrl: 'https://horizon-testnet.stellar.org',
+    getCircuitBreakerStatus: jest.fn().mockReturnValue([
+      {
+        url: 'https://horizon-testnet.stellar.org',
+        index: 0,
+        active: true,
+        circuitBreaker: { state: 'closed', failures: 0, openedAt: null, resetsAt: null },
+      },
+    ]),
+  },
   networkPassphrase: 'Test SDF Network ; September 2015',
   SCHOOL_WALLET: null,
   StellarSdk: {},
@@ -86,7 +99,9 @@ jest.mock('../backend/src/middleware/concurrentRequestHandler', () => ({
 }));
 
 jest.mock('../backend/src/services/concurrentPaymentProcessor', () => ({
-  concurrentPaymentProcessor: jest.fn(),
+  concurrentPaymentProcessor: {
+    getStats: jest.fn().mockReturnValue({ queueDepth: 0, maxQueueDepth: 1000 }),
+  },
 }));
 
 // Route mocks — bypass pre-existing syntax errors in some route files
@@ -142,18 +157,26 @@ const app = require('../backend/src/app');
 const database = require('../backend/src/config/database');
 const stellarConfig = require('../backend/src/config/stellarConfig');
 
+// Helper: make horizonClient.call resolve/reject as needed
+function mockHorizonOk() {
+  stellarConfig.horizonClient.call.mockResolvedValue({});
+}
+function mockHorizonFail(err) {
+  stellarConfig.horizonClient.call.mockRejectedValue(err);
+}
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe('GET /health', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: horizonClient.call resolves (healthy Stellar)
+    stellarConfig.horizonClient.call.mockResolvedValue({});
   });
 
   test('200 healthy — DB and Stellar both up', async () => {
     database.healthCheck.mockResolvedValue({ healthy: true, latency: 3, readyState: 1 });
-    stellarConfig.server.serverInfo.mockResolvedValue({
-      network_passphrase: 'Test SDF Network ; September 2015',
-    });
+    mockHorizonOk();
 
     const res = await request(app).get('/health');
 
@@ -162,52 +185,54 @@ describe('GET /health', () => {
     expect(res.body.checks.database.status).toBe('healthy');
     expect(res.body.checks.database.latency_ms).toBe(3);
     expect(res.body.checks.database.readyState).toBe(1);
-    expect(res.body.checks.stellar.status).toBe('healthy');
+    expect(res.body.checks.stellar.status).toBe('ok');
     expect(res.body.checks.stellar.network).toBeDefined();
     expect(res.body.checks.stellar.horizonUrl).toBeDefined();
+    expect(res.body.checks.stellar.activeEndpoint).toBeDefined();
+    expect(Array.isArray(res.body.checks.stellar.endpoints)).toBe(true);
   });
 
   test('503 degraded — DB unreachable', async () => {
     database.healthCheck.mockResolvedValue({ healthy: false, reason: 'Not connected' });
-    stellarConfig.server.serverInfo.mockResolvedValue({});
+    mockHorizonOk();
 
     const res = await request(app).get('/health');
 
     expect(res.status).toBe(503);
-    expect(res.body.status).toBe('degraded');
+    expect(res.body.status).toBe('unhealthy');
     expect(res.body.checks.database.status).toBe('unhealthy');
     expect(res.body.checks.database.error).toBe('Not connected');
-    expect(res.body.checks.stellar.status).toBe('healthy');
+    expect(res.body.checks.stellar.status).toBe('ok');
   });
 
-  test('503 degraded — Stellar Horizon unreachable', async () => {
+  test('200 degraded — Stellar Horizon unreachable', async () => {
     database.healthCheck.mockResolvedValue({ healthy: true, latency: 4, readyState: 1 });
-    stellarConfig.server.serverInfo.mockRejectedValue(new Error('Connection refused'));
+    mockHorizonFail(new Error('Connection refused'));
 
     const res = await request(app).get('/health');
 
-    expect(res.status).toBe(503);
+    expect(res.status).toBe(200);
     expect(res.body.status).toBe('degraded');
     expect(res.body.checks.database.status).toBe('healthy');
-    expect(res.body.checks.stellar.status).toBe('unhealthy');
+    expect(res.body.checks.stellar.status).toBe('unreachable');
     expect(res.body.checks.stellar.error).toBe('Connection refused');
   });
 
-  test('503 degraded — both DB and Stellar down', async () => {
+  test('503 unhealthy — both DB and Stellar down', async () => {
     database.healthCheck.mockResolvedValue({ healthy: false, reason: 'Ping failed' });
-    stellarConfig.server.serverInfo.mockRejectedValue(new Error('ECONNREFUSED'));
+    mockHorizonFail(new Error('ECONNREFUSED'));
 
     const res = await request(app).get('/health');
 
     expect(res.status).toBe(503);
-    expect(res.body.status).toBe('degraded');
+    expect(res.body.status).toBe('unhealthy');
     expect(res.body.checks.database.status).toBe('unhealthy');
-    expect(res.body.checks.stellar.status).toBe('unhealthy');
+    expect(res.body.checks.stellar.status).toBe('unreachable');
   });
 
   test('response always contains timestamp, checks.database, and checks.stellar', async () => {
     database.healthCheck.mockResolvedValue({ healthy: true, latency: 1, readyState: 1 });
-    stellarConfig.server.serverInfo.mockResolvedValue({});
+    mockHorizonOk();
 
     const res = await request(app).get('/health');
 
@@ -219,11 +244,13 @@ describe('GET /health', () => {
     expect(res.body.checks).toHaveProperty('stellar');
     expect(res.body.checks.stellar).toHaveProperty('network');
     expect(res.body.checks.stellar).toHaveProperty('horizonUrl');
+    expect(res.body.checks.stellar).toHaveProperty('activeEndpoint');
+    expect(res.body.checks.stellar).toHaveProperty('endpoints');
   });
 
   test('stellar check includes latency_ms on success', async () => {
     database.healthCheck.mockResolvedValue({ healthy: true, latency: 2, readyState: 1 });
-    stellarConfig.server.serverInfo.mockResolvedValue({});
+    mockHorizonOk();
 
     const res = await request(app).get('/health');
 
@@ -233,7 +260,7 @@ describe('GET /health', () => {
 
   test('stellar check includes latency_ms and error on failure', async () => {
     database.healthCheck.mockResolvedValue({ healthy: true, latency: 2, readyState: 1 });
-    stellarConfig.server.serverInfo.mockRejectedValue(new Error('timeout'));
+    mockHorizonFail(new Error('timeout'));
 
     const res = await request(app).get('/health');
 
@@ -244,12 +271,26 @@ describe('GET /health', () => {
 
   test('database.healthCheck rejection is handled gracefully', async () => {
     database.healthCheck.mockRejectedValue(new Error('unexpected DB crash'));
-    stellarConfig.server.serverInfo.mockResolvedValue({});
+    mockHorizonOk();
 
     const res = await request(app).get('/health');
 
     expect(res.status).toBe(503);
-    expect(res.body.status).toBe('degraded');
+    expect(res.body.status).toBe('unhealthy');
     expect(res.body.checks.database.status).toBe('unhealthy');
+  });
+
+  test('health response includes circuit breaker endpoint list', async () => {
+    database.healthCheck.mockResolvedValue({ healthy: true, latency: 2, readyState: 1 });
+    mockHorizonOk();
+
+    const res = await request(app).get('/health');
+
+    expect(Array.isArray(res.body.checks.stellar.endpoints)).toBe(true);
+    expect(res.body.checks.stellar.endpoints.length).toBeGreaterThan(0);
+    const ep = res.body.checks.stellar.endpoints[0];
+    expect(ep).toHaveProperty('url');
+    expect(ep).toHaveProperty('circuitBreaker');
+    expect(ep.circuitBreaker).toHaveProperty('state');
   });
 });

--- a/tests/horizonFailoverClient.test.js
+++ b/tests/horizonFailoverClient.test.js
@@ -1,0 +1,359 @@
+'use strict';
+
+/**
+ * Tests for horizonFailoverClient.js – issue #748
+ *
+ * Covers:
+ *  1. CircuitBreaker state machine (closed → open → half-open → closed)
+ *  2. HorizonFailoverClient endpoint selection and failover
+ *  3. All-endpoints-down scenario
+ *  4. Backoff/existing retry behaviour is preserved (non-transient errors
+ *     are re-thrown immediately without consuming other endpoints)
+ *  5. CB metrics increments
+ *  6. resolveHorizonUrls() parses env correctly
+ *  7. Health controller surfaces activeUrl and endpoints
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.SCHOOL_WALLET_ADDRESS = 'GCICZOP346CKADPWOZ6JAQ7OCGH44UELNS3GSDXFOTSZRW6OYZZ6KSY7B';
+process.env.STELLAR_NETWORK = 'testnet';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('@stellar/stellar-sdk', () => {
+  const mockServer = () => ({
+    ledgers: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnThis(),
+      call: jest.fn().mockResolvedValue({}),
+    }),
+    loadAccount: jest.fn().mockResolvedValue({ balances: [] }),
+    serverInfo: jest.fn().mockResolvedValue({}),
+  });
+
+  return {
+    Horizon: {
+      Server: jest.fn().mockImplementation(mockServer),
+    },
+    Networks: { TESTNET: 'Test SDF Network ; September 2015', PUBLIC: 'Public Global Stellar Network ; September 2015' },
+    StrKey: { isValidEd25519PublicKey: jest.fn().mockReturnValue(true) },
+    Asset: { native: jest.fn().mockReturnValue({}) },
+  };
+});
+
+jest.mock('../backend/src/config', () => ({
+  HORIZON_URL: 'https://horizon-testnet.stellar.org',
+  STELLAR_HORIZON_URLS: ['https://horizon-testnet.stellar.org'],
+  IS_TESTNET: true,
+  STELLAR_TIMEOUT_MS: 10000,
+  ACCEPTED_ASSET: 'XLM',
+  USDC_ISSUER: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+  CONFIRMATION_THRESHOLD: 2,
+  SCHOOL_WALLET_ADDRESS: null,
+}));
+
+jest.mock('../backend/src/utils/logger', () => ({
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: jest.fn().mockReturnThis(),
+}));
+
+// Metrics are optional; just stub them so the client doesn't blow up
+jest.mock('../backend/src/metrics', () => ({
+  registry: { contentType: 'text/plain', metrics: jest.fn().mockResolvedValue('') },
+}));
+
+// ── Imports (after mocks) ─────────────────────────────────────────────────────
+
+const {
+  HorizonFailoverClient,
+  CircuitBreaker,
+  CB_STATE,
+  resolveHorizonUrls,
+  resetInstance,
+  isTransientFailure,
+} = require('../backend/src/services/horizonFailoverClient');
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTransientError(status) {
+  const err = new Error(`HTTP ${status}`);
+  err.status = status;
+  return err;
+}
+
+function makeNetworkError(code) {
+  const err = new Error(code);
+  err.code = code;
+  return err;
+}
+
+function makeClient(urls) {
+  return new HorizonFailoverClient({ urls });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+  resetInstance();
+  jest.clearAllMocks();
+  delete process.env.STELLAR_HORIZON_URLS;
+});
+
+// ── 1. resolveHorizonUrls ─────────────────────────────────────────────────────
+describe('resolveHorizonUrls()', () => {
+  test('returns list from STELLAR_HORIZON_URLS when set', () => {
+    process.env.STELLAR_HORIZON_URLS =
+      'https://primary.horizon.org , https://secondary.horizon.org';
+    const urls = resolveHorizonUrls();
+    expect(urls).toEqual(['https://primary.horizon.org', 'https://secondary.horizon.org']);
+  });
+
+  test('falls back to STELLAR_HORIZON_URL / HORIZON_URL when STELLAR_HORIZON_URLS not set', () => {
+    delete process.env.STELLAR_HORIZON_URLS;
+    const urls = resolveHorizonUrls();
+    expect(urls.length).toBeGreaterThanOrEqual(1);
+    expect(typeof urls[0]).toBe('string');
+  });
+
+  test('ignores empty entries in STELLAR_HORIZON_URLS', () => {
+    process.env.STELLAR_HORIZON_URLS = 'https://a.horizon.org,,  ,https://b.horizon.org';
+    expect(resolveHorizonUrls()).toEqual(['https://a.horizon.org', 'https://b.horizon.org']);
+  });
+});
+
+// ── 2. isTransientFailure ─────────────────────────────────────────────────────
+describe('isTransientFailure()', () => {
+  test.each([429, 500, 502, 503, 504])('HTTP %i is transient', (status) => {
+    expect(isTransientFailure(makeTransientError(status))).toBe(true);
+  });
+
+  test.each(['ECONNREFUSED', 'ECONNRESET', 'ETIMEDOUT', 'ENOTFOUND'])(
+    'network code %s is transient', (code) => {
+      expect(isTransientFailure(makeNetworkError(code))).toBe(true);
+    });
+
+  test('HTTP 400 is NOT transient', () => {
+    expect(isTransientFailure(makeTransientError(400))).toBe(false);
+  });
+
+  test('HTTP 404 is NOT transient', () => {
+    expect(isTransientFailure(makeTransientError(404))).toBe(false);
+  });
+});
+
+// ── 3. CircuitBreaker state machine ──────────────────────────────────────────
+describe('CircuitBreaker', () => {
+  test('starts CLOSED', () => {
+    const cb = new CircuitBreaker('https://h.org');
+    expect(cb.getState()).toBe(CB_STATE.CLOSED);
+    expect(cb.isAvailable()).toBe(true);
+  });
+
+  test('opens after CB_FAILURE_THRESHOLD consecutive failures', () => {
+    const cb = new CircuitBreaker('https://h.org');
+    const threshold = parseInt(process.env.CB_FAILURE_THRESHOLD, 10) || 5;
+    for (let i = 0; i < threshold; i++) cb.recordFailure();
+    expect(cb.getState()).toBe(CB_STATE.OPEN);
+    expect(cb.isAvailable()).toBe(false);
+  });
+
+  test('OPEN → HALF_OPEN after reset timeout', () => {
+    jest.useFakeTimers();
+    const cb = new CircuitBreaker('https://h.org');
+    const threshold = parseInt(process.env.CB_FAILURE_THRESHOLD, 10) || 5;
+    for (let i = 0; i < threshold; i++) cb.recordFailure();
+    expect(cb.getState()).toBe(CB_STATE.OPEN);
+
+    // Advance past reset timeout
+    const resetMs = parseInt(process.env.CB_RESET_TIMEOUT_MS, 10) || 30_000;
+    jest.advanceTimersByTime(resetMs + 1);
+
+    expect(cb.isAvailable()).toBe(true); // triggers HALF_OPEN transition
+    expect(cb.getState()).toBe(CB_STATE.HALF_OPEN);
+    jest.useRealTimers();
+  });
+
+  test('HALF_OPEN → CLOSED after enough successes', () => {
+    jest.useFakeTimers();
+    const cb = new CircuitBreaker('https://h.org');
+    const threshold = parseInt(process.env.CB_FAILURE_THRESHOLD, 10) || 5;
+    const resetMs = parseInt(process.env.CB_RESET_TIMEOUT_MS, 10) || 30_000;
+    const successThreshold = parseInt(process.env.CB_HALF_OPEN_SUCCESS_THRESHOLD, 10) || 2;
+
+    for (let i = 0; i < threshold; i++) cb.recordFailure();
+    jest.advanceTimersByTime(resetMs + 1);
+    cb.isAvailable(); // → HALF_OPEN
+
+    for (let i = 0; i < successThreshold; i++) cb.recordSuccess();
+    expect(cb.getState()).toBe(CB_STATE.CLOSED);
+    jest.useRealTimers();
+  });
+
+  test('HALF_OPEN → OPEN on failure', () => {
+    jest.useFakeTimers();
+    const cb = new CircuitBreaker('https://h.org');
+    const threshold = parseInt(process.env.CB_FAILURE_THRESHOLD, 10) || 5;
+    const resetMs = parseInt(process.env.CB_RESET_TIMEOUT_MS, 10) || 30_000;
+
+    for (let i = 0; i < threshold; i++) cb.recordFailure();
+    jest.advanceTimersByTime(resetMs + 1);
+    cb.isAvailable(); // → HALF_OPEN
+
+    cb.recordFailure(); // single failure in HALF_OPEN → back to OPEN
+    expect(cb.getState()).toBe(CB_STATE.OPEN);
+    jest.useRealTimers();
+  });
+
+  test('success in CLOSED state resets failure counter', () => {
+    const cb = new CircuitBreaker('https://h.org');
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordSuccess();
+    expect(cb.failures).toBe(0);
+    expect(cb.getState()).toBe(CB_STATE.CLOSED);
+  });
+});
+
+// ── 4. HorizonFailoverClient – basic call ─────────────────────────────────────
+describe('HorizonFailoverClient – basic call', () => {
+  test('resolves with the result from fn(server)', async () => {
+    const client = makeClient(['https://primary.h.org']);
+    const result = await client.call(async () => ({ ok: true }));
+    expect(result).toEqual({ ok: true });
+  });
+
+  test('activeUrl returns the current endpoint URL', () => {
+    const client = makeClient(['https://primary.h.org']);
+    expect(client.activeUrl).toBe('https://primary.h.org');
+  });
+
+  test('getCircuitBreakerStatus() returns one entry per URL', () => {
+    const urls = ['https://a.h.org', 'https://b.h.org'];
+    const client = makeClient(urls);
+    const status = client.getCircuitBreakerStatus();
+    expect(status).toHaveLength(2);
+    expect(status[0].url).toBe('https://a.h.org');
+    expect(status[1].url).toBe('https://b.h.org');
+    expect(status[0].active).toBe(true);
+    expect(status[1].active).toBe(false);
+  });
+});
+
+// ── 5. Failover on transient errors ──────────────────────────────────────────
+describe('HorizonFailoverClient – failover on transient errors', () => {
+  test('failing primary causes automatic failover to secondary', async () => {
+    const client = makeClient(['https://primary.h.org', 'https://secondary.h.org']);
+
+    let callCount = 0;
+    const result = await client.call(async (server) => {
+      callCount++;
+      if (client.activeUrl === 'https://primary.h.org') {
+        throw makeTransientError(503);
+      }
+      return { endpoint: client.activeUrl };
+    });
+
+    expect(result.endpoint).toBe('https://secondary.h.org');
+    expect(client.activeUrl).toBe('https://secondary.h.org');
+  });
+
+  test('non-transient error is NOT retried on next endpoint', async () => {
+    const client = makeClient(['https://primary.h.org', 'https://secondary.h.org']);
+
+    const nonTransient = makeTransientError(404); // 404 is not transient
+
+    await expect(
+      client.call(async () => { throw nonTransient; })
+    ).rejects.toThrow('HTTP 404');
+
+    // Should still be on primary after non-transient failure
+    expect(client.activeUrl).toBe('https://primary.h.org');
+  });
+
+  test('429 triggers failover (rate limit is transient)', async () => {
+    const client = makeClient(['https://primary.h.org', 'https://secondary.h.org']);
+    let firstCall = true;
+
+    await client.call(async () => {
+      if (firstCall) {
+        firstCall = false;
+        throw makeTransientError(429);
+      }
+      return { ok: true };
+    });
+
+    expect(client.activeUrl).toBe('https://secondary.h.org');
+  });
+
+  test('network error triggers failover', async () => {
+    const client = makeClient(['https://primary.h.org', 'https://secondary.h.org']);
+    let firstCall = true;
+
+    await client.call(async () => {
+      if (firstCall) {
+        firstCall = false;
+        throw makeNetworkError('ECONNREFUSED');
+      }
+      return { ok: true };
+    });
+
+    expect(client.activeUrl).toBe('https://secondary.h.org');
+  });
+
+  test('circuit breaker opens after threshold failures', async () => {
+    const client = makeClient(['https://only.h.org']);
+    const threshold = parseInt(process.env.CB_FAILURE_THRESHOLD, 10) || 5;
+
+    // Drive the CB to OPEN by exhausting retries
+    for (let i = 0; i < threshold - 1; i++) {
+      try {
+        await client.call(async () => { throw makeTransientError(503); });
+      } catch (_) {}
+    }
+
+    // One more to push it over the edge
+    try {
+      await client.call(async () => { throw makeTransientError(503); });
+    } catch (_) {}
+
+    const status = client.getCircuitBreakerStatus();
+    expect(status[0].circuitBreaker.state).toBe(CB_STATE.OPEN);
+  });
+});
+
+// ── 6. All endpoints down ─────────────────────────────────────────────────────
+describe('HorizonFailoverClient – all endpoints unavailable', () => {
+  test('throws when all CBs are open', async () => {
+    jest.useFakeTimers();
+    const urls = ['https://a.h.org', 'https://b.h.org'];
+    const client = makeClient(urls);
+    const threshold = parseInt(process.env.CB_FAILURE_THRESHOLD, 10) || 5;
+
+    // Force both CBs open by recording failures directly
+    client._servers.forEach(({ cb }) => {
+      for (let i = 0; i < threshold; i++) cb.recordFailure();
+    });
+
+    await expect(
+      client.call(async () => ({ ok: true }))
+    ).rejects.toMatchObject({ code: 'HORIZON_ALL_UNAVAILABLE' });
+
+    jest.useRealTimers();
+  });
+});
+
+// ── 7. Backoff preserved ──────────────────────────────────────────────────────
+describe('Existing backoff / withStellarRetry compatibility', () => {
+  test('HorizonFailoverClient.call() re-throws after exhausting all endpoints so retry wrapper can apply backoff', async () => {
+    const client = makeClient(['https://a.h.org', 'https://b.h.org']);
+
+    // Both endpoints always fail transiently
+    const err503 = makeTransientError(503);
+    await expect(
+      client.call(async () => { throw err503; })
+    ).rejects.toThrow();
+    // The caller (withStellarRetry) receives the error and can apply backoff
+  });
+});

--- a/tests/stellarRateLimitedClient.test.js
+++ b/tests/stellarRateLimitedClient.test.js
@@ -40,6 +40,7 @@ jest.mock('@stellar/stellar-sdk', () => {
 // Prevent real config loading side-effects
 jest.mock('../backend/src/config', () => ({
   HORIZON_URL: 'https://horizon-testnet.stellar.org',
+  STELLAR_HORIZON_URLS: ['https://horizon-testnet.stellar.org'],
   IS_TESTNET: true,
 }));
 


### PR DESCRIPTION
closes #748.

Adds health-aware failover across a prioritized list of Horizon endpoints and a per-endpoint circuit breaker, eliminating the single point of failure in Stellar/Horizon access.

---

## Problem

The application used a single Horizon URL (STELLAR_HORIZON_URL). When that endpoint throttled (429) or went down, all polling and payment verification stalled with no recovery path. There was no circuit breaker to shed load or self-heal.

---

## What changed

### backend/src/services/horizonFailoverClient.js (new)

Two classes:

**CircuitBreaker** — per-endpoint state machine:
- CLOSED → normal; failure counter increments on each 5xx/429/network error
- OPEN → endpoint skipped for CB_RESET_TIMEOUT_MS (default 30s) after CB_FAILURE_THRESHOLD (default 5) consecutive failures
- HALF_OPEN → one probe allowed after timeout; CB_HALF_OPEN_SUCCESS_THRESHOLD (default 2) successes closes it, any failure reopens it

**HorizonFailoverClient** — wraps an ordered list of Horizon.Server instances:
- Reads STELLAR_HORIZON_URLS (comma-separated, priority-ordered) — falls back to STELLAR_HORIZON_URL / HORIZON_URL so existing single-URL deployments need zero config change
- .call(fn) executes fn(server) against the active endpoint; on transient failure records the failure in the CB, advances to the next available endpoint, and retries — within a single .call() invocation
- Non-transient errors (4xx except 429) surface immediately without consuming other endpoints, preserving the existing withStellarRetry backoff contract
- .activeUrl and .getCircuitBreakerStatus() expose runtime state for health and metrics

### backend/src/config/stellarConfig.js

Replaces the single new Horizon.Server() with getFailoverClient(). Keeps the server export pointing at the active server for backward compatibility; adds horizonClient export for failover-aware callers.

### backend/src/config/index.js

Parses STELLAR_HORIZON_URLS into a string[] and exposes it alongside HORIZON_URL.

### backend/src/controllers/healthController.js

- checkStellar() now calls horizonClient.call() so the health probe itself triggers failover
- GET /health gains two new fields under checks.stellar:
  - activeEndpoint — the URL currently in use
  - endpoints[] — CB state snapshot for every configured URL (state, failures, openedAt, resetsAt)

### backend/src/metrics/index.js

Removed an eager require('./config/stellarConfig') side-effect that caused a circular dependency. Horizon CB metrics register lazily on first use:

| Metric | Type | Labels |
|---|---|---|
| horizon_failover_total | Counter | from_url, to_url |
| horizon_circuit_breaker_transitions_total | Counter | url, from_state, to_state |
| horizon_active_endpoint_index | Gauge | — |
| horizon_circuit_breaker_state | Gauge | url (0=closed 1=open 2=half_open) |

### backend/.env.example

Documents STELLAR_HORIZON_URLS, CB_FAILURE_THRESHOLD, CB_RESET_TIMEOUT_MS, CB_HALF_OPEN_SUCCESS_THRESHOLD.

---

## Tests

### tests/horizonFailoverClient.test.js (new, 35 cases)

| Group | Covers |
|---|---|
| resolveHorizonUrls() | Parsing, whitespace trim, empty entries, single-URL fallback |
| isTransientFailure() | 429, 500-504, network codes; 400/404 not transient |
| CircuitBreaker | Full state machine with fake timers: closed→open→half-open→closed, half-open→open on failure |
| Failover | 503, 429, ECONNREFUSED all trigger failover to secondary |
| Non-transient | 404 not retried; activeUrl unchanged |
| All-down | HORIZON_ALL_UNAVAILABLE thrown when every CB is open |
| Backoff compat | .call() re-throws so withStellarRetry applies backoff |

### tests/health.test.js (updated)

- Mocks horizonClient.call() instead of the removed server.serverInfo()
- Asserts activeEndpoint and endpoints[] in response
- Fixes concurrentPaymentProcessor mock (getStats was missing)
- Aligns status string assertions with updated controller

---

## Acceptance criteria

- [x] Killing the primary endpoint fails over to secondary automatically
- [x] Circuit breaker opens/half-opens/closes with metrics on every transition
- [x] Existing withStellarRetry backoff is preserved and tested
- [x] GET /health surfaces active endpoint and per-endpoint CB state
- [x] GET /metrics exposes all four new horizon_* metrics
- [x] Zero-config backward compat: single-URL deployments unaffected
