### PR TITLE
fix: resolve issues #751, #767, #753, #796 — money math, report valid…

### DIFF
--- a/backend/src/controllers/reportController.js
+++ b/backend/src/controllers/reportController.js
@@ -4,18 +4,10 @@ const { generateReport, reportToCsv, getDashboardMetrics } = require('../service
 const { get, set, KEYS, TTL } = require('../cache');
 const School = require('../models/schoolModel');
 
-const ISO_8601 = /^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(\.\d+)?Z)?$/;
-
 async function getReport(req, res, next) {
   try {
+    // Date-range validation is handled by the Joi middleware in reportRoutes.
     const { startDate, endDate, format = 'json' } = req.query;
-
-    for (const [name, val] of [['startDate', startDate], ['endDate', endDate]]) {
-      if (val && (!ISO_8601.test(val) || isNaN(Date.parse(val))))
-        return next(Object.assign(new Error(`Invalid ${name} — must be ISO 8601`), { code: 'INVALID_DATE_FORMAT' }));
-    }
-    if (startDate && endDate && new Date(startDate) > new Date(endDate))
-      return next(Object.assign(new Error('startDate must be before or equal to endDate'), { code: 'INVALID_DATE_FORMAT' }));
 
     const school = await School.findOne({ schoolId: req.schoolId }).lean();
     const timezone = school?.timezone || 'UTC';

--- a/backend/src/middleware/schemas/reportSchemas.js
+++ b/backend/src/middleware/schemas/reportSchemas.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const Joi = require('joi');
+
+// Maximum allowed date range in days (configurable via env, default 366 days).
+const MAX_RANGE_DAYS = parseInt(process.env.REPORT_MAX_RANGE_DAYS || '366', 10);
+
+/**
+ * Joi schema for GET /api/reports query params.
+ *
+ * Validates:
+ *  - startDate / endDate are valid ISO 8601 date strings (YYYY-MM-DD or full ISO)
+ *  - startDate <= endDate when both are provided
+ *  - Date range does not exceed MAX_RANGE_DAYS
+ *  - format is 'json' or 'csv'
+ */
+const reportQuerySchema = Joi.object({
+  startDate: Joi.string().isoDate().optional(),
+  endDate:   Joi.string().isoDate().optional(),
+  format:    Joi.string().valid('json', 'csv').default('json'),
+}).custom((value, helpers) => {
+  const { startDate, endDate } = value;
+  if (startDate && endDate) {
+    const start = new Date(startDate);
+    const end   = new Date(endDate);
+    if (start > end) {
+      return helpers.error('any.invalid', {
+        message: 'startDate must be before or equal to endDate',
+      });
+    }
+    const diffDays = (end - start) / (1000 * 60 * 60 * 24);
+    if (diffDays > MAX_RANGE_DAYS) {
+      return helpers.error('any.invalid', {
+        message: `Date range exceeds the maximum of ${MAX_RANGE_DAYS} days`,
+      });
+    }
+  }
+  return value;
+}).messages({
+  'any.invalid': '{{#message}}',
+});
+
+module.exports = { reportQuerySchema, MAX_RANGE_DAYS };

--- a/backend/src/routes/reportRoutes.js
+++ b/backend/src/routes/reportRoutes.js
@@ -4,10 +4,12 @@ const express = require('express');
 const router = express.Router();
 const { getReport, getDashboard } = require('../controllers/reportController');
 const { resolveSchool } = require('../middleware/schoolContext');
+const { validate } = require('../middleware/validate');
+const { reportQuerySchema } = require('../middleware/schemas/reportSchemas');
 
 router.use(resolveSchool);
 
 router.get('/dashboard', getDashboard);
-router.get('/', getReport);
+router.get('/', validate(reportQuerySchema, 'query'), getReport);
 
 module.exports = router;

--- a/backend/src/services/currencyConversionService.js
+++ b/backend/src/services/currencyConversionService.js
@@ -1,178 +1,230 @@
 "use strict";
 
 /**
- * currencyConversionService — converts XLM and USDC amounts to local currency equivalents.
+ * currencyConversionService — converts XLM and USDC amounts to local currency.
  *
- * Design decisions:
- *   - Uses CoinGecko's API (/simple/price) — supports optional API key for Pro tier.
- *   - Per-currency in-memory cache with configurable TTL (default 60 s).
- *   - Request deduplication: concurrent requests for same currency share one HTTP call.
- *   - Supports both XLM and USDC asset codes (the two accepted assets in StellarEduPay).
- *   - Graceful degradation: if the price feed is unavailable, fiat fields are null
- *     and `available: false` is returned — callers display XLM-only without crashing.
- *   - Per-school target currency support (defaults to USD).
+ * Design decisions (Issue #796):
+ *   - Primary provider: CoinGecko (/simple/price).
+ *   - Secondary provider: Coinbase Exchange (/exchange-rates) — used
+ *     automatically when CoinGecko fails or returns invalid data.
+ *   - Redis-backed shared cache (keyed by `currency:rates:<CURRENCY>`).
+ *     Falls back to in-process Map when Redis is unavailable, so each replica
+ *     does not independently hammer the price feed.
+ *   - All logging via logger.child('CurrencyConversion') — no console.warn.
+ *   - Prometheus gauges: price_feed_available{provider} and
+ *     price_feed_staleness_seconds{provider}.
+ *   - Stale-while-revalidate: serve stale cache when both providers fail,
+ *     up to PRICE_STALE_THRESHOLD_MS (default 1 hour).
  */
 
 const https = require("https");
+const client = require("prom-client");
+const { getRedisClient, isRedisReady } = require("../config/redisClient");
+const logger = require("../utils/logger").child("CurrencyConversion");
 
-// ── Cache ────────────────────────────────────────────────────────────────────
+// ── Config ───────────────────────────────────────────────────────────────────
 
-const CACHE_TTL_MS = parseInt(process.env.PRICE_CACHE_TTL_MS || "60000", 10);
-const PRICE_STALE_THRESHOLD_MS = parseInt(process.env.PRICE_STALE_THRESHOLD_MS || "3600000", 10); // 1 hour default
-const COINGECKO_API_KEY = process.env.COINGECKO_API_KEY || null;
+const CACHE_TTL_MS             = parseInt(process.env.PRICE_CACHE_TTL_MS        || "60000",  10);
+const PRICE_STALE_THRESHOLD_MS = parseInt(process.env.PRICE_STALE_THRESHOLD_MS  || "3600000", 10);
+const COINGECKO_API_KEY        = process.env.COINGECKO_API_KEY || null;
 
-/**
- * Cache structure (keyed by uppercase currency code):
- *   rateCache['USD'] = { rates: { XLM: 0.24, USDC: 1.00 }, fetchedAt: Date, lastSuccessfulFetch: Date }
- */
-const rateCache = {};
+// Redis cache TTL in seconds (slightly longer than in-memory TTL to allow
+// cross-replica stale-while-revalidate).
+const REDIS_CACHE_TTL_S = Math.ceil(PRICE_STALE_THRESHOLD_MS / 1000);
 
-/**
- * In-flight request deduplication map.
- * Prevents concurrent requests for the same currency from hitting the API multiple times.
- * Structure: inFlightRequests['USD'] = Promise<{ rates, fetchedAt }>
- */
-const inFlightRequests = {};
+// ── Prometheus metrics ───────────────────────────────────────────────────────
 
-/** Exposed for testing — resets the in-memory cache. */
-function resetCache() {
-  Object.keys(rateCache).forEach((k) => delete rateCache[k]);
+let _metricsInitialized = false;
+let priceFeedAvailable;
+let priceFeedStaleness;
+
+function _initMetrics() {
+  if (_metricsInitialized) return;
+  try {
+    // Attempt to use the shared registry if metrics/index already initialized it.
+    const { registry } = require("../metrics/index");
+
+    priceFeedAvailable = new client.Gauge({
+      name: "price_feed_available",
+      help: "1 if the price feed provider is available, 0 otherwise",
+      labelNames: ["provider"],
+      registers: [registry],
+    });
+
+    priceFeedStaleness = new client.Gauge({
+      name: "price_feed_staleness_seconds",
+      help: "Seconds since the last successful price fetch per provider",
+      labelNames: ["provider"],
+      registers: [registry],
+    });
+
+    _metricsInitialized = true;
+  } catch (_) {
+    // metrics/index not loaded yet — will be initialized lazily on first use
+  }
 }
 
-/** Return the current cache snapshot (copy) — used by health endpoints. */
-function getCachedRates() {
-  return Object.fromEntries(
-    Object.entries(rateCache).map(([k, v]) => [
-      k,
-      { rates: { ...v.rates }, fetchedAt: v.fetchedAt },
-    ]),
-  );
+function _recordAvailable(provider, available) {
+  _initMetrics();
+  if (priceFeedAvailable) priceFeedAvailable.set({ provider }, available ? 1 : 0);
 }
 
-// ── HTTP helper ──────────────────────────────────────────────────────────────
+function _recordStaleness(provider, lastSuccessfulFetchMs) {
+  _initMetrics();
+  if (priceFeedStaleness && lastSuccessfulFetchMs) {
+    priceFeedStaleness.set({ provider }, Math.floor((Date.now() - lastSuccessfulFetchMs) / 1000));
+  }
+}
 
-/**
- * Minimal promise-based HTTPS GET (uses only Node built-ins).
- * @param {string} url
- * @returns {Promise<object>} Parsed JSON body
- */
+// ── In-process cache (fallback when Redis unavailable) ───────────────────────
+// Structure: Map<CURRENCY, { rates, fetchedAt (ms), lastSuccessfulFetch (ms) }>
+
+const _localCache = new Map();
+
+// ── In-flight deduplication ──────────────────────────────────────────────────
+const _inFlight = new Map();
+
+// ── HTTP helper ───────────────────────────────────────────────────────────────
+
 function httpsGet(url) {
   return new Promise((resolve, reject) => {
     const req = https.get(url, { timeout: 8000 }, (res) => {
       let body = "";
-      res.on("data", (chunk) => {
-        body += chunk;
-      });
+      res.on("data", (c) => { body += c; });
       res.on("end", () => {
-        if (res.statusCode < 200 || res.statusCode >= 300) {
+        if (res.statusCode < 200 || res.statusCode >= 300)
           return reject(new Error(`HTTP ${res.statusCode} from price feed`));
-        }
-        try {
-          resolve(JSON.parse(body));
-        } catch {
-          reject(new Error("Invalid JSON from price feed"));
-        }
+        try { resolve(JSON.parse(body)); }
+        catch { reject(new Error("Invalid JSON from price feed")); }
       });
     });
-    req.on("timeout", () => {
-      req.destroy();
-      reject(new Error("Price feed request timed out"));
-    });
+    req.on("timeout", () => { req.destroy(); reject(new Error("Price feed request timed out")); });
     req.on("error", reject);
   });
 }
 
-// ── Price feed ───────────────────────────────────────────────────────────────
+// ── Provider: CoinGecko ───────────────────────────────────────────────────────
 
-/**
- * Fetch rates for both XLM and USDC against targetCurrency from CoinGecko.
- * CoinGecko IDs: stellar = XLM, usd-coin = USDC.
- *
- * Uses Pro API endpoint if COINGECKO_API_KEY is set, otherwise uses free tier.
- *
- * @param {string} currency  Lowercase ISO 4217 code (e.g. "usd", "pgk", "ngn")
- * @returns {Promise<{ XLM: number, USDC: number }>}
- */
-async function fetchRatesFromCoinGecko(currency) {
+async function _fetchFromCoinGecko(currency) {
   let url =
     "https://api.coingecko.com/api/v3/simple/price" +
     `?ids=stellar%2Cusd-coin&vs_currencies=${encodeURIComponent(currency)}`;
-
-  // Add API key header if available (Pro tier)
-  if (COINGECKO_API_KEY) {
-    url += `&x_cg_pro_api_key=${encodeURIComponent(COINGECKO_API_KEY)}`;
-  }
+  if (COINGECKO_API_KEY) url += `&x_cg_pro_api_key=${encodeURIComponent(COINGECKO_API_KEY)}`;
 
   const data = await httpsGet(url);
+  const xlmRate  = data?.stellar?.["" + currency];
+  const usdcRate = data?.["usd-coin"]?.["" + currency];
 
-  const xlmRate = data?.stellar?.[currency];
-  const usdcRate = data?.["usd-coin"]?.[currency];
-
-  if (typeof xlmRate !== "number" || xlmRate <= 0) {
-    throw new Error(
-      `CoinGecko did not return a valid XLM rate for "${currency}". ` +
-        `Verify this is a supported vs_currency code.`,
-    );
-  }
-  if (typeof usdcRate !== "number" || usdcRate <= 0) {
-    throw new Error(
-      `CoinGecko did not return a valid USDC rate for "${currency}".`,
-    );
-  }
+  if (typeof xlmRate !== "number" || xlmRate <= 0)
+    throw new Error(`CoinGecko: no valid XLM rate for "${currency}"`);
+  if (typeof usdcRate !== "number" || usdcRate <= 0)
+    throw new Error(`CoinGecko: no valid USDC rate for "${currency}"`);
 
   return { XLM: xlmRate, USDC: usdcRate };
 }
 
-/**
- * Return cached rates if fresh, otherwise fetch and cache.
- * Implements stale-while-revalidate: if fetch fails, return stale cache with stale flag.
- * Implements request deduplication: concurrent calls for the same currency
- * share a single in-flight HTTP request.
- *
- * @param {string} currency  Uppercase ISO 4217 code (e.g. "USD", "PGK", "NGN")
- * @returns {Promise<{ rates: { XLM: number, USDC: number }, fetchedAt: Date, stale?: boolean, staleAge?: number } | null>}
- */
-async function getRates(currency) {
-  const key = currency.toUpperCase();
-  const cached = rateCache[key];
+// ── Provider: Coinbase Exchange ───────────────────────────────────────────────
+// Uses /exchange-rates?currency=XLM and /exchange-rates?currency=USDC.
+// Coinbase returns fiat rates for any supported vs_currency.
 
-  // Return fresh cache if available
-  if (cached && Date.now() - cached.fetchedAt.getTime() < CACHE_TTL_MS) {
-    return cached;
-  }
+async function _fetchFromCoinbase(currency) {
+  const [xlmData, usdcData] = await Promise.all([
+    httpsGet(`https://api.coinbase.com/v2/exchange-rates?currency=XLM`),
+    httpsGet(`https://api.coinbase.com/v2/exchange-rates?currency=USDC`),
+  ]);
 
-  // Request deduplication: if a request is already in-flight, wait for it
-  if (inFlightRequests[key]) {
+  const xlmRate  = parseFloat(xlmData?.data?.rates?.[currency.toUpperCase()]);
+  const usdcRate = parseFloat(usdcData?.data?.rates?.[currency.toUpperCase()]);
+
+  if (!isFinite(xlmRate)  || xlmRate  <= 0) throw new Error(`Coinbase: no valid XLM rate for "${currency}"`);
+  if (!isFinite(usdcRate) || usdcRate <= 0) throw new Error(`Coinbase: no valid USDC rate for "${currency}"`);
+
+  return { XLM: xlmRate, USDC: usdcRate };
+}
+
+// ── Shared cache helpers (Redis + local fallback) ─────────────────────────────
+
+const _REDIS_KEY = (c) => `currency:rates:${c}`;
+
+async function _readCache(key) {
+  if (isRedisReady()) {
     try {
-      return await inFlightRequests[key];
+      const raw = await getRedisClient().get(_REDIS_KEY(key));
+      if (raw) return JSON.parse(raw);
+    } catch (e) {
+      logger.warn("Redis cache read failed, falling back to local", { error: e.message });
+    }
+  }
+  return _localCache.get(key) || null;
+}
+
+async function _writeCache(key, entry) {
+  if (isRedisReady()) {
+    try {
+      await getRedisClient().set(_REDIS_KEY(key), JSON.stringify(entry), "EX", REDIS_CACHE_TTL_S);
+    } catch (e) {
+      logger.warn("Redis cache write failed, storing locally", { error: e.message });
+    }
+  }
+  _localCache.set(key, entry);
+}
+
+// ── Core fetch with provider failover ────────────────────────────────────────
+
+async function _fetchRates(currency) {
+  // Try CoinGecko first, fall back to Coinbase.
+  const providers = [
+    { name: "coingecko",  fetch: () => _fetchFromCoinGecko(currency)  },
+    { name: "coinbase",   fetch: () => _fetchFromCoinbase(currency)   },
+  ];
+
+  for (const { name, fetch } of providers) {
+    try {
+      const rates = await fetch();
+      const now = Date.now();
+      _recordAvailable(name, true);
+      _recordStaleness(name, now);
+      logger.info("Price feed fetch succeeded", { provider: name, currency });
+      return { rates, fetchedAt: now, lastSuccessfulFetch: now, provider: name };
     } catch (err) {
-      // If in-flight request failed, fall through to retry
-      delete inFlightRequests[key];
+      _recordAvailable(name, false);
+      logger.warn("Price feed provider failed", { provider: name, currency, error: err.message });
     }
   }
 
-  // Create new in-flight request
+  throw new Error(`All price feed providers failed for currency "${currency}"`);
+}
+
+// ── getRates (cache + dedup + stale-while-revalidate) ────────────────────────
+
+async function getRates(currency) {
+  const key = currency.toUpperCase();
+
+  // Return from cache if fresh.
+  const cached = await _readCache(key);
+  if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+    return cached;
+  }
+
+  // Deduplicate concurrent requests.
+  if (_inFlight.has(key)) {
+    try { return await _inFlight.get(key); }
+    catch { _inFlight.delete(key); }
+  }
+
   const fetchPromise = (async () => {
     try {
-      const rates = await fetchRatesFromCoinGecko(key.toLowerCase());
-      const now = new Date();
-      const entry = { rates, fetchedAt: now, lastSuccessfulFetch: now };
-      rateCache[key] = entry;
-      delete inFlightRequests[key];
+      const entry = await _fetchRates(key.toLowerCase());
+      await _writeCache(key, entry);
+      _inFlight.delete(key);
       return entry;
     } catch (err) {
-      delete inFlightRequests[key];
-      console.warn("[CurrencyConversion] Price feed unavailable:", err.message);
-      
-      // Stale-while-revalidate: return stale cache if within threshold
+      _inFlight.delete(key);
+      // Stale-while-revalidate: return stale data within threshold.
       if (cached) {
-        const staleAge = Math.floor((Date.now() - cached.lastSuccessfulFetch.getTime()) / 1000);
-        if (staleAge < PRICE_STALE_THRESHOLD_MS / 1000) {
-          console.warn(
-            "[CurrencyConversion] Serving stale rate from",
-            cached.lastSuccessfulFetch.toISOString(),
-            `(${staleAge}s old)`,
-          );
+        const staleAge = Math.floor((Date.now() - cached.lastSuccessfulFetch) / 1000);
+        if (Date.now() - cached.lastSuccessfulFetch < PRICE_STALE_THRESHOLD_MS) {
+          logger.warn("Serving stale rate", { currency: key, staleAge, provider: cached.provider });
           return { ...cached, stale: true, staleAge };
         }
       }
@@ -180,171 +232,98 @@ async function getRates(currency) {
     }
   })();
 
-  inFlightRequests[key] = fetchPromise;
-
-  try {
-    return await fetchPromise;
-  } catch (err) {
-    return null;
-  }
+  _inFlight.set(key, fetchPromise);
+  try { return await fetchPromise; }
+  catch { return null; }
 }
 
-// ── Public API ───────────────────────────────────────────────────────────────
+// ── Public API ────────────────────────────────────────────────────────────────
 
-/**
- * Convert an asset amount (XLM or USDC) to its local currency equivalent.
- *
- * @param {number} amount         Amount in asset units
- * @param {string} assetCode      "XLM" or "USDC"
- * @param {string} targetCurrency ISO 4217 currency code, e.g. "USD", "PGK", "NGN"
- *
- * @returns {Promise<{
- *   localAmount:    number | null,   // rounded to 2 decimal places; null if unavailable
- *   currency:       string,          // e.g. "USD"
- *   rate:           number | null,   // exchange rate used (assetCode → currency)
- *   rateTimestamp:  string | null,   // ISO string of when rate was fetched
- *   available:      boolean,         // false when price feed was unavailable
- *   stale:          boolean,         // true if rate is older than CACHE_TTL_MS but within PRICE_STALE_THRESHOLD_MS
- *   staleAge:       number | null,   // seconds since last successful fetch (only if stale: true)
- * }>}
- */
-async function convertToLocalCurrency(
-  amount,
-  assetCode = "XLM",
-  targetCurrency = "USD",
-) {
-  const currency = targetCurrency.toUpperCase();
+async function convertToLocalCurrency(amount, assetCode = "XLM", targetCurrency = "USD") {
+  const currency  = targetCurrency.toUpperCase();
   const rateEntry = await getRates(currency);
 
   if (!rateEntry) {
-    return {
-      localAmount: null,
-      currency,
-      rate: null,
-      rateTimestamp: null,
-      available: false,
-      stale: false,
-      staleAge: null,
-    };
+    return { localAmount: null, currency, rate: null, rateTimestamp: null, available: false, stale: false, staleAge: null };
   }
 
-  // Normalise: treat unknown assets like XLM for display purposes
   const assetKey = assetCode === "USDC" ? "USDC" : "XLM";
   const rate = rateEntry.rates[assetKey];
 
   if (typeof rate !== "number" || rate <= 0) {
-    return {
-      localAmount: null,
-      currency,
-      rate: null,
-      rateTimestamp: rateEntry.fetchedAt.toISOString(),
-      available: false,
-      stale: rateEntry.stale || false,
-      staleAge: rateEntry.staleAge || null,
-    };
+    return { localAmount: null, currency, rate: null, rateTimestamp: new Date(rateEntry.fetchedAt).toISOString(), available: false, stale: rateEntry.stale || false, staleAge: rateEntry.staleAge || null };
   }
 
   return {
-    localAmount: parseFloat((amount * rate).toFixed(2)),
+    localAmount:   parseFloat((amount * rate).toFixed(2)),
     currency,
     rate,
-    rateTimestamp: rateEntry.fetchedAt.toISOString(),
-    available: true,
-    stale: rateEntry.stale || false,
-    staleAge: rateEntry.staleAge || null,
+    rateTimestamp: new Date(rateEntry.fetchedAt).toISOString(),
+    available:     true,
+    stale:         rateEntry.stale || false,
+    staleAge:      rateEntry.staleAge || null,
   };
 }
 
-/**
- * Attach a `localCurrency` field to a payment object (non-mutating).
- * Used by controllers to enrich responses without repeating conversion logic.
- *
- * @param {object} payment        Must have `amount` and optionally `assetCode`
- * @param {string} targetCurrency School's preferred currency
- * @returns {Promise<object>}
- */
 async function enrichPaymentWithConversion(payment, targetCurrency = "USD") {
-  const assetCode = payment.assetCode || "XLM";
-  const conversion = await convertToLocalCurrency(
-    payment.amount,
-    assetCode,
-    targetCurrency,
-  );
+  const assetCode  = payment.assetCode || "XLM";
+  const conversion = await convertToLocalCurrency(payment.amount, assetCode, targetCurrency);
 
-  const txHash = payment.transactionHash || payment.txHash || null;
-  const network =
-    process.env.STELLAR_NETWORK === "mainnet" ? "public" : "testnet";
-  const explorerUrl = txHash
-    ? `https://stellar.expert/explorer/${network}/tx/${txHash}`
-    : null;
+  const txHash     = payment.transactionHash || payment.txHash || null;
+  const network    = process.env.STELLAR_NETWORK === "mainnet" ? "public" : "testnet";
+  const explorerUrl = txHash ? `https://stellar.expert/explorer/${network}/tx/${txHash}` : null;
 
   return {
     ...payment,
     stellarExplorerUrl: explorerUrl,
     explorerUrl,
     localCurrency: {
-      amount: conversion.localAmount,
-      currency: conversion.currency,
-      rate: conversion.rate,
+      amount:       conversion.localAmount,
+      currency:     conversion.currency,
+      rate:         conversion.rate,
       rateTimestamp: conversion.rateTimestamp,
-      available: conversion.available,
+      available:    conversion.available,
     },
   };
 }
 
-/**
- * Build a human-readable dual-currency display string.
- *
- * Examples:
- *   "10.0000000 XLM (≈ 2.40 USD)"
- *   "50.0000000 USDC (≈ 50.00 USD)"
- *   "10.0000000 XLM (rate unavailable)"
- *
- * @param {number} amount
- * @param {string} assetCode
- * @param {string} targetCurrency
- * @returns {Promise<string>}
- */
-async function formatWithLocalEquivalent(
-  amount,
-  assetCode = "XLM",
-  targetCurrency = "USD",
-) {
+async function formatWithLocalEquivalent(amount, assetCode = "XLM", targetCurrency = "USD") {
   const base = `${parseFloat(amount).toFixed(7)} ${assetCode}`;
   const conv = await convertToLocalCurrency(amount, assetCode, targetCurrency);
-
-  if (!conv.available || conv.localAmount === null) {
-    return `${base} (rate unavailable)`;
-  }
+  if (!conv.available || conv.localAmount === null) return `${base} (rate unavailable)`;
   return `${base} (≈ ${conv.localAmount.toFixed(2)} ${conv.currency})`;
 }
 
-// Back-compat alias (kept for existing call sites that used the old XLM-only service)
-const fetchXlmRate = (currency = "usd") =>
-  getRates(currency.toUpperCase()).then((e) => e?.rates?.XLM ?? null);
-const convertXlmToLocal = (xlmAmount, targetCurrency = "USD") =>
-  convertToLocalCurrency(xlmAmount, "XLM", targetCurrency);
-const formatWithConversion = (xlmAmount, targetCurrency = "USD") =>
-  formatWithLocalEquivalent(xlmAmount, "XLM", targetCurrency);
-const attachConversion = (obj, targetCurrency = "USD") =>
-  enrichPaymentWithConversion(obj, targetCurrency);
+function getCachedRates() {
+  const result = {};
+  for (const [k, v] of _localCache) {
+    result[k] = { rates: { ...v.rates }, fetchedAt: new Date(v.fetchedAt) };
+  }
+  return result;
+}
+
+function resetCache() {
+  _localCache.clear();
+}
+
+// Back-compat aliases
+const fetchXlmRate       = (c = "usd") => getRates(c.toUpperCase()).then((e) => e?.rates?.XLM ?? null);
+const convertXlmToLocal  = (a, c = "USD") => convertToLocalCurrency(a, "XLM", c);
+const formatWithConversion = (a, c = "USD") => formatWithLocalEquivalent(a, "XLM", c);
+const attachConversion   = (o, c = "USD") => enrichPaymentWithConversion(o, c);
 
 module.exports = {
-  // Primary API
   convertToLocalCurrency,
   enrichPaymentWithConversion,
   formatWithLocalEquivalent,
   getCachedRates,
   resetCache,
-
-  // Back-compat aliases (XLM-only callers)
   fetchXlmRate,
   convertXlmToLocal,
   formatWithConversion,
   attachConversion,
-
   // Testing internals
-  _fetchRatesFromCoinGecko: fetchRatesFromCoinGecko,
+  _fetchRatesFromCoinGecko: (c) => _fetchFromCoinGecko(c),
   _getRates: getRates,
-  _getCache: () => ({ ...rateCache }),
+  _getCache: getCachedRates,
 };

--- a/backend/src/services/feeAdjustmentEngine.js
+++ b/backend/src/services/feeAdjustmentEngine.js
@@ -1,5 +1,25 @@
 'use strict';
 
+/**
+ * ROUNDING POLICY (Issue #751)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * All monetary arithmetic in this engine uses decimal.js (Decimal) to avoid
+ * IEEE-754 floating-point drift.
+ *
+ * Scale and rounding mode per asset:
+ *   XLM  — 7 decimal places, ROUND_HALF_UP (Stellar native precision)
+ *   USDC — 7 decimal places, ROUND_HALF_UP (stablecoin, same on-chain scale)
+ *   Fiat — 2 decimal places, ROUND_HALF_UP (standard currency display)
+ *
+ * Rule: NO raw JS Number arithmetic (+, -, *, /) on monetary values anywhere
+ * in the fee/payment path. Always construct `new Decimal(value)` and chain
+ * Decimal operations; convert back to Number only at the final output boundary
+ * via `.toDecimalPlaces(2, Decimal.ROUND_HALF_UP).toNumber()`.
+ */
+
+const Decimal = require('decimal.js');
+Decimal.set({ precision: 20, rounding: Decimal.ROUND_HALF_UP });
+
 const logger = require('../utils/logger');
 
 /**
@@ -81,58 +101,70 @@ class DynamicFeeAdjustmentEngine {
   }
 
   /**
-   * Calculate final fee after applying all matching rules
+   * Calculate final fee after applying all matching rules.
+   * All arithmetic uses Decimal to prevent floating-point drift (Issue #751).
+   *
    * @param {Object} context - Fee calculation context
    * @returns {Object} Fee calculation result
    */
   calculateFee(context) {
-    let currentFee = Number(context.baseAmount || 0);
+    // Use Decimal throughout — no raw Number arithmetic on monetary values.
+    let currentFee = new Decimal(context.baseAmount || 0);
     const adjustments = [];
 
     for (const rule of this.rules) {
       if (rule.condition(context)) {
-        let adjustmentAmount = 0;
-
         const isFixed = rule.isFixed === true ||
           (typeof rule.description === 'string' && rule.description.toLowerCase().startsWith('fixed'));
+        const ruleValue = new Decimal(rule.value);
+        let adjustmentAmount;
+
         if (rule.type === 'discount') {
-          adjustmentAmount = isFixed ? -rule.value : -(currentFee * (rule.value / 100));
+          adjustmentAmount = isFixed
+            ? ruleValue.negated()
+            : currentFee.mul(ruleValue).div(100).negated();
         } else if (rule.type === 'penalty') {
-          adjustmentAmount = isFixed ? rule.value : currentFee * (rule.value / 100);
+          adjustmentAmount = isFixed
+            ? ruleValue
+            : currentFee.mul(ruleValue).div(100);
         } else {
-          adjustmentAmount = rule.value; // fixed amount
+          adjustmentAmount = ruleValue;
         }
 
-        currentFee += adjustmentAmount;
+        currentFee = currentFee.plus(adjustmentAmount);
 
         adjustments.push({
           ruleName: rule.name,
           type: rule.type,
           value: rule.value,
-          amountAdjusted: Math.abs(adjustmentAmount),
-          finalFeeAfterRule: parseFloat(currentFee.toFixed(2)),
+          amountAdjusted: adjustmentAmount.abs().toDecimalPlaces(2).toNumber(),
+          finalFeeAfterRule: currentFee.toDecimalPlaces(2).toNumber(),
           reason: rule.description,
         });
       }
     }
 
-    const finalFee = Math.max(0, currentFee); // Prevent negative fees
+    // Clamp to zero — no negative fees.
+    const finalFee = Decimal.max(new Decimal(0), currentFee);
 
-    if (currentFee < 0) {
+    if (currentFee.lt(0)) {
       logger.warn({
         msg: 'Fee clamped to 0 after adjustments',
         studentId: context.studentId || null,
-        unclampedAmount: parseFloat(currentFee.toFixed(2)),
+        unclampedAmount: currentFee.toDecimalPlaces(2).toNumber(),
       });
     }
 
+    const baseDecimal = new Decimal(context.baseAmount || 0);
+    const effectiveRate = baseDecimal.gt(0)
+      ? finalFee.div(baseDecimal).mul(100).toDecimalPlaces(2).toNumber()
+      : 100;
+
     return {
-      baseFee: context.baseAmount,
-      finalFee: parseFloat(finalFee.toFixed(2)),
+      baseFee: baseDecimal.toDecimalPlaces(2).toNumber(),
+      finalFee: finalFee.toDecimalPlaces(2).toNumber(),
       adjustments,
-      effectiveRate: context.baseAmount > 0 
-        ? parseFloat(((finalFee / context.baseAmount) * 100).toFixed(2)) 
-        : 100,
+      effectiveRate,
       totalAdjustments: adjustments.length,
     };
   }

--- a/backend/src/services/webhookService.js
+++ b/backend/src/services/webhookService.js
@@ -8,6 +8,51 @@ const { validateWebhookUrl } = require('../utils/validateWebhookUrl');
 
 const WEBHOOK_TIMEOUT_MS = 10000; // 10 second timeout
 
+// ── Replay protection ────────────────────────────────────────────────────────
+// Delivered delivery IDs are stored (in-process or Redis) for REPLAY_WINDOW_S
+// seconds. Any webhook whose delivery ID is already in the store is rejected.
+const REPLAY_WINDOW_S = parseInt(process.env.WEBHOOK_REPLAY_WINDOW_S || '300', 10); // 5 min default
+
+/**
+ * In-process nonce store: Map<deliveryId, expiresAt (ms)>.
+ * Used when Redis is not configured. Entries are evicted lazily on each check.
+ */
+const _localNonces = new Map();
+
+function _evictExpiredNonces() {
+  const now = Date.now();
+  for (const [id, exp] of _localNonces) {
+    if (now > exp) _localNonces.delete(id);
+  }
+}
+
+/**
+ * Check if a delivery ID has been seen before (replay detection).
+ * Stores the ID if it is fresh.
+ *
+ * @param {string} deliveryId
+ * @returns {Promise<boolean>} true if this is a REPLAY (already seen), false if fresh
+ */
+async function _isReplay(deliveryId) {
+  const { getRedisClient, isRedisReady } = require('../config/redisClient');
+  if (isRedisReady()) {
+    const redis = getRedisClient();
+    const key = `webhook:nonce:${deliveryId}`;
+    // SET NX EX — only sets if the key does not exist; returns 'OK' or null
+    const result = await redis.set(key, '1', 'EX', REPLAY_WINDOW_S, 'NX');
+    return result === null; // null means key already existed → replay
+  }
+
+  // In-process fallback
+  _evictExpiredNonces();
+  if (_localNonces.has(deliveryId)) return true;
+  _localNonces.set(deliveryId, Date.now() + REPLAY_WINDOW_S * 1000);
+  return false;
+}
+
+/** Exposed for testing — clears the local nonce store. */
+function _resetNonces() { _localNonces.clear(); }
+
 /**
  * Generate HMAC-SHA256 signature for a webhook payload.
  *
@@ -74,6 +119,12 @@ async function fireWebhook(url, event, payload, secret = null, deliveryId = null
 
   const timestamp = Math.floor(Date.now() / 1000);
   const id = deliveryId || uuidv4();
+
+  // Replay protection: reject if this delivery ID has already been processed.
+  if (await _isReplay(id)) {
+    logger.warn('Webhook replay detected — delivery already processed', { deliveryId: id, event, url, correlationId });
+    return { success: false, error: 'Replay detected: delivery already processed', deliveryId: id };
+  }
 
   const body = {
     event,
@@ -442,4 +493,6 @@ module.exports = {
   processPendingRetries,
   retryWebhook,
   getBackoffDelay,
+  // Testing internals
+  _resetNonces,
 };

--- a/backend/src/utils/paymentLimits.js
+++ b/backend/src/utils/paymentLimits.js
@@ -1,25 +1,46 @@
 'use strict';
 
+/**
+ * ROUNDING POLICY (Issue #751)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Monetary comparisons use Decimal to avoid IEEE-754 drift.
+ *   XLM  — 7 decimal places (Stellar on-chain precision)
+ *   USDC — 7 decimal places
+ *   Fiat — 2 decimal places
+ *
+ * Rule: never use raw JS Number arithmetic on monetary values. Use Decimal for
+ * all comparisons and arithmetic; convert to Number only at output boundaries.
+ */
+
+const Decimal = require('decimal.js');
 const { MIN_PAYMENT_AMOUNT, MAX_PAYMENT_AMOUNT } = require('../config');
 
+const D_MIN = new Decimal(MIN_PAYMENT_AMOUNT);
+const D_MAX = new Decimal(MAX_PAYMENT_AMOUNT);
+
 function validatePaymentAmount(amount) {
-  if (typeof amount !== 'number' || isNaN(amount) || amount <= 0)
+  const d = new Decimal(typeof amount === 'number' && isFinite(amount) ? amount : NaN);
+  if (!d.isFinite() || d.lte(0))
     return { valid: false, error: 'Payment amount must be a valid positive number', code: 'INVALID_AMOUNT' };
-  if (amount < MIN_PAYMENT_AMOUNT)
+  if (d.lt(D_MIN))
     return { valid: false, error: `Payment amount ${amount} is below the minimum of ${MIN_PAYMENT_AMOUNT}`, code: 'AMOUNT_TOO_LOW' };
-  if (amount > MAX_PAYMENT_AMOUNT)
+  if (d.gt(D_MAX))
     return { valid: false, error: `Payment amount ${amount} exceeds the maximum of ${MAX_PAYMENT_AMOUNT}`, code: 'AMOUNT_TOO_HIGH' };
   return { valid: true };
 }
 
 function validatePaymentAmountAgainstFee(paymentAmount, feeAmount, maxPaymentMultiplier = 3.0) {
-  if (typeof paymentAmount !== 'number' || isNaN(paymentAmount) || paymentAmount <= 0)
+  const dPayment = new Decimal(typeof paymentAmount === 'number' && isFinite(paymentAmount) ? paymentAmount : NaN);
+  const dFee    = new Decimal(typeof feeAmount    === 'number' && isFinite(feeAmount)    ? feeAmount    : NaN);
+
+  if (!dPayment.isFinite() || dPayment.lte(0))
     return { valid: false, error: 'Payment amount must be a valid positive number', code: 'INVALID_AMOUNT' };
-  if (typeof feeAmount !== 'number' || isNaN(feeAmount) || feeAmount <= 0)
+  if (!dFee.isFinite() || dFee.lte(0))
     return { valid: false, error: 'Fee amount must be a valid positive number', code: 'INVALID_FEE' };
-  const maxAllowed = feeAmount * maxPaymentMultiplier;
-  if (paymentAmount > maxAllowed)
-    return { valid: false, error: `Payment amount ${paymentAmount} exceeds the maximum of ${maxAllowed} (${maxPaymentMultiplier}× the fee)`, code: 'AMOUNT_TOO_HIGH' };
+
+  const maxAllowed = dFee.mul(new Decimal(maxPaymentMultiplier));
+  if (dPayment.gt(maxAllowed))
+    return { valid: false, error: `Payment amount ${paymentAmount} exceeds the maximum of ${maxAllowed.toNumber()} (${maxPaymentMultiplier}× the fee)`, code: 'AMOUNT_TOO_HIGH' };
   return { valid: true };
 }
 


### PR DESCRIPTION
…ation, webhook replay protection, currency failover

## Issue #751 — Enforce Decimal end-to-end (money math / data integrity)

Problem: monetary arithmetic in feeAdjustmentEngine.js and paymentLimits.js used raw JS Number (+, -, *, /) which is subject to IEEE-754 floating-point drift. XLM has 7 decimal places; even simple percentage calculations (e.g. 15% of 100.001 XLM) produced rounding errors that could cause reconciliation mismatches.

Changes:
- backend/src/services/feeAdjustmentEngine.js
  - Added `require('decimal.js')` (already in package.json).
  - Configured global Decimal settings: precision=20, ROUND_HALF_UP.
  - Replaced all Number arithmetic in calculateFee() with Decimal chains: mul/div/plus/abs/negated/max, converting back to Number only at output via .toDecimalPlaces(2).toNumber().
  - Added rounding-policy doc-comment at the top of the file documenting per-asset scale: XLM=7dp, USDC=7dp, Fiat=2dp, ROUND_HALF_UP.

- backend/src/utils/paymentLimits.js
  - Replaced raw Number comparisons (>, <) with Decimal equivalents (.lt, .gt, .lte, .mul) in validatePaymentAmount() and validatePaymentAmountAgainstFee().
  - Added same rounding-policy comment.

Closes #751.

## Issue #767 — Validate report date-range params (format, from<=to, max cap)

Problem: GET /api/reports accepted any query string for startDate/endDate. The controller had an inline regex check but no cap on the range size and no Joi schema. Very large date ranges could cause unbounded CSV exports.

Changes:
- backend/src/middleware/schemas/reportSchemas.js  (NEW FILE)
  - Joi schema using isoDate() for startDate and endDate.
  - Custom validator: enforces startDate <= endDate and rejects ranges exceeding REPORT_MAX_RANGE_DAYS (env var, default 366 days).
  - Returns clear 400 messages: 'startDate must be before or equal to endDate' and 'Date range exceeds the maximum of N days'.

- backend/src/routes/reportRoutes.js
  - Wired validate(reportQuerySchema, 'query') middleware onto GET / before the controller, using the existing validate() helper from middleware/validate.js.

- backend/src/controllers/reportController.js
  - Removed the now-redundant inline ISO_8601 regex and manual date checks (validation is fully handled by the middleware layer).

Closes #767.

## Issue #753 — Webhook replay protection (nonce store)

Problem: webhook receivers had no way to detect replayed payloads. An attacker (or network retry) could replay a legitimate signed webhook and trigger duplicate processing. The HMAC signing and DLQ admin endpoints already existed; replay protection was the missing piece.

Changes:
- backend/src/services/webhookService.js
  - Added REPLAY_WINDOW_S constant (env WEBHOOK_REPLAY_WINDOW_S, default 300s).
  - Added _isReplay(deliveryId) — checks a delivery ID against Redis (SET NX EX) when Redis is available, falls back to an in-process Map with lazy TTL eviction. Returns true if the ID was already seen (replay), false if fresh (also records it).
  - Wired _isReplay() into fireWebhook() immediately after URL validation: replayed deliveries are rejected with a structured log entry and a { success: false, error: 'Replay detected' } return value — no HTTP call is made.
  - Exported _resetNonces() for unit tests.

Note: DLQ admin endpoints (GET /api/admin/webhooks/dlq and POST /api/admin/webhooks/dlq/:id/retry) already existed in webhookAdminController.js and adminRoutes.js — no changes required there.

Closes #753.

## Issue #796 — Currency conversion failover (secondary provider, Redis cache, metrics)

Problem: currencyConversionService.js relied solely on CoinGecko. A CoinGecko outage caused all fiat display to fail. The in-memory cache was per-process, so each replica independently hammered the API. Logging used console.warn instead of the structured Winston logger, making failures invisible in log aggregation. No Prometheus metrics for feed availability/staleness.

Changes:
- backend/src/services/currencyConversionService.js  (full rewrite)

  Provider failover:
  - Extracted _fetchFromCoinGecko(currency) (unchanged behaviour).
  - Added _fetchFromCoinbase(currency) using Coinbase /v2/exchange-rates for both XLM and USDC (two parallel requests, then cross-join rates).
  - _fetchRates(currency) tries CoinGecko first; on any error falls through to Coinbase; throws only if both fail.

  Redis-backed shared cache:
  - _readCache / _writeCache wrap both Redis (key: currency:rates:<CODE>, TTL = PRICE_STALE_THRESHOLD_MS seconds) and the local Map fallback.
  - When Redis is available, all replicas share a single fetch result. When Redis is unavailable, behaviour degrades to the previous per-process in-memory cache.

  Structured logging:
  - Replaced every console.warn with logger.child('CurrencyConversion').
  - Log levels: info on success, warn on provider failure / stale serve, warn on Redis cache read/write errors.

  Prometheus metrics (lazy-initialised to avoid circular require):
  - price_feed_available{provider} — 1 when the last fetch succeeded, 0 on failure; updated for each provider on each fetch attempt.
  - price_feed_staleness_seconds{provider} — seconds since last successful fetch; updated on each successful fetch.

  All back-compat aliases (fetchXlmRate, convertXlmToLocal, etc.) and
  testing internals (_fetchRatesFromCoinGecko, _getRates, _getCache)
  preserved.

Closes #796.