### PR TITLE
feat(idempotency): single source of truth + shared key derivation

### DIFF
--- a/backend/src/middleware/idempotency.js
+++ b/backend/src/middleware/idempotency.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const IdempotencyKey = require('../models/idempotencyKeyModel');
+const { deriveIdempotencyKey } = require('../utils/idempotencyKey');
+const idempotencyStore = require('../services/idempotencyStore');
 
 /**
  * Idempotency middleware.
@@ -10,22 +11,29 @@ const IdempotencyKey = require('../models/idempotencyKeyModel');
  * - If the key is new, processes the request normally and caches the response.
  * - If the header is missing, rejects with 400.
  *
+ * The canonical key is derived via the shared `deriveIdempotencyKey` util
+ * (scoped by request path) and stored in the persistent `idempotencyStore`, so
+ * a replay is recognized after a restart or on another replica — and the
+ * derivation never diverges from the payment processor's.
+ *
  * Usage: apply to individual POST routes that must be idempotent.
  */
 function idempotency(req, res, next) {
-  const key = req.headers['idempotency-key'];
+  const rawKey = req.headers['idempotency-key'];
 
-  if (!key || typeof key !== 'string' || !key.trim()) {
+  if (!rawKey || typeof rawKey !== 'string' || !rawKey.trim()) {
     return res.status(400).json({
       error: 'Idempotency-Key header is required for this request',
       code: 'MISSING_IDEMPOTENCY_KEY',
     });
   }
 
-  const normalizedKey = key.trim();
+  const scope = req.path;
+  const canonicalKey = deriveIdempotencyKey(rawKey, scope);
 
   // Check for a cached response
-  IdempotencyKey.findOne({ key: normalizedKey, requestPath: req.path })
+  idempotencyStore
+    .get(canonicalKey)
     .then((record) => {
       if (record) {
         // Replay the cached response — same status, same body
@@ -38,17 +46,15 @@ function idempotency(req, res, next) {
       res.json = function (body) {
         // Only cache successful or expected error responses (not 5xx)
         if (res.statusCode < 500) {
-          IdempotencyKey.create({
-            key: normalizedKey,
-            requestPath: req.path,
-            responseStatus: res.statusCode,
-            responseBody: body,
-          }).catch((err) => {
-            // Duplicate key race condition — safe to ignore, another request won
-            if (err.code !== 11000) {
+          idempotencyStore
+            .set(canonicalKey, {
+              scope,
+              responseStatus: res.statusCode,
+              responseBody: body,
+            })
+            .catch((err) => {
               console.error('[Idempotency] Failed to cache response:', err.message);
-            }
-          });
+            });
         }
         return originalJson(body);
       };
@@ -56,7 +62,7 @@ function idempotency(req, res, next) {
       next();
     })
     .catch((err) => {
-      console.error('[Idempotency] DB lookup failed:', err.message);
+      console.error('[Idempotency] store lookup failed:', err.message);
       // Fail open — let the request through rather than blocking the user
       next();
     });

--- a/backend/src/models/idempotencyKeyModel.js
+++ b/backend/src/models/idempotencyKeyModel.js
@@ -8,12 +8,23 @@ const mongoose = require('mongoose');
 const TTL_SECONDS = parseInt(process.env.IDEMPOTENCY_KEY_TTL_SECONDS || '86400', 10);
 
 /**
- * Stores idempotency key → cached response mappings.
+ * Persistent idempotency store — the single source of truth for whether a
+ * logical request has already been processed. Keyed by the canonical key
+ * produced by `utils/idempotencyKey.deriveIdempotencyKey`, which already folds
+ * the operation scope into the hash, so the canonical `key` alone is unique.
+ *
+ * Records survive process restarts and are shared across replicas, so a request
+ * replayed after a deploy (or hitting a second replica) is still recognized as
+ * a duplicate.
+ *
  * TTL index automatically purges records after IDEMPOTENCY_KEY_TTL_SECONDS.
  */
 const idempotencyKeySchema = new mongoose.Schema({
   key: { type: String, required: true, unique: true, index: true },
-  requestPath: { type: String, required: true },
+  // Informational namespace for the canonical key (e.g. a request path or
+  // 'payment-processor'). The scope is already baked into `key`; this is kept
+  // for debuggability and is not part of the lookup.
+  scope: { type: String, default: '' },
   responseStatus: { type: Number, required: true },
   responseBody: { type: mongoose.Schema.Types.Mixed, required: true },
   createdAt: { type: Date, default: Date.now, expires: TTL_SECONDS },

--- a/backend/src/services/concurrentPaymentProcessor.js
+++ b/backend/src/services/concurrentPaymentProcessor.js
@@ -7,38 +7,87 @@ const Student = require("../models/studentModel");
 const Payment = require("../models/paymentModel");
 const PaymentIntent = require("../models/paymentIntentModel");
 const { sendPaymentWebhook } = require("./webhookService");
+const { deriveIdempotencyKey } = require("../utils/idempotencyKey");
+const idempotencyStore = require("./idempotencyStore");
+
+// Scope under which the processor namespaces its idempotency keys. Distinct
+// from any HTTP middleware scope (request path) so the two layers never collide
+// in the shared persistent store — while still deriving keys through the same
+// canonical function, so they cannot disagree about what a given client key
+// means.
+const PROCESSOR_SCOPE = "payment-processor";
+
+// Reconstruct a PaymentProcessingResult from a persisted JSON body so replayed
+// results behave like freshly produced ones (`.success`, `.toJSON()`).
+function rehydrateResult(body) {
+  if (!body) return null;
+  const result = new PaymentProcessingResult(
+    Boolean(body.success),
+    body.data || {},
+    body.error || null
+  );
+  if (body.timestamp) result.timestamp = body.timestamp;
+  return result;
+}
 
 // ── Idempotency Cache ─────────────────────────────────────────────────────────
+// Demoted to a pure read-through cache of the persistent `idempotencyStore`.
+// The persistent store (Mongo, optionally fronted by Redis) is the single
+// source of truth and survives restarts / spans replicas; this in-process Map
+// is only an L1 to skip a store round-trip within the TTL window.
 class IdempotencyCache {
-  constructor(ttlMs = 60000) {
-    this.cache = new Map();
+  constructor(ttlMs = 60000, store = idempotencyStore) {
+    this.l1 = new Map();
     this.ttlMs = ttlMs;
+    this.store = store;
+    this.scope = PROCESSOR_SCOPE;
   }
 
-  has(key) {
-    const entry = this.cache.get(key);
-    if (!entry) return false;
+  _l1Get(canonicalKey) {
+    const entry = this.l1.get(canonicalKey);
+    if (!entry) return null;
     if (Date.now() > entry.expiresAt) {
-      this.cache.delete(key);
-      return false;
+      this.l1.delete(canonicalKey);
+      return null;
     }
-    return true;
+    return entry.result;
   }
 
-  get(key) {
-    if (!this.has(key)) return null;
-    return this.cache.get(key).result;
+  // Returns a cached PaymentProcessingResult or null. The persistent store is
+  // authoritative; the L1 is consulted first only as an optimization.
+  async get(rawKey) {
+    const canonicalKey = deriveIdempotencyKey(rawKey, this.scope);
+    if (!canonicalKey) return null;
+
+    const local = this._l1Get(canonicalKey);
+    if (local) return local;
+
+    const record = await this.store.get(canonicalKey);
+    if (!record) return null;
+
+    const result = rehydrateResult(record.responseBody);
+    this.l1.set(canonicalKey, { result, expiresAt: Date.now() + this.ttlMs });
+    return result;
   }
 
-  set(key, result) {
-    this.cache.set(key, { result, expiresAt: Date.now() + this.ttlMs });
-    if (this.cache.size % 100 === 0) this.cleanup();
+  async set(rawKey, result) {
+    const canonicalKey = deriveIdempotencyKey(rawKey, this.scope);
+    if (!canonicalKey) return;
+
+    this.l1.set(canonicalKey, { result, expiresAt: Date.now() + this.ttlMs });
+    if (this.l1.size % 100 === 0) this.cleanup();
+
+    await this.store.set(canonicalKey, {
+      scope: this.scope,
+      responseStatus: 200,
+      responseBody: result.toJSON ? result.toJSON() : result,
+    });
   }
 
   cleanup() {
     const now = Date.now();
-    for (const [key, entry] of this.cache.entries()) {
-      if (now > entry.expiresAt) this.cache.delete(key);
+    for (const [key, entry] of this.l1.entries()) {
+      if (now > entry.expiresAt) this.l1.delete(key);
     }
   }
 }
@@ -146,12 +195,16 @@ class ConcurrentPaymentProcessor {
       );
     }
 
-    // Idempotency check
-    if (idempotencyKey && this.idempotencyCache.has(idempotencyKey)) {
-      logger.info("[PaymentProcessor] Returning cached result", {
-        idempotencyKey,
-      });
-      return this.idempotencyCache.get(idempotencyKey);
+    // Idempotency check — persistent store is the source of truth, so a replay
+    // is recognized even after a restart or on another replica.
+    if (idempotencyKey) {
+      const cached = await this.idempotencyCache.get(idempotencyKey);
+      if (cached) {
+        logger.info("[PaymentProcessor] Returning persisted idempotent result", {
+          idempotencyKey,
+        });
+        return cached;
+      }
     }
 
     // Rate limit check
@@ -178,7 +231,7 @@ class ConcurrentPaymentProcessor {
           duplicate: true,
           existingPaymentId: existingPayment._id,
         });
-        if (idempotencyKey) this.idempotencyCache.set(idempotencyKey, result);
+        if (idempotencyKey) await this.idempotencyCache.set(idempotencyKey, result);
         return result;
       }
 
@@ -213,7 +266,7 @@ class ConcurrentPaymentProcessor {
 
       // Cache success
       if (idempotencyKey && processingResult.success)
-        this.idempotencyCache.set(idempotencyKey, processingResult);
+        await this.idempotencyCache.set(idempotencyKey, processingResult);
 
       // Trigger webhook (non-blocking)
       this.triggerWebhook(
@@ -542,7 +595,7 @@ class ConcurrentPaymentProcessor {
   // ── Stats ───────────────────────────────────────────────────────────────
   getStats() {
     return {
-      idempotencyCacheSize: this.idempotencyCache.cache.size,
+      idempotencyCacheSize: this.idempotencyCache.l1.size,
       rateLimiterStats: { trackedKeys: this.rateLimiter.requests.size },
       transactionManagerStats: {
         activeTransactions: transactionManager.getActiveTransactionCount(),

--- a/backend/src/services/idempotencyStore.js
+++ b/backend/src/services/idempotencyStore.js
@@ -1,0 +1,121 @@
+'use strict';
+
+/**
+ * Persistent idempotency store — the single source of truth for idempotency
+ * decisions across the app.
+ *
+ * Backing: MongoDB (`idempotencyKeyModel`) is authoritative and durable, so a
+ * replayed request is recognized as a duplicate even after a process restart or
+ * on a different replica. An OPTIONAL Redis layer sits in front as a
+ * read-through cache to avoid a Mongo round-trip on the hot path; it is never
+ * the source of truth. When REDIS_HOST is unset, the store degrades to
+ * Mongo-only, which is fully correct (just one extra query per lookup).
+ *
+ * All keys passed in must already be the canonical key produced by
+ * `utils/idempotencyKey.deriveIdempotencyKey`.
+ */
+
+const IdempotencyKey = require('../models/idempotencyKeyModel');
+const logger = require('../utils/logger').child('IdempotencyStore');
+
+const TTL_SECONDS = IdempotencyKey.TTL_SECONDS;
+const REDIS_PREFIX = 'idem:';
+
+const redisEnabled = Boolean(process.env.REDIS_HOST);
+
+let redis = null;
+if (redisEnabled) {
+  const Redis = require('ioredis');
+  redis = new Redis({
+    host: process.env.REDIS_HOST || 'localhost',
+    port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+    password: process.env.REDIS_PASSWORD || undefined,
+    lazyConnect: true,
+    maxRetriesPerRequest: null,
+    enableOfflineQueue: false,
+  });
+  redis.on('error', (err) => logger.error('Redis idempotency client error', { error: err.message }));
+  redis.connect().catch((err) =>
+    logger.error('Redis idempotency client connect failed', { error: err.message })
+  );
+}
+
+async function redisGet(key) {
+  if (!redis) return null;
+  try {
+    const raw = await redis.get(REDIS_PREFIX + key);
+    return raw ? JSON.parse(raw) : null;
+  } catch (err) {
+    logger.warn('Redis idempotency read failed, falling back to Mongo', { error: err.message });
+    return null;
+  }
+}
+
+async function redisSet(key, record) {
+  if (!redis) return;
+  try {
+    await redis.set(REDIS_PREFIX + key, JSON.stringify(record), 'EX', TTL_SECONDS);
+  } catch (err) {
+    logger.warn('Redis idempotency write failed (non-fatal)', { error: err.message });
+  }
+}
+
+/**
+ * Look up a previously stored idempotency record by canonical key.
+ * Checks Redis first (if enabled), then Mongo; populates Redis on a Mongo hit.
+ *
+ * @param {string} key canonical idempotency key
+ * @returns {Promise<{responseStatus:number, responseBody:*, scope:string}|null>}
+ */
+async function get(key) {
+  if (!key) return null;
+
+  const cached = await redisGet(key);
+  if (cached) return cached;
+
+  const record = await IdempotencyKey.findOne({ key }).lean();
+  if (!record) return null;
+
+  const result = {
+    responseStatus: record.responseStatus,
+    responseBody: record.responseBody,
+    scope: record.scope || '',
+  };
+
+  // Read-through: warm Redis for subsequent lookups.
+  await redisSet(key, result);
+  return result;
+}
+
+/**
+ * Persist an idempotency record. Mongo is written first (source of truth),
+ * then Redis is warmed. A duplicate-key race (another request won) is treated
+ * as success — the stored result is equivalent.
+ *
+ * @param {string} key canonical idempotency key
+ * @param {{responseStatus:number, responseBody:*, scope?:string}} record
+ * @returns {Promise<void>}
+ */
+async function set(key, record) {
+  if (!key) return;
+
+  const doc = {
+    responseStatus: record.responseStatus,
+    responseBody: record.responseBody,
+    scope: record.scope || '',
+  };
+
+  try {
+    await IdempotencyKey.create({ key, ...doc });
+  } catch (err) {
+    if (err.code !== 11000) {
+      logger.error('Failed to persist idempotency record', { error: err.message });
+      throw err;
+    }
+    // Duplicate key — another request already persisted this result. Fine.
+  }
+
+  await redisSet(key, doc);
+}
+
+module.exports = { get, set, redisEnabled };

--- a/backend/src/utils/idempotencyKey.js
+++ b/backend/src/utils/idempotencyKey.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/**
+ * Canonical idempotency-key derivation.
+ *
+ * This is the SINGLE source of truth for turning a client-supplied
+ * `Idempotency-Key` (HTTP header) into the canonical key under which a
+ * request's result is stored and looked up. Both the idempotency middleware
+ * and the concurrent payment processor MUST derive keys through this module so
+ * that the same logical request maps to the same canonical key — otherwise the
+ * two layers can disagree about whether a request is a duplicate.
+ *
+ * Derivation rules:
+ *   - The raw client key is normalized: coerced to string, trimmed. An empty
+ *     or missing key yields `null` (no idempotency).
+ *   - A `scope` namespaces the key so that the same client key used on
+ *     different operations (e.g. a route path vs. the payment processor) does
+ *     not collide. The scope is itself trimmed/normalized.
+ *   - The canonical key is `sha256(scope "\n" clientKey)` hex-encoded. Hashing
+ *     gives a fixed-length, index-friendly key and avoids leaking raw client
+ *     values into logs/storage keys.
+ */
+
+const crypto = require('crypto');
+
+/**
+ * Normalize a raw client-supplied idempotency key.
+ * @param {*} rawKey
+ * @returns {string|null} trimmed string, or null when absent/empty.
+ */
+function normalizeClientKey(rawKey) {
+  if (rawKey === null || rawKey === undefined) return null;
+  const str = String(rawKey).trim();
+  return str.length > 0 ? str : null;
+}
+
+/**
+ * Derive the canonical idempotency key for a (clientKey, scope) pair.
+ * @param {*} rawKey raw client-supplied key (e.g. the Idempotency-Key header)
+ * @param {string} [scope] namespace for the operation (e.g. request path)
+ * @returns {string|null} canonical hex key, or null when no usable client key.
+ */
+function deriveIdempotencyKey(rawKey, scope = '') {
+  const clientKey = normalizeClientKey(rawKey);
+  if (!clientKey) return null;
+
+  const normalizedScope = scope === null || scope === undefined ? '' : String(scope).trim();
+
+  return crypto
+    .createHash('sha256')
+    .update(`${normalizedScope}\n${clientKey}`)
+    .digest('hex');
+}
+
+module.exports = {
+  normalizeClientKey,
+  deriveIdempotencyKey,
+};

--- a/backend/tests/idempotencyKey.test.js
+++ b/backend/tests/idempotencyKey.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+/**
+ * Unit tests for the canonical idempotency-key derivation — the single
+ * function shared by the idempotency middleware and the payment processor.
+ * These guarantee both layers interpret a client key identically (no
+ * divergence) and that scoping prevents cross-operation collisions.
+ */
+
+const crypto = require('crypto');
+const {
+  deriveIdempotencyKey,
+  normalizeClientKey,
+} = require('../src/utils/idempotencyKey');
+
+const sha256 = (s) => crypto.createHash('sha256').update(s).digest('hex');
+
+describe('normalizeClientKey', () => {
+  it('returns null for missing keys', () => {
+    expect(normalizeClientKey(undefined)).toBeNull();
+    expect(normalizeClientKey(null)).toBeNull();
+  });
+
+  it('returns null for empty / whitespace-only keys', () => {
+    expect(normalizeClientKey('')).toBeNull();
+    expect(normalizeClientKey('   ')).toBeNull();
+    expect(normalizeClientKey('\t\n')).toBeNull();
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeClientKey('  abc  ')).toBe('abc');
+  });
+
+  it('coerces non-strings to string', () => {
+    expect(normalizeClientKey(12345)).toBe('12345');
+  });
+});
+
+describe('deriveIdempotencyKey', () => {
+  it('returns null when there is no usable client key', () => {
+    expect(deriveIdempotencyKey(undefined, 'scope')).toBeNull();
+    expect(deriveIdempotencyKey('', 'scope')).toBeNull();
+    expect(deriveIdempotencyKey('   ', 'scope')).toBeNull();
+  });
+
+  it('produces a deterministic sha256 hex string', () => {
+    const key = deriveIdempotencyKey('order-1', 'payment-processor');
+    expect(key).toBe(sha256('payment-processor\norder-1'));
+    expect(key).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('is stable across calls for the same inputs', () => {
+    expect(deriveIdempotencyKey('order-1', 's')).toBe(
+      deriveIdempotencyKey('order-1', 's')
+    );
+  });
+
+  it('normalizes the client key before hashing (whitespace-insensitive)', () => {
+    // The core anti-divergence guarantee: a padded key and a clean key map to
+    // the same canonical key, so middleware and processor cannot disagree.
+    expect(deriveIdempotencyKey('  order-1  ', 's')).toBe(
+      deriveIdempotencyKey('order-1', 's')
+    );
+  });
+
+  it('namespaces by scope so the same client key never collides across operations', () => {
+    const inProcessor = deriveIdempotencyKey('order-1', 'payment-processor');
+    const inMiddleware = deriveIdempotencyKey('order-1', '/api/payments/process');
+    expect(inProcessor).not.toBe(inMiddleware);
+  });
+
+  it('treats missing/empty/whitespace scopes identically', () => {
+    const expected = deriveIdempotencyKey('order-1', '');
+    expect(deriveIdempotencyKey('order-1', undefined)).toBe(expected);
+    expect(deriveIdempotencyKey('order-1', null)).toBe(expected);
+    expect(deriveIdempotencyKey('order-1', '   ')).toBe(expected);
+  });
+
+  it('distinguishes different client keys within the same scope', () => {
+    expect(deriveIdempotencyKey('order-1', 's')).not.toBe(
+      deriveIdempotencyKey('order-2', 's')
+    );
+  });
+});

--- a/backend/tests/idempotencyStore.test.js
+++ b/backend/tests/idempotencyStore.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/**
+ * Tests for the persistent idempotency store.
+ *
+ * The Mongo model is mocked with a Map that lives in the TEST process (not the
+ * module under test), so we can re-require `idempotencyStore` with fresh module
+ * state to simulate a process restart / second replica while the durable
+ * backing survives. Redis is disabled (REDIS_HOST unset), exercising the
+ * Mongo-only source-of-truth path.
+ */
+
+// Durable backing store, shared across module reloads. `mock` prefix lets the
+// hoisted jest.mock factory reference it.
+const mockDb = new Map();
+
+jest.mock('../src/utils/logger', () => ({
+  child: () => ({ info() {}, warn() {}, error() {}, debug() {} }),
+}));
+
+jest.mock('../src/models/idempotencyKeyModel', () => {
+  const model = {
+    findOne: ({ key }) => ({
+      lean: async () => mockDb.get(key) || null,
+    }),
+    create: async (doc) => {
+      if (mockDb.has(doc.key)) {
+        const err = new Error('duplicate key');
+        err.code = 11000;
+        throw err;
+      }
+      mockDb.set(doc.key, doc);
+      return doc;
+    },
+  };
+  model.TTL_SECONDS = 86400;
+  return model;
+});
+
+beforeEach(() => {
+  mockDb.clear();
+  delete process.env.REDIS_HOST;
+  jest.resetModules();
+});
+
+describe('idempotencyStore', () => {
+  it('returns null for an unknown key', async () => {
+    const store = require('../src/services/idempotencyStore');
+    expect(await store.get('missing')).toBeNull();
+  });
+
+  it('persists and reads back a record', async () => {
+    const store = require('../src/services/idempotencyStore');
+    await store.set('k1', { scope: 's', responseStatus: 200, responseBody: { ok: true } });
+
+    const rec = await store.get('k1');
+    expect(rec).toEqual({ scope: 's', responseStatus: 200, responseBody: { ok: true } });
+  });
+
+  it('recognizes a replay after a process restart (fresh module state)', async () => {
+    // Replica A writes the result.
+    const storeA = require('../src/services/idempotencyStore');
+    await storeA.set('order-1', {
+      scope: 'payment-processor',
+      responseStatus: 200,
+      responseBody: { success: true, data: { paymentId: 'p1' } },
+    });
+
+    // Simulate a restart / second replica: brand-new module instance, no
+    // in-process state — only the durable Mongo backing remains.
+    jest.resetModules();
+    const storeB = require('../src/services/idempotencyStore');
+
+    const rec = await storeB.get('order-1');
+    expect(rec).not.toBeNull();
+    expect(rec.responseBody).toEqual({ success: true, data: { paymentId: 'p1' } });
+  });
+
+  it('treats a duplicate-key write race as success', async () => {
+    const store = require('../src/services/idempotencyStore');
+    const record = { scope: 's', responseStatus: 200, responseBody: { ok: 1 } };
+    await store.set('dup', record);
+    // Second writer loses the race; must not throw.
+    await expect(store.set('dup', record)).resolves.toBeUndefined();
+  });
+
+  it('does nothing for a null key', async () => {
+    const store = require('../src/services/idempotencyStore');
+    expect(await store.get(null)).toBeNull();
+    await expect(store.set(null, { responseStatus: 200, responseBody: {} })).resolves.toBeUndefined();
+    expect(mockDb.size).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #742

## Problem

Two idempotency mechanisms coexisted and could disagree:

- An **in-memory** `IdempotencyCache` (60s TTL) in `concurrentPaymentProcessor.js` — per-process, lost on restart, so the same logical payment could be reprocessed after a deploy or on a second replica, defeating the persistent model.
- A **persistent** `idempotencyKeyModel` + `middleware/idempotency.js`.

The two layers also derived the canonical key differently (raw header in the processor vs. trimmed header + request path in the middleware), so the same client key could be interpreted inconsistently.

## Solution

- **Single key derivation** — new `utils/idempotencyKey.js` exposes `deriveIdempotencyKey(rawKey, scope)` (normalize → `sha256(scope "\n" clientKey)`). Both the middleware and the processor go through it, so they can no longer disagree on what a client key means. `scope` namespaces keys so the HTTP layer and the processor don't collide while sharing normalization.
- **One source of truth** — new `services/idempotencyStore.js` with MongoDB as the durable store and an **optional** Redis read-through cache (gated on `REDIS_HOST`; degrades to Mongo-only otherwise).
- **Middleware** now derives the canonical key (scoped by `req.path`) and reads/writes through the store; still fails open on store errors.
- **Processor's `IdempotencyCache` demoted** to a pure read-through L1 over the persistent store. `processPayment` now recognizes a replay after a restart or on another replica.
- **Model** keys by the canonical key alone (scope is folded into the hash).

## Acceptance criteria

- [x] A replayed request after a process restart is still recognized as a duplicate (persistent store; covered by a test that re-requires the store with fresh module state).
- [x] Single key-derivation function with unit tests.
- [x] No divergence between middleware and processor decisions (shared derivation + normalization).

## Tests

- `tests/idempotencyKey.test.js` — 11 cases: normalization, determinism, whitespace-insensitivity, scope namespacing.
- `tests/idempotencyStore.test.js` — persistence across a simulated restart, duplicate-write race, null-key handling.

Both new suites pass.

## Notes

A third, in-memory idempotency middleware lives in `concurrentRequestHandler.js` (`createConcurrentPaymentRoutes`), but it is **unmounted** — `app.js` only uses that module's rate-limiter/queue — so it was left untouched. Worth removing in a follow-up if those routes stay dead.