### PR TITLE
feat(auth): silent access-token refresh with single-flight replay

### DIFF
--- a/backend/src/controllers/authController.js
+++ b/backend/src/controllers/authController.js
@@ -67,6 +67,36 @@ function getStore() {
 // Exposed for testing
 function _resetStore() { _store = null; }
 
+// ── Cookies ───────────────────────────────────────────────────────────────────
+// The access token rides in the `admin_token` cookie (sent on every API call),
+// while the refresh token rides in `admin_refresh_token`, scoped to the auth
+// routes so it is never transmitted to ordinary endpoints. Both are HttpOnly so
+// JS — and therefore an XSS payload — can never read them.
+
+const ACCESS_COOKIE = 'admin_token';
+const REFRESH_COOKIE = 'admin_refresh_token';
+const REFRESH_COOKIE_PATH = '/api/auth';
+
+function accessCookieOptions(ttlSeconds) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    maxAge: ttlSeconds * 1000,
+    path: '/',
+  };
+}
+
+function refreshCookieOptions(ttlSeconds) {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    maxAge: ttlSeconds * 1000,
+    path: REFRESH_COOKIE_PATH,
+  };
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function parseTTL(envVar, defaultSeconds) {
@@ -125,14 +155,11 @@ async function handleLogin(req, res) {
   // Store refresh token (non-blocking — fire and forget; failure means token won't be usable)
   getStore().set(refreshToken, refreshTTL).catch(() => {});
 
-  res.cookie('admin_token', token, {
-    httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
-    maxAge: accessTTL * 1000,
-    path: '/',
-  });
+  res.cookie(ACCESS_COOKIE, token, accessCookieOptions(accessTTL));
+  res.cookie(REFRESH_COOKIE, refreshToken, refreshCookieOptions(refreshTTL));
 
+  // refreshToken is still returned in the body for non-browser API clients that
+  // cannot use cookies; browser clients rely on the HttpOnly cookie above.
   return res.json({
     isAdmin: true,
     expiresIn: accessTTL,
@@ -143,28 +170,53 @@ async function handleLogin(req, res) {
 
 /**
  * POST /api/auth/refresh
- * Body: { refreshToken }
- * Returns { token, expiresIn }
+ * Token source: the HttpOnly `admin_refresh_token` cookie (browser flow), with
+ * a `{ refreshToken }` body fallback for non-browser API clients.
+ *
+ * Refreshes the access token AND rotates the refresh token: the presented token
+ * is invalidated and a fresh one issued, so a leaked refresh token is usable at
+ * most once. Sets new `admin_token` and `admin_refresh_token` cookies and also
+ * returns the new tokens in the body for API clients.
+ *
+ * Returns { token, expiresIn, refreshToken, refreshExpiresIn }.
  */
 async function handleRefresh(req, res) {
-  const { refreshToken } = req.body || {};
+  const refreshToken = req.cookies?.[REFRESH_COOKIE] || (req.body && req.body.refreshToken);
 
   if (!refreshToken) {
     return res.status(401).json({ error: 'Refresh token required.', code: 'MISSING_REFRESH_TOKEN' });
   }
 
-  const valid = await getStore().has(refreshToken);
+  const store = getStore();
+  const valid = await store.has(refreshToken);
   if (!valid) {
+    // Clear the stale cookie so the browser stops presenting a dead token.
+    res.clearCookie(REFRESH_COOKIE, { path: REFRESH_COOKIE_PATH });
     return res.status(401).json({ error: 'Invalid or expired refresh token.', code: 'INVALID_REFRESH_TOKEN' });
   }
 
   const jwt = require('jsonwebtoken');
   const secret = process.env.JWT_SECRET;
   const accessTTL = parseTTL('JWT_ACCESS_TOKEN_TTL', 8 * 3600);
+  const refreshTTL = parseTTL('JWT_REFRESH_TOKEN_TTL', 30 * 86400);
+
+  // Rotate: mint a new refresh token, then invalidate the one just used. Storing
+  // the new token before deleting the old avoids a window with neither valid.
+  const newRefreshToken = crypto.randomBytes(40).toString('hex');
+  await store.set(newRefreshToken, refreshTTL);
+  await store.del(refreshToken);
 
   const token = jwt.sign({ role: 'admin' }, secret, { expiresIn: accessTTL });
 
-  return res.json({ token, expiresIn: accessTTL });
+  res.cookie(ACCESS_COOKIE, token, accessCookieOptions(accessTTL));
+  res.cookie(REFRESH_COOKIE, newRefreshToken, refreshCookieOptions(refreshTTL));
+
+  return res.json({
+    token,
+    expiresIn: accessTTL,
+    refreshToken: newRefreshToken,
+    refreshExpiresIn: refreshTTL,
+  });
 }
 
 /**
@@ -173,13 +225,14 @@ async function handleRefresh(req, res) {
  * Invalidates the refresh token.
  */
 async function handleLogout(req, res) {
-  const { refreshToken } = req.body || {};
+  const refreshToken = req.cookies?.[REFRESH_COOKIE] || (req.body && req.body.refreshToken);
 
   if (refreshToken) {
     await getStore().del(refreshToken);
   }
 
-  res.clearCookie('admin_token', { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'strict', path: '/' });
+  res.clearCookie(ACCESS_COOKIE, { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'strict', path: '/' });
+  res.clearCookie(REFRESH_COOKIE, { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'strict', path: REFRESH_COOKIE_PATH });
   return res.json({ message: 'Logged out.' });
 }
 

--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -32,10 +32,10 @@ async function requireAdminAuth(req, res, next) {
   const cookieToken = req.cookies?.admin_token || null;
   const token = cookieToken || bearerToken;
 
-  const handleAuthFailure = async (reason, code) => {
-    logger.warn(`Failed admin auth attempt: ${reason} from ${ip}`, { 
-      endpoint: req.originalUrl, 
-      code 
+  const handleAuthFailure = async (reason, code, { countTowardsBlock = true } = {}) => {
+    logger.warn(`Failed admin auth attempt: ${reason} from ${ip}`, {
+      endpoint: req.originalUrl,
+      code
     });
 
     // Use X-School-ID if available, else 'system'
@@ -54,13 +54,19 @@ async function requireAdminAuth(req, res, next) {
         userAgent: req.headers?.['user-agent'],
     });
 
-    const failKey = `fail_count:${ip}`;
-    const failCount = (get(failKey) || 0) + 1;
-    set(failKey, failCount, 300); // 5 mins
+    // A normally-expired token is not a credential-guessing attempt, so it must
+    // not count toward the brute-force block — otherwise a burst of concurrent
+    // requests arriving just after the 8h access token expires would lock the
+    // IP out (429) and defeat the silent-refresh + replay flow on the client.
+    if (countTowardsBlock) {
+      const failKey = `fail_count:${ip}`;
+      const failCount = (get(failKey) || 0) + 1;
+      set(failKey, failCount, 300); // 5 mins
 
-    if (failCount >= 5) {
-        set(blockKey, true, 900); // 15 mins
-        await sendAdminAlert(`IP ${ip} blocked due to repeated auth failures`, { ip, endpoint: req.originalUrl });
+      if (failCount >= 5) {
+          set(blockKey, true, 900); // 15 mins
+          await sendAdminAlert(`IP ${ip} blocked due to repeated auth failures`, { ip, endpoint: req.originalUrl });
+      }
     }
 
     return res.status(401).json({ error: reason, code });
@@ -95,7 +101,7 @@ async function requireAdminAuth(req, res, next) {
     next();
   } catch (err) {
     if (err.name === 'TokenExpiredError') {
-      return handleAuthFailure('Token has expired.', 'TOKEN_EXPIRED');
+      return handleAuthFailure('Token has expired.', 'TOKEN_EXPIRED', { countTowardsBlock: false });
     }
     return handleAuthFailure('Invalid token.', 'INVALID_AUTH_TOKEN');
   }

--- a/frontend/src/pages/login.jsx
+++ b/frontend/src/pages/login.jsx
@@ -3,6 +3,15 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { useAdminAuth } from '../hooks/useAdminAuth';
 
+// Only honour same-origin, absolute internal paths as a post-login destination.
+// Anything else (external URLs, protocol-relative "//evil.com", missing) falls
+// back to the dashboard — prevents open-redirect via the returnTo query param.
+function safeReturnTo(returnTo) {
+  if (typeof returnTo !== 'string') return '/dashboard';
+  if (!returnTo.startsWith('/') || returnTo.startsWith('//')) return '/dashboard';
+  return returnTo;
+}
+
 export default function LoginPage() {
   const router = useRouter();
   const { login } = useAdminAuth();
@@ -25,7 +34,7 @@ export default function LoginPage() {
       const data = await res.json();
       if (!res.ok) { setError(data.error || 'Login failed.'); return; }
       login();
-      router.push('/dashboard');
+      router.push(safeReturnTo(router.query.returnTo));
     } catch {
       setError('Network error. Please try again.');
     } finally {

--- a/frontend/src/services/__tests__/authRefresh.test.js
+++ b/frontend/src/services/__tests__/authRefresh.test.js
@@ -1,0 +1,145 @@
+/**
+ * Tests for the single-flight access-token refresh coordinator used by the
+ * axios response interceptor.
+ *
+ * Maps directly to the acceptance criteria:
+ *   - access-token expiry transparently refreshes and replays (no redirect)
+ *   - concurrent 401s trigger exactly one refresh and replay all requests
+ *   - a failed refresh redirects to login and rejects the parked requests
+ */
+
+import { createRefreshHandler } from '../authRefresh';
+
+// A promise whose resolution is controlled by the test, to interleave the
+// concurrent-401 case deterministically.
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+function build(overrides = {}) {
+  const refresh = overrides.refresh || jest.fn(() => Promise.resolve());
+  const retry = overrides.retry || jest.fn((config) => Promise.resolve({ replayed: config.url }));
+  const redirectToLogin = overrides.redirectToLogin || jest.fn();
+  const isAuthUrl = overrides.isAuthUrl || ((url) => url.includes('/auth/'));
+  const handler = createRefreshHandler({ refresh, retry, redirectToLogin, isAuthUrl });
+  return { handler, refresh, retry, redirectToLogin, isAuthUrl };
+}
+
+function err401(url = '/students', extra = {}) {
+  return { config: { url, ...extra }, response: { status: 401 } };
+}
+
+describe('createRefreshHandler', () => {
+  describe('transparent refresh (single request)', () => {
+    it('refreshes once and replays the original request without redirecting', async () => {
+      const { handler, refresh, retry, redirectToLogin } = build();
+
+      const result = await handler(err401('/students'));
+
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(retry).toHaveBeenCalledTimes(1);
+      expect(retry.mock.calls[0][0].url).toBe('/students');
+      expect(redirectToLogin).not.toHaveBeenCalled();
+      expect(result).toEqual({ replayed: '/students' });
+    });
+
+    it('marks the request retried so a second 401 is not refreshed again', async () => {
+      const { handler, refresh } = build({
+        // The replay itself comes back 401 → must NOT trigger another refresh.
+        retry: jest.fn((config) => Promise.reject(err401(config.url, { _retry: config._retry }))),
+      });
+
+      await expect(handler(err401('/students'))).rejects.toBeDefined();
+      expect(refresh).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('concurrent 401s', () => {
+    it('triggers exactly one refresh and replays every parked request', async () => {
+      const gate = deferred();
+      const refresh = jest.fn(() => gate.promise);
+      const { handler, retry, redirectToLogin } = build({ refresh });
+
+      // Three requests fail with 401 at (nearly) the same time.
+      const p1 = handler(err401('/students'));
+      const p2 = handler(err401('/payments'));
+      const p3 = handler(err401('/fees'));
+
+      // Only the first owns the refresh; the rest are parked behind it.
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(retry).not.toHaveBeenCalled();
+
+      gate.resolve();
+      const results = await Promise.all([p1, p2, p3]);
+
+      expect(refresh).toHaveBeenCalledTimes(1); // still exactly one
+      expect(retry).toHaveBeenCalledTimes(3);   // all three replayed
+      const replayedUrls = results.map((r) => r.replayed).sort();
+      expect(replayedUrls).toEqual(['/fees', '/payments', '/students']);
+      expect(redirectToLogin).not.toHaveBeenCalled();
+    });
+
+    it('allows a fresh refresh on a later 401 after the first cycle completes', async () => {
+      const { handler, refresh } = build();
+
+      await handler(err401('/students'));
+      await handler(err401('/payments'));
+
+      expect(refresh).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('failed refresh', () => {
+    it('redirects to login once and rejects the original and parked requests', async () => {
+      const gate = deferred();
+      const refresh = jest.fn(() => gate.promise);
+      const { handler, retry, redirectToLogin } = build({ refresh });
+
+      const p1 = handler(err401('/students'));
+      const p2 = handler(err401('/payments'));
+
+      gate.reject(new Error('refresh failed'));
+
+      await expect(p1).rejects.toBeDefined();
+      await expect(p2).rejects.toBeDefined();
+
+      expect(refresh).toHaveBeenCalledTimes(1);
+      expect(retry).not.toHaveBeenCalled();
+      expect(redirectToLogin).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('pass-through (no refresh attempted)', () => {
+    it('ignores non-401 errors', async () => {
+      const { handler, refresh, redirectToLogin } = build();
+      const error = { config: { url: '/students' }, response: { status: 500 } };
+      await expect(handler(error)).rejects.toBe(error);
+      expect(refresh).not.toHaveBeenCalled();
+      expect(redirectToLogin).not.toHaveBeenCalled();
+    });
+
+    it('ignores network errors that carry no response', async () => {
+      const { handler, refresh } = build();
+      const error = { config: { url: '/students' }, message: 'timeout' };
+      await expect(handler(error)).rejects.toBe(error);
+      expect(refresh).not.toHaveBeenCalled();
+    });
+
+    it('does not try to refresh when the refresh endpoint itself 401s', async () => {
+      const { handler, refresh, redirectToLogin } = build();
+      const error = err401('/auth/refresh');
+      await expect(handler(error)).rejects.toBe(error);
+      expect(refresh).not.toHaveBeenCalled();
+      expect(redirectToLogin).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh an already-retried request', async () => {
+      const { handler, refresh } = build();
+      const error = err401('/students', { _retry: true });
+      await expect(handler(error)).rejects.toBe(error);
+      expect(refresh).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { createRefreshHandler } from "./authRefresh";
 
 const TIMEOUT_MS = parseInt(process.env.NEXT_PUBLIC_REQUEST_TIMEOUT_MS || "15000", 10);
 
@@ -22,15 +23,26 @@ api.interceptors.request.use((config) => {
   return config;
 });
 
-api.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (error.response?.status === 401 && typeof window !== "undefined") {
-      window.location.href = "/login";
-    }
-    return Promise.reject(error);
-  }
-);
+// On a 401 we transparently refresh the access token (the HttpOnly cookies are
+// rotated by the backend) and replay the request, instead of hard-redirecting
+// and losing in-flight work. Only a failed refresh sends the user to /login,
+// preserving where they were via a return-to URL.
+function redirectToLogin() {
+  if (typeof window === "undefined") return;
+  const { pathname, search } = window.location;
+  if (pathname === "/login") return; // already there — avoid a redirect loop
+  const returnTo = encodeURIComponent(`${pathname}${search}`);
+  window.location.href = `/login?returnTo=${returnTo}`;
+}
+
+const onResponseRejected = createRefreshHandler({
+  refresh: () => api.post("/auth/refresh"),
+  retry: (config) => api(config),
+  redirectToLogin,
+  isAuthUrl: (url) => url.includes("/auth/"),
+});
+
+api.interceptors.response.use((response) => response, onResponseRejected);
 
 export const getStudents = (page = 1, limit = 20, { search, status, className } = {}) =>
   api.get("/students", {

--- a/frontend/src/services/authRefresh.js
+++ b/frontend/src/services/authRefresh.js
@@ -1,0 +1,77 @@
+/**
+ * Single-flight access-token refresh coordinator for the axios response
+ * interceptor.
+ *
+ * On a 401 the original request is held while the access token is refreshed
+ * exactly once, then replayed. Any other requests that 401 while that refresh is
+ * in flight are queued and replayed together when it resolves — so a burst of
+ * concurrent 401s triggers exactly one call to the refresh endpoint, never one
+ * per request. If the refresh itself fails the queued requests are rejected and
+ * the caller is sent to the login screen.
+ *
+ * The factory takes its side effects as dependencies so it can be unit-tested
+ * without a live network or a browser:
+ *   - refresh()          -> Promise   performs POST /auth/refresh (sets cookies)
+ *   - retry(config)      -> Promise   replays the original request
+ *   - redirectToLogin()  -> void      navigates to /login (only on refresh fail)
+ *   - isAuthUrl(url)     -> boolean   true for auth endpoints (never refreshed)
+ */
+export function createRefreshHandler({ refresh, retry, redirectToLogin, isAuthUrl }) {
+  let isRefreshing = false;
+  // Requests parked while a refresh is in flight. Each entry resolves when the
+  // refresh succeeds (replay) or rejects when it fails (give up).
+  let waiters = [];
+
+  function settleWaiters(error) {
+    const pending = waiters;
+    waiters = [];
+    for (const { resolve, reject } of pending) {
+      if (error) reject(error);
+      else resolve();
+    }
+  }
+
+  function waitForRefresh() {
+    return new Promise((resolve, reject) => waiters.push({ resolve, reject }));
+  }
+
+  return async function onRejected(error) {
+    const original = error?.config;
+    const status = error?.response?.status;
+
+    // Only act on a retryable 401. Anything else (other status, no config, a
+    // request we already retried, or an auth endpoint itself) passes through so
+    // a failed refresh can't recurse into another refresh.
+    if (status !== 401 || !original || original._retry || isAuthUrl(original.url || "")) {
+      return Promise.reject(error);
+    }
+
+    original._retry = true;
+
+    // A refresh is already running — park this request and replay it after.
+    if (isRefreshing) {
+      try {
+        await waitForRefresh();
+      } catch {
+        // Refresh failed; surface the original 401 (the refresher already
+        // handled redirecting to login).
+        return Promise.reject(error);
+      }
+      return retry(original);
+    }
+
+    // This request owns the refresh.
+    isRefreshing = true;
+    try {
+      await refresh();
+      isRefreshing = false;
+      settleWaiters(); // release everyone parked behind us
+      return retry(original);
+    } catch (refreshError) {
+      isRefreshing = false;
+      settleWaiters(refreshError); // reject everyone parked behind us
+      redirectToLogin();
+      return Promise.reject(refreshError);
+    }
+  };
+}


### PR DESCRIPTION
## Problem

The axios client did only `if (error.response?.status === 401) window.location.href = "/login"`. So every 8-hour access-token expiry hard-redirected the user to `/login`, losing in-flight work and unsaved form state, and a burst of concurrent 401s fired multiple redirects. The `refreshToken` returned at login was never used.

## Solution

### Frontend (the core change)
- **`services/authRefresh.js`** — a single-flight refresh coordinator. On a 401 it calls `/auth/refresh` **exactly once**, parks any other requests that 401 while the refresh is in flight, and replays them all when it resolves. Only a *failed* refresh redirects — to `/login?returnTo=<path>` so the user lands back where they were. Side effects are injected, so it's unit-testable without a network or a browser.
- **`services/api.js`** — the response interceptor now uses the coordinator instead of the unconditional redirect.
- **`pages/login.jsx`** — honours `returnTo` after sign-in, validated to internal absolute paths only (blocks open-redirect via `//evil.com` etc.).

### Backend (coordination — the access token is an HttpOnly cookie)
- Login now also stores the refresh token in an **HttpOnly, auth-path-scoped** `admin_refresh_token` cookie (still returned in the body for non-browser clients).
- **`/auth/refresh`** reads the refresh cookie, **rotates** the token (the presented one is single-use), and sets fresh `admin_token` + `admin_refresh_token` cookies — previously it returned a token in the body but never re-set the cookie the access flow actually reads.
- Logout reads and clears both cookies.
- A normally-expired access token (`TOKEN_EXPIRED`) no longer counts toward the brute-force IP block, so a burst of concurrent requests right at expiry can't lock the IP out (429) and defeat the refresh-and-replay flow.

## Acceptance criteria

- ✅ **Access-token expiry transparently refreshes without redirect** — 401 → one refresh → original request replayed; no navigation.
- ✅ **Concurrent 401s trigger exactly one refresh and replay** — the first request owns the refresh; the rest are parked and replayed together (verified by test).
- ✅ **Failed refresh redirects cleanly with a return-to URL** — `/login?returnTo=<encoded path>`, and the parked requests reject.

## Tests

`frontend/src/services/__tests__/authRefresh.test.js` — 9 passing tests covering transparent refresh + replay, exactly-one-refresh under concurrent 401s, failed-refresh redirect, and pass-through cases (non-401, network errors, the refresh endpoint itself, already-retried requests).

Backend refresh rotation / cookie behaviour was smoke-tested with mocked req/res (login sets both cookies; refresh rotates and invalidates the old token single-use; stale/missing tokens 401).

> Note: the full backend Jest suite is not runnable in this sandbox — it crashes on a clean `main` checkout too because several suites require live network access to Stellar Horizon. The frontend tests run independently and pass.

Closes #746 
