### PR TITLE
feat(schools): cross-replica cache invalidation on School writes

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -264,6 +264,7 @@ async function shutdown(signal) {
     await bullMQRetryService.shutdownQueue();
     await require('./services/sseService').close();
     await require('./services/distributedLock').close();
+    await require('./services/schoolCacheInvalidator').close();
     logger.info('BullMQ resources closed cleanly');
   } catch (err) {
     logger.error('Error closing BullMQ resources during shutdown', { error: err.message });

--- a/backend/src/controllers/schoolController.js
+++ b/backend/src/controllers/schoolController.js
@@ -6,6 +6,7 @@ const School = require('../models/schoolModel');
 const { logAudit } = require('../services/auditService');
 const { verifyStellarAccountFunding } = require('../services/stellarAccountVerificationService');
 const { validateWebhookUrl } = require('../utils/validateWebhookUrl');
+const schoolCache = require('../services/schoolCacheInvalidator');
 
 function isValidTimezone(tz) {
   try {
@@ -224,6 +225,10 @@ async function updateSchool(req, res, next) {
       { new: true, runValidators: true }
     );
 
+    // Drop the stale lean copy on every replica so the rotated address /
+    // changed config is served within seconds, not after the 5-minute TTL.
+    schoolCache.invalidate(school);
+
     // Audit log — mark stellarAddress changes as high-severity
     if (req.auditContext) {
       await logAudit({
@@ -272,6 +277,9 @@ async function deactivateSchool(req, res, next) {
       e.code = 'NOT_FOUND';
       return next(e);
     }
+
+    // Drop the cached copy everywhere so deactivation blocks requests at once.
+    schoolCache.invalidate(school);
 
     // Audit log
     if (req.auditContext) {
@@ -322,6 +330,7 @@ async function deactivateSchoolEndpoint(req, res, next) {
       });
     }
 
+    schoolCache.invalidate(school);
     res.json({ message: `School "${school.name}" deactivated`, schoolId: school.schoolId, isActive: false });
   } catch (err) {
     next(err);
@@ -356,6 +365,7 @@ async function activateSchool(req, res, next) {
       });
     }
 
+    schoolCache.invalidate(school);
     res.json({ message: `School "${school.name}" activated`, schoolId: school.schoolId, isActive: true });
   } catch (err) {
     next(err);
@@ -402,6 +412,7 @@ async function registerWebhook(req, res, next) {
       });
     }
 
+    schoolCache.invalidate(school);
     res.json({ webhookUrl: school.webhookUrl });
   } catch (err) {
     next(err);

--- a/backend/src/services/schoolCacheInvalidator.js
+++ b/backend/src/services/schoolCacheInvalidator.js
@@ -1,0 +1,135 @@
+'use strict';
+
+/**
+ * Cross-replica invalidation for the school-context cache.
+ *
+ * `schoolContext` middleware caches the lean School doc in the process-local
+ * node-cache with a 5-minute TTL. On a multi-replica deployment that TTL means
+ * a mutation (rotating the Stellar address, deactivating the school, changing
+ * accepted asset) is not reflected on replicas that already cached the doc for
+ * up to 5 minutes — a deactivated school keeps being served, and a rotated
+ * wallet keeps matching payments to the old address.
+ *
+ * To fix this without giving up the fast in-memory read path, every School
+ * write publishes an invalidation message on a Redis pub/sub channel:
+ *
+ *   invalidate(school) -> PUBLISH school:invalidate {schoolId, slug}   (any replica)
+ *   each replica's subscriber receives the message -> deletes the matching
+ *   `school:<id>` / `school:<slug>` keys from its own node-cache.
+ *
+ * The emitting replica also drops its own copy synchronously (deletion is
+ * idempotent, so the echo it receives from its own publish is harmless). This
+ * guarantees the mutating request never serves its own stale entry on the next
+ * read, even before the pub/sub round-trip completes.
+ *
+ * When REDIS_HOST is not configured the service degrades to single-process
+ * mode: invalidate() drops the local copy only, which is correct for a single
+ * replica (there are no other caches to clear).
+ */
+
+const cache = require('../cache');
+const logger = require('../utils/logger').child('SchoolCacheInvalidator');
+
+const CHANNEL = 'school:invalidate';
+
+// Only enabled when REDIS_HOST is set (mirrors sseService / distributedLock).
+// A subscriber connection cannot issue regular commands such as PUBLISH, so two
+// dedicated connections are required.
+const redisEnabled = Boolean(process.env.REDIS_HOST);
+
+const redisConfig = {
+  host: process.env.REDIS_HOST || 'localhost',
+  port: parseInt(process.env.REDIS_PORT, 10) || 6379,
+  password: process.env.REDIS_PASSWORD || undefined,
+  lazyConnect: true,
+  maxRetriesPerRequest: null,
+  enableOfflineQueue: false,
+};
+
+let publisher = null;
+let subscriber = null;
+
+if (redisEnabled) {
+  const Redis = require('ioredis');
+  publisher = new Redis(redisConfig);
+  subscriber = new Redis(redisConfig);
+
+  for (const [name, conn] of [['publisher', publisher], ['subscriber', subscriber]]) {
+    conn.on('error', (err) => logger.error(`Redis ${name} error`, { error: err.message }));
+    conn.connect().catch((err) =>
+      logger.error(`Redis ${name} connect failed`, { error: err.message })
+    );
+  }
+
+  subscriber.on('message', (channel, message) => {
+    if (channel !== CHANNEL) return;
+    try {
+      const { schoolId, slug } = JSON.parse(message);
+      dropLocal(schoolId, slug);
+    } catch (err) {
+      logger.error('Failed to handle invalidation message', { error: err.message, message });
+    }
+  });
+
+  subscriber
+    .subscribe(CHANNEL)
+    .catch((err) => logger.error('School invalidation subscribe failed', { error: err.message }));
+}
+
+/**
+ * Delete this replica's cached entries for a school. The middleware caches the
+ * same doc under both its schoolId and its slug (whichever header was used to
+ * resolve it), so both keys must be cleared.
+ */
+function dropLocal(schoolId, slug) {
+  const keys = [];
+  if (schoolId) keys.push(cache.KEYS.school(schoolId));
+  if (slug) keys.push(cache.KEYS.school(slug));
+  if (keys.length) cache.del(...keys);
+}
+
+/**
+ * Invalidate a school across every replica after a write.
+ *
+ * @param {{schoolId?: string, slug?: string}} school The mutated school (the
+ *   doc returned by the write is fine — only schoolId and slug are read).
+ */
+function invalidate(school) {
+  if (!school) return;
+  const schoolId = school.schoolId;
+  const slug = school.slug;
+  if (!schoolId && !slug) return;
+
+  // Always drop on this replica immediately so the mutating request never
+  // serves its own stale entry — independent of the pub/sub round-trip.
+  dropLocal(schoolId, slug);
+
+  if (publisher) {
+    publisher
+      .publish(CHANNEL, JSON.stringify({ schoolId, slug }))
+      .catch((err) =>
+        logger.error('School invalidation publish failed', { error: err.message, schoolId, slug })
+      );
+  }
+}
+
+/**
+ * Close Redis connections during graceful shutdown.
+ */
+async function close() {
+  try {
+    if (subscriber) await subscriber.quit();
+    if (publisher) await publisher.quit();
+  } catch (err) {
+    logger.error('Error closing school invalidation Redis connections', { error: err.message });
+  }
+}
+
+module.exports = {
+  invalidate,
+  close,
+  CHANNEL,
+  // Exposed for testing
+  _dropLocal: dropLocal,
+  _isRedisEnabled: () => Boolean(publisher),
+};

--- a/backend/tests/schoolCacheInvalidator.test.js
+++ b/backend/tests/schoolCacheInvalidator.test.js
@@ -1,0 +1,177 @@
+'use strict';
+
+/**
+ * Tests for the cross-replica school-cache invalidator.
+ *
+ * Covers the multi-replica guarantee (an invalidate() on one replica drops the
+ * cached doc on another within the pub/sub round-trip), that both the schoolId
+ * and slug keys are cleared, the synchronous local drop on the emitting replica,
+ * and the single-process (no-Redis) fallback.
+ *
+ * ioredis is mocked with an in-process pub/sub bus shared across all client
+ * instances, so two isolated module loads behave like two replicas talking to
+ * the same Redis. Each replica also gets its OWN node-cache instance (the cache
+ * module is re-required inside isolateModules), mirroring per-process caches.
+ */
+
+const EventEmitter = require('events');
+
+// Shared bus across all mocked Redis instances. The `mock` prefix lets the
+// jest.mock factory (hoisted above imports) reference it.
+const mockBus = new EventEmitter();
+mockBus.setMaxListeners(0);
+
+jest.mock('ioredis', () => {
+  const NodeEventEmitter = require('events');
+  return class MockRedis extends NodeEventEmitter {
+    constructor() {
+      super();
+      this._channels = new Set();
+      this._onPublish = (channel, message) => {
+        if (this._channels.has(channel)) this.emit('message', channel, message);
+      };
+      mockBus.on('publish', this._onPublish);
+    }
+    connect() { return Promise.resolve(); }
+    async subscribe(ch) { this._channels.add(ch); }
+    async unsubscribe(ch) { this._channels.delete(ch); }
+    async publish(ch, msg) { mockBus.emit('publish', ch, msg); return 1; }
+    async quit() { mockBus.off('publish', this._onPublish); return 'OK'; }
+  };
+});
+
+// Load a "replica": a fresh invalidator module bound to its own fresh cache
+// instance. Returns both so tests can seed/inspect that replica's cache.
+function loadReplica() {
+  let invalidator;
+  let cache;
+  jest.isolateModules(() => {
+    cache = require('../src/cache');
+    invalidator = require('../src/services/schoolCacheInvalidator');
+  });
+  return { invalidator, cache };
+}
+
+function seed(cache, school) {
+  if (school.schoolId) cache.set(cache.KEYS.school(school.schoolId), school, 300);
+  if (school.slug) cache.set(cache.KEYS.school(school.slug), school, 300);
+}
+
+// Let the publish->message->drop chain settle (publish().catch is async).
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('schoolCacheInvalidator', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    mockBus.removeAllListeners('publish');
+  });
+
+  describe('cross-replica invalidation (Redis pub/sub)', () => {
+    beforeEach(() => {
+      process.env.REDIS_HOST = 'localhost';
+    });
+
+    it('drops a school cached on replica B when replica A invalidates it', async () => {
+      const a = loadReplica();
+      const b = loadReplica();
+
+      const school = { schoolId: 'SCH-1', slug: 'lincoln-high', stellarAddress: 'GOLD' };
+      seed(a.cache, school);
+      seed(b.cache, school);
+      expect(b.cache.get(b.cache.KEYS.school('SCH-1'))).toBeDefined();
+
+      a.invalidator.invalidate(school);
+      await flush();
+
+      // Cleared on the remote replica (via pub/sub) under both keys...
+      expect(b.cache.get(b.cache.KEYS.school('SCH-1'))).toBeUndefined();
+      expect(b.cache.get(b.cache.KEYS.school('lincoln-high'))).toBeUndefined();
+      // ...and on the emitting replica too.
+      expect(a.cache.get(a.cache.KEYS.school('SCH-1'))).toBeUndefined();
+      expect(a.cache.get(a.cache.KEYS.school('lincoln-high'))).toBeUndefined();
+
+      await a.invalidator.close();
+      await b.invalidator.close();
+    });
+
+    it('drops the emitting replica copy synchronously, before the pub/sub round-trip', () => {
+      const a = loadReplica();
+      const school = { schoolId: 'SCH-2', slug: 'maple-academy' };
+      seed(a.cache, school);
+
+      a.invalidator.invalidate(school);
+
+      // No flush() — the local drop must be synchronous so the mutating request
+      // never serves its own stale entry on the next read.
+      expect(a.cache.get(a.cache.KEYS.school('SCH-2'))).toBeUndefined();
+      expect(a.cache.get(a.cache.KEYS.school('maple-academy'))).toBeUndefined();
+    });
+
+    it('does not touch an unrelated school still cached on the remote replica', async () => {
+      const a = loadReplica();
+      const b = loadReplica();
+
+      const target = { schoolId: 'SCH-3', slug: 'oak-prep' };
+      const bystander = { schoolId: 'SCH-9', slug: 'pine-college' };
+      seed(b.cache, target);
+      seed(b.cache, bystander);
+
+      a.invalidator.invalidate(target);
+      await flush();
+
+      expect(b.cache.get(b.cache.KEYS.school('SCH-3'))).toBeUndefined();
+      expect(b.cache.get(b.cache.KEYS.school('SCH-9'))).toBeDefined();
+      expect(b.cache.get(b.cache.KEYS.school('pine-college'))).toBeDefined();
+
+      await a.invalidator.close();
+      await b.invalidator.close();
+    });
+
+    it('invalidates by slug alone when no schoolId is present', async () => {
+      const a = loadReplica();
+      const b = loadReplica();
+
+      b.cache.set(b.cache.KEYS.school('slug-only'), { slug: 'slug-only' }, 300);
+
+      a.invalidator.invalidate({ slug: 'slug-only' });
+      await flush();
+
+      expect(b.cache.get(b.cache.KEYS.school('slug-only'))).toBeUndefined();
+
+      await a.invalidator.close();
+      await b.invalidator.close();
+    });
+
+    it('reports Redis as enabled when REDIS_HOST is set', () => {
+      const a = loadReplica();
+      expect(a.invalidator._isRedisEnabled()).toBe(true);
+    });
+  });
+
+  describe('single-process fallback (no Redis)', () => {
+    beforeEach(() => {
+      delete process.env.REDIS_HOST;
+    });
+
+    it('drops the local copy under both keys without Redis', () => {
+      const a = loadReplica();
+      expect(a.invalidator._isRedisEnabled()).toBe(false);
+
+      const school = { schoolId: 'SCH-4', slug: 'birch-school' };
+      seed(a.cache, school);
+
+      a.invalidator.invalidate(school);
+
+      expect(a.cache.get(a.cache.KEYS.school('SCH-4'))).toBeUndefined();
+      expect(a.cache.get(a.cache.KEYS.school('birch-school'))).toBeUndefined();
+    });
+
+    it('is a no-op for null / empty input', () => {
+      const a = loadReplica();
+      expect(() => a.invalidator.invalidate(null)).not.toThrow();
+      expect(() => a.invalidator.invalidate({})).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Problem

`backend/src/middleware/schoolContext.js` caches the lean School doc in a process-local `node-cache` with a 5-minute TTL. On a multi-replica deployment, a School mutation (rotating its Stellar address, deactivating it, changing config) is **not reflected on other replicas for up to 5 minutes** — a deactivated school keeps being served, and a rotated wallet keeps matching payments to the old address.

## Solution

Keep the fast in-memory read path, but broadcast a **Redis pub/sub key-invalidation** on every School write — mirroring the existing `sseService.js` / `distributedLock.js` conventions already in the codebase (same `redisConfig`, `REDIS_HOST`-gated enablement, single-process fallback, graceful `close()`).

**New — `backend/src/services/schoolCacheInvalidator.js`**
- `invalidate(school)` drops the local copy **synchronously** (so the mutating request never serves its own stale entry) and `PUBLISH`es `{schoolId, slug}` on the `school:invalidate` channel.
- Every replica's subscriber deletes both the `school:<schoolId>` and `school:<slug>` keys (the middleware caches under whichever header resolved it).
- No Redis configured → degrades to a local-only drop (correct for a single replica).

**`backend/src/controllers/schoolController.js`** — calls `schoolCache.invalidate(school)` after each successful write: `updateSchool`, `deactivateSchool`, `deactivateSchoolEndpoint`, `activateSchool`, `registerWebhook`. (`createSchool` needs none — a brand-new doc was never cached.)

**`backend/src/app.js`** — registers `schoolCacheInvalidator.close()` in the SIGTERM/SIGINT shutdown path alongside the other Redis services.

## Acceptance criteria

- ✅ **A School update is visible on all replicas within seconds** — broadcast clears every replica's cache on the next pub/sub round-trip, no longer bounded by the TTL.
- ✅ **Deactivating a school immediately blocks its requests** — caches drop, the next request re-reads from Mongo; `resolveSchool` already returns `403 SCHOOL_INACTIVE` for `isActive: false` and never re-caches an inactive doc.
- ✅ **Cache layer has unit tests for invalidation** — `backend/tests/schoolCacheInvalidator.test.js`, 7/7 passing.

## Tests

`schoolCacheInvalidator.test.js` reuses the SSE suite's mock-Redis-bus pattern (two isolated module loads = two replicas sharing one Redis, each with its own cache): cross-replica drop under both keys, synchronous local drop, unrelated-school isolation, slug-only invalidation, and the no-Redis fallback / null-input no-op. The existing `sseService.test.js` still passes.

Closes #745

