### PR TITLE
feat(frontend): same-origin API proxy for local/Codespaces dev

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,7 +1,19 @@
 # Required: frontend API base URL.
 # Set this in frontend/.env.local for local development only.
 # In Docker/production, configure NEXT_PUBLIC_API_URL in the environment instead of relying on a fallback.
-NEXT_PUBLIC_API_URL=http://localhost:5000/api
+#
+# Two supported values:
+#   /api                    -> same-origin: the browser calls this app's own
+#                              origin and next.config.js rewrites() proxies /api/*
+#                              to the backend. Recommended — auth cookies stay
+#                              first-party, and it works in split-host setups
+#                              (e.g. GitHub Codespaces) without exposing the
+#                              backend port. Override the proxy target with
+#                              BACKEND_PROXY_TARGET (default http://localhost:5000).
+#   http://localhost:5000/api -> direct: the browser calls the backend origin
+#                              directly (requires CORS + the backend reachable
+#                              from the browser).
+NEXT_PUBLIC_API_URL=/api
 
 # Stellar Network: "testnet" or "mainnet"
 NEXT_PUBLIC_STELLAR_NETWORK=testnet

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -52,10 +52,22 @@ const securityHeaders = [
   { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
 ];
 
+// Server-side origin of the backend, used by the dev proxy (rewrites) below.
+// Lets the browser call the API same-origin (/api/*) so cookies stay first-party
+// — essential in split-host setups like GitHub Codespaces.
+const BACKEND_ORIGIN = process.env.BACKEND_PROXY_TARGET || 'http://localhost:5000';
+
 const nextConfig = {
   // Produces a self-contained build in .next/standalone — required for Docker
   output: 'standalone',
   eslint: { ignoreDuringBuilds: true },
+  // Same-origin API proxy: browser → /api/* (this origin) → backend. Keeps
+  // requests first-party so HttpOnly SameSite=Strict auth cookies are sent.
+  async rewrites() {
+    return [
+      { source: '/api/:path*', destination: `${BACKEND_ORIGIN}/api/:path*` },
+    ];
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Problem

The frontend called the backend at a separate origin (`http://localhost:5000/api`). That breaks in split-host setups — notably **GitHub Codespaces**:

- The browser (on the public frontend URL) can't reach the backend port, which is **private** by default → every API call fails with a "Network error".
- Even if the backend port is made public, the frontend (`*-3000.app.github.dev`) and backend (`*-5000.app.github.dev`) are **cross-site** (`app.github.dev` is a public suffix), so the HttpOnly `SameSite=Strict` admin cookies are silently dropped — you can "log in" but every authenticated request comes back 401.

## Solution

Add a Next.js `rewrites()` proxy so the browser only ever calls **this app's own origin**:

```
browser → /api/* (frontend origin) → backend (server-side)
```

- `next.config.js` proxies `/api/:path*` to the backend. Target is configurable via `BACKEND_PROXY_TARGET` (default `http://localhost:5000`).
- Auth cookies stay **first-party**, so `SameSite=Strict` works.
- Only the frontend port needs to be exposed; the backend port can stay private.
- No CORS needed for the browser path.

`.env.local.example` now documents `NEXT_PUBLIC_API_URL=/api` (same-origin, recommended) versus the direct cross-origin value.

## Verification

Ran it in a Codespace end-to-end via the proxy (port 3000 only):
- `POST /api/auth/login` → 200, both HttpOnly cookies set first-party.
- `GET /api/auth/me` with the cookie → `{"isAdmin":true}`.
- Authenticated `GET /api/students`, `/api/payments/summary`, `/api/fees` all return seeded data.

## Notes

- Pure dev/deployment ergonomics — no app logic changes. Production (`output: 'standalone'`) is unaffected; rewrites still apply if you choose the same-origin path, otherwise the direct cross-origin value keeps working.
- `frontend/.env.local` is gitignored and intentionally not committed.
