### PR TITLE
Fix audit log pagination, health probes, payment status transitions, …

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -51,7 +51,7 @@ const { requestLogger } = require('./middleware/requestLogger');
 const { createConcurrentRequestMiddleware } = require('./middleware/concurrentRequestHandler');
 const { requireAdminAuth } = require('./middleware/auth');
 const { runConsistencyCheck } = require('./controllers/consistencyController');
-const { healthCheck } = require('./controllers/healthController');
+const { healthCheck, livenessCheck, readinessCheck } = require('./controllers/healthController');
 const logger = require('./utils/logger');
 const { startHeapMonitoring } = require('./utils/heapMonitoring');
 
@@ -121,6 +121,8 @@ app.use('/api/admin', adminRoutes);
 app.use('/api/auth', authRoutes);
 app.get('/api/consistency', requireAdminAuth, runConsistencyCheck);
 app.get('/health', healthCheck);
+app.get('/health/live', livenessCheck);
+app.get('/health/ready', readinessCheck);
 
 // Issue #671: OpenAPI/Swagger documentation
 try {

--- a/backend/src/controllers/auditController.js
+++ b/backend/src/controllers/auditController.js
@@ -8,16 +8,17 @@ const { getAuditLogs, getRecentAuditLogs } = require('../services/auditService')
  * Query parameters:
  *   - action: filter by action type
  *   - targetType: filter by target type (student, payment, fee, school)
- *   - performedBy: filter by admin user
+ *   - performedBy: filter by actor (admin user)
  *   - startDate: filter by date range (ISO 8601)
  *   - endDate: filter by date range (ISO 8601)
- *   - page: page number (default: 1)
+ *   - cursor: opaque pagination cursor from a prior response's nextCursor field
+ *   - page: page number for offset pagination (default: 1; ignored when cursor is set)
  *   - limit: results per page (default: 50, max: 200)
  */
 async function getAuditLogsEndpoint(req, res, next) {
   try {
     const { schoolId } = req;
-    const { action, targetType, performedBy, result, startDate, endDate, page, limit } = req.query;
+    const { action, targetType, performedBy, result, startDate, endDate, cursor, page, limit } = req.query;
 
     const auditResult = await getAuditLogs({
       schoolId,
@@ -27,6 +28,7 @@ async function getAuditLogsEndpoint(req, res, next) {
       result,
       startDate,
       endDate,
+      cursor: cursor || null,
       page: page ? parseInt(page, 10) : 1,
       limit: limit ? parseInt(limit, 10) : 50,
     });

--- a/backend/src/controllers/feeController.js
+++ b/backend/src/controllers/feeController.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const mongoose = require('mongoose');
 const FeeStructure = require('../models/feeStructureModel');
 const { get, set, del, KEYS, TTL } = require('../cache');
 const { logAudit } = require('../services/auditService');
@@ -97,13 +98,75 @@ async function updateFeeStructure(req, res, next) {
     let studentsUpdated = 0;
     if (cascadeToStudents === true) {
       const Student = require('../models/studentModel');
-      const students = await Student.find({ schoolId: req.schoolId, class: className, deletedAt: null });
-      for (const s of students) {
-        s.feeAmount = feeAmount;
-        s.remainingBalance = Math.max(0, feeAmount - (s.totalPaid || 0));
-        s.feePaid = (s.totalPaid || 0) >= feeAmount;
-        await s.save();
-        studentsUpdated++;
+      const Payment = require('../models/paymentModel');
+      const StudentFeeHistory = require('../models/studentFeeHistoryModel');
+
+      const students = await Student.find({ schoolId: req.schoolId, class: className, deletedAt: null }).lean();
+
+      if (students.length > 0) {
+        const studentIds = students.map(s => s.studentId);
+
+        // Aggregate confirmed payments for all affected students in one query.
+        const confirmedAgg = await Payment.aggregate([
+          {
+            $match: {
+              schoolId: req.schoolId,
+              studentId: { $in: studentIds },
+              status: 'SUCCESS',
+              deletedAt: null,
+            },
+          },
+          { $group: { _id: '$studentId', totalConfirmed: { $sum: '$amount' } } },
+        ]);
+
+        const confirmedByStudent = {};
+        for (const entry of confirmedAgg) {
+          confirmedByStudent[entry._id] = entry.totalConfirmed;
+        }
+
+        const bulkStudentOps = [];
+        const historyDocs = [];
+
+        for (const s of students) {
+          const amountPaid = confirmedByStudent[s.studentId] || 0;
+          const newRemainingBalance = Math.max(0, feeAmount - amountPaid);
+          const newFeePaid = amountPaid >= feeAmount;
+
+          bulkStudentOps.push({
+            updateOne: {
+              filter: { _id: s._id },
+              update: {
+                $set: {
+                  feeAmount,
+                  remainingBalance: newRemainingBalance,
+                  feePaid: newFeePaid,
+                },
+              },
+            },
+          });
+
+          historyDocs.push({
+            schoolId: req.schoolId,
+            studentId: s.studentId,
+            category: 'fee_cascade_update',
+            amount: feeAmount,
+            paid: newFeePaid,
+            totalPaid: amountPaid,
+            remainingBalance: newRemainingBalance,
+          });
+        }
+
+        const session = await mongoose.startSession();
+        try {
+          await session.withTransaction(async () => {
+            await Student.bulkWrite(bulkStudentOps, { session });
+            await StudentFeeHistory.insertMany(historyDocs, { session });
+          });
+        } finally {
+          await session.endSession();
+        }
+
+        studentsUpdated = bulkStudentOps.length;
       }
     }
 

--- a/backend/src/controllers/healthController.js
+++ b/backend/src/controllers/healthController.js
@@ -7,6 +7,7 @@ const { concurrentPaymentProcessor } = require('../services/concurrentPaymentPro
 const { getReminderStatus } = require('../services/reminderService');
 const { getCachedRates } = require('../services/currencyConversionService');
 const { getAuditHealth } = require('../services/auditService');
+const { getRedisStatus } = require('../config/redisClient');
 const logger = require('../utils/logger');
 
 const STELLAR_CHECK_TIMEOUT_MS = 3000; // 3 second timeout for Stellar health check
@@ -55,10 +56,6 @@ async function healthCheck(req, res) {
       ? stellarResult.value
       : { status: 'unreachable', error: stellarResult.reason?.message };
 
-  // Determine overall status:
-  // - healthy: DB is up AND Stellar is ok
-  // - degraded: DB is up BUT Stellar is unreachable
-  // - unhealthy: DB is down
   const retrySelector = require('../services/retryServiceSelector');
   const retryBackend = retrySelector.getSelectedBackend();
   const redisStatus = getRedisStatus();
@@ -79,11 +76,6 @@ async function healthCheck(req, res) {
   }
 
   const { queueDepth, maxQueueDepth } = concurrentPaymentProcessor.getStats();
-
-  // Retry queue backend info
-  const retrySelector = require('../services/retryServiceSelector');
-  const retryBackend = retrySelector.getSelectedBackend();
-  const redisConfigured = Boolean(process.env.REDIS_HOST);
 
   // Retry queue init status. For the Redis-backed BullMQ pipeline this reflects
   // whether initializeRetryQueue() succeeded; for the MongoDB fallback it reflects
@@ -163,4 +155,58 @@ async function healthCheck(req, res) {
   return res.status(statusCode).json(body);
 }
 
-module.exports = { healthCheck };
+/**
+ * GET /health/live
+ * Liveness probe — returns 200 as long as the process is running.
+ * Orchestrators (e.g. Kubernetes) restart the pod when this fails.
+ */
+function livenessCheck(req, res) {
+  return res.status(200).json({ status: 'alive', timestamp: new Date().toISOString() });
+}
+
+/**
+ * GET /health/ready
+ * Readiness probe — returns 200 only when the service can handle traffic:
+ * the database must be reachable and Stellar Horizon must be responsive.
+ * Orchestrators stop routing traffic to the instance when this returns non-200.
+ */
+async function readinessCheck(req, res) {
+  const [dbResult, stellarResult] = await Promise.allSettled([
+    database.healthCheck(),
+    checkStellar(),
+  ]);
+
+  const db =
+    dbResult.status === 'fulfilled'
+      ? dbResult.value
+      : { healthy: false, reason: dbResult.reason?.message };
+
+  const stellar =
+    stellarResult.status === 'fulfilled'
+      ? stellarResult.value
+      : { status: 'unreachable', error: stellarResult.reason?.message };
+
+  const redisStatus = getRedisStatus();
+  const redisConfigured = Boolean(redisStatus.configured);
+
+  const ready =
+    db.healthy === true &&
+    stellar.status === 'ok' &&
+    (!redisConfigured || redisStatus.status === 'ready');
+
+  const statusCode = ready ? 200 : 503;
+
+  return res.status(statusCode).json({
+    ready,
+    timestamp: new Date().toISOString(),
+    checks: {
+      database: db.healthy ? 'ok' : 'fail',
+      stellar: stellar.status,
+      ...(stellar.activeUrl && { horizonEndpoint: stellar.activeUrl }),
+      ...(stellar.endpoints && { circuitState: stellar.endpoints }),
+      ...(redisConfigured && { redis: redisStatus.status }),
+    },
+  });
+}
+
+module.exports = { healthCheck, livenessCheck, readinessCheck };

--- a/backend/src/controllers/paymentAdminController.js
+++ b/backend/src/controllers/paymentAdminController.js
@@ -257,11 +257,13 @@ async function getStuckPayments(req, res, next) {
   }
 }
 
-// Allowed manual status transitions: from → [to, ...]
+// Admin-allowed manual status transitions: from → [to, ...]
+// Mirrors ADMIN_PAYMENT_STATUS_TRANSITIONS in paymentModel.js.
 const ALLOWED_TRANSITIONS = {
-  SUCCESS: ['DISPUTED'],
-  PENDING: ['FAILED'],
+  SUCCESS:   ['DISPUTED', 'REFUNDED'],
+  PENDING:   ['FAILED'],
   SUBMITTED: ['FAILED'],
+  DISPUTED:  ['REFUNDED'],
 };
 
 async function updatePaymentStatus(req, res, next) {
@@ -272,19 +274,24 @@ async function updatePaymentStatus(req, res, next) {
     if (!newStatus || !reason) return res.status(400).json({ error: 'status and reason are required', code: 'VALIDATION_ERROR' });
     if (newStatus === 'PENDING') return res.status(400).json({ error: 'Cannot transition to PENDING', code: 'INVALID_TRANSITION' });
 
-    const payment = await Payment.findOne({ schoolId: req.schoolId, txHash }).lean();
+    const payment = await Payment.findOne({ schoolId: req.schoolId, txHash });
     if (!payment) {
       const err = new Error('Payment not found');
       err.code = 'NOT_FOUND';
       return next(err);
     }
 
-    const allowed = ALLOWED_TRANSITIONS[payment.status] || [];
+    const previousStatus = payment.status;
+    const allowed = ALLOWED_TRANSITIONS[previousStatus] || [];
     if (!allowed.includes(newStatus)) {
-      return res.status(400).json({ error: `Cannot transition from ${payment.status} to ${newStatus}`, code: 'INVALID_TRANSITION' });
+      return res.status(400).json({ error: `Cannot transition from ${previousStatus} to ${newStatus}`, code: 'INVALID_TRANSITION' });
     }
 
-    const updated = await Payment.findOneAndUpdate({ schoolId: req.schoolId, txHash }, { $set: { status: newStatus } }, { new: true });
+    // Use the admin override path so the model's pre-save hook allows the
+    // expanded admin transition table. The audit trail is recorded below.
+    payment._adminOverride = true;
+    payment.status = newStatus;
+    const updated = await payment.save();
 
     await logAudit({
       schoolId: req.schoolId,
@@ -292,7 +299,7 @@ async function updatePaymentStatus(req, res, next) {
       performedBy: req.auditContext?.performedBy || 'unknown',
       targetId: txHash,
       targetType: 'payment',
-      details: { from: payment.status, to: newStatus, reason },
+      details: { from: previousStatus, to: newStatus, reason, adminOverride: true },
       result: 'success',
       ipAddress: req.auditContext?.ipAddress,
       userAgent: req.auditContext?.userAgent,

--- a/backend/src/models/paymentModel.js
+++ b/backend/src/models/paymentModel.js
@@ -30,7 +30,7 @@ const paymentSchema = new mongoose.Schema(
     assetCode: { type: String, default: null },
     assetType: { type: String, default: null },
 
-    status: { type: String, enum: ['PENDING', 'SUBMITTED', 'SUCCESS', 'FAILED', 'DISPUTED', 'INVALID'], default: 'PENDING' },
+    status: { type: String, enum: ['PENDING', 'SUBMITTED', 'SUCCESS', 'FAILED', 'DISPUTED', 'REFUNDED', 'INVALID'], default: 'PENDING' },
     memo: { type: String },
     senderAddress: { type: String, default: null },
     isSuspicious: { type: Boolean, default: false },
@@ -132,6 +132,20 @@ const PAYMENT_STATUS_TRANSITIONS = {
   SUBMITTED: ['FAILED'],
 };
 
+/**
+ * Additional transitions available only when an admin sets adminOverride = true
+ * on the document before calling save(). These paths are audited by the caller.
+ *
+ * SUCCESS  → REFUNDED  : admin refunds a confirmed payment
+ * DISPUTED → REFUNDED  : admin resolves a dispute via refund
+ */
+const ADMIN_PAYMENT_STATUS_TRANSITIONS = {
+  SUCCESS:   ['DISPUTED', 'REFUNDED'],
+  PENDING:   ['FAILED'],
+  SUBMITTED: ['FAILED'],
+  DISPUTED:  ['REFUNDED'],
+};
+
 paymentSchema.pre('save', function (next) {
   // Use in-memory Mongoose helpers instead of a DB query to avoid an N+1
   // round-trip on every save. this.isNew is true for inserts; for existing
@@ -145,8 +159,13 @@ paymentSchema.pre('save', function (next) {
     const newStatus = this.status;
 
     if (originalStatus !== null && originalStatus !== newStatus) {
-      // Status is being changed — validate against the allowed transition table.
-      const allowed = PAYMENT_STATUS_TRANSITIONS[originalStatus] || [];
+      // When adminOverride is set the caller is responsible for auditing the
+      // action; the model enforces the wider admin-allowed transition table.
+      const transitionTable = this._adminOverride
+        ? ADMIN_PAYMENT_STATUS_TRANSITIONS
+        : PAYMENT_STATUS_TRANSITIONS;
+
+      const allowed = transitionTable[originalStatus] || [];
       if (!allowed.includes(newStatus)) {
         const err = new Error(
           `Payment status transition from ${originalStatus} to ${newStatus} is not allowed`,

--- a/backend/src/services/auditService.js
+++ b/backend/src/services/auditService.js
@@ -69,16 +69,27 @@ async function logAudit({
 /**
  * getAuditLogs — retrieves audit logs with filtering and pagination.
  *
+ * Supports two pagination modes:
+ *  - Cursor-based (preferred for large datasets): pass `cursor` (opaque token
+ *    from a prior response's `nextCursor`). Uses the compound index
+ *    { schoolId, createdAt } — no collection scan, O(1) seek.
+ *  - Page/offset (backward-compatible): pass `page` + `limit`. Limited to
+ *    MAX_PAGE_SIZE results; avoid large page numbers on high-volume schools.
+ *
  * @param {Object} filters
- * @param {string} filters.schoolId - Required school context
- * @param {string} filters.action - Filter by action type
+ * @param {string} filters.schoolId   - Required school context
+ * @param {string} filters.action     - Filter by action type
  * @param {string} filters.targetType - Filter by target type
- * @param {string} filters.performedBy - Filter by admin user
- * @param {Date} filters.startDate - Filter by date range (start)
- * @param {Date} filters.endDate - Filter by date range (end)
- * @param {number} filters.page - Page number (default: 1)
- * @param {number} filters.limit - Results per page (default: 50, max: 200)
+ * @param {string} filters.performedBy - Filter by actor (admin user)
+ * @param {string} filters.result     - Filter by result ('success' | 'failure')
+ * @param {Date}   filters.startDate  - Filter by date range start (ISO 8601)
+ * @param {Date}   filters.endDate    - Filter by date range end (ISO 8601)
+ * @param {string} filters.cursor     - Opaque cursor from a prior response
+ * @param {number} filters.page       - Page number for offset pagination (default: 1)
+ * @param {number} filters.limit      - Results per page (default: 50, max: 200)
  */
+const MAX_PAGE_SIZE = 200;
+
 async function getAuditLogs(filters = {}) {
   const {
     schoolId,
@@ -88,34 +99,89 @@ async function getAuditLogs(filters = {}) {
     result,
     startDate,
     endDate,
+    cursor,
     page = 1,
     limit = 50,
   } = filters;
 
-  const query = { schoolId };
+  const baseQuery = { schoolId };
 
-  if (action) query.action = action;
-  if (targetType) query.targetType = targetType;
-  if (performedBy) query.performedBy = performedBy;
-  if (result) query.result = result;
+  if (action) baseQuery.action = action;
+  if (targetType) baseQuery.targetType = targetType;
+  if (performedBy) baseQuery.performedBy = performedBy;
+  if (result) baseQuery.result = result;
 
   if (startDate || endDate) {
-    query.createdAt = {};
-    if (startDate) query.createdAt.$gte = new Date(startDate);
-    if (endDate) query.createdAt.$lte = new Date(endDate);
+    baseQuery.createdAt = {};
+    if (startDate) baseQuery.createdAt.$gte = new Date(startDate);
+    if (endDate) baseQuery.createdAt.$lte = new Date(endDate);
   }
 
-  const actualLimit = Math.min(limit, 200);
+  const actualLimit = Math.min(Math.max(1, limit), MAX_PAGE_SIZE);
+
+  if (cursor) {
+    // Cursor-based pagination: decode the cursor to get { createdAt, _id }
+    // and page forward using a range predicate on the compound index.
+    let cursorData;
+    try {
+      cursorData = JSON.parse(Buffer.from(cursor, 'base64').toString('utf8'));
+    } catch {
+      const err = new Error('Invalid pagination cursor');
+      err.code = 'INVALID_CURSOR';
+      throw err;
+    }
+
+    const query = { ...baseQuery };
+    // Continue from where the previous page left off. Documents are sorted
+    // { createdAt: -1 }, so "next page" means createdAt < cursorCreatedAt,
+    // or same createdAt with a smaller _id (tie-break).
+    query.$or = [
+      { createdAt: { $lt: new Date(cursorData.createdAt) } },
+      {
+        createdAt: new Date(cursorData.createdAt),
+        _id: { $lt: cursorData._id },
+      },
+    ];
+
+    const logs = await AuditLog.find(query)
+      .sort({ createdAt: -1, _id: -1 })
+      .limit(actualLimit)
+      .lean();
+
+    const nextCursor =
+      logs.length === actualLimit
+        ? Buffer.from(
+            JSON.stringify({
+              createdAt: logs[logs.length - 1].createdAt,
+              _id: logs[logs.length - 1]._id,
+            }),
+          ).toString('base64')
+        : null;
+
+    return { logs, limit: actualLimit, nextCursor };
+  }
+
+  // Offset-based pagination (page/limit) — kept for backward compatibility.
   const skip = (page - 1) * actualLimit;
 
   const [logs, total] = await Promise.all([
-    AuditLog.find(query)
-      .sort({ createdAt: -1 })
+    AuditLog.find(baseQuery)
+      .sort({ createdAt: -1, _id: -1 })
       .skip(skip)
       .limit(actualLimit)
       .lean(),
-    AuditLog.countDocuments(query),
+    AuditLog.countDocuments(baseQuery),
   ]);
+
+  const nextCursor =
+    skip + logs.length < total && logs.length > 0
+      ? Buffer.from(
+          JSON.stringify({
+            createdAt: logs[logs.length - 1].createdAt,
+            _id: logs[logs.length - 1]._id,
+          }),
+        ).toString('base64')
+      : null;
 
   return {
     logs,
@@ -123,6 +189,7 @@ async function getAuditLogs(filters = {}) {
     page,
     limit: actualLimit,
     pages: Math.ceil(total / actualLimit) || 1,
+    nextCursor,
   };
 }
 


### PR DESCRIPTION
…and fee cascade

#805 – Audit log cursor-based pagination
- Add cursor-based pagination to GET /api/audit-logs using a base64-encoded { createdAt, _id } cursor; leverages the compound index { schoolId, createdAt } from migration 016 for O(1) seeks instead of costly skip() scans.
- Offset-based page/limit pagination is preserved for backward compatibility and now carries a nextCursor field so callers can switch incrementally.
- Max page size capped at 200; filters by action, targetType, performedBy, result, startDate, endDate remain in place.

#804 – Health check liveness vs readiness separation
- Fix duplicate const declarations (retrySelector, retryBackend, redisConfigured) inside healthCheck() that caused a SyntaxError at module load time.
- Import getRedisStatus from config/redisClient (was called but never imported).
- Add GET /health/live – lightweight liveness probe; returns 200 while the process is running. Orchestrators use this to decide when to restart a pod.
- Add GET /health/ready – readiness probe; checks DB reachability, Stellar Horizon connectivity (with timeout), and Redis state. Returns 503 when any dependency is unhealthy so orchestrators stop routing traffic.
- Horizon failover endpoint URL and circuit-breaker state are included in the readiness response.

#806 – Payment model admin status override
- Add REFUNDED to the payment status enum alongside DISPUTED/FAILED/etc.
- Introduce ADMIN_PAYMENT_STATUS_TRANSITIONS with the wider admin-permitted table: SUCCESS → REFUNDED, DISPUTED → REFUNDED (in addition to the existing standard transitions).
- Pre-save hook checks this._adminOverride; when truthy the admin table is used, allowing the extra paths while still rejecting all other illegal transitions.
- paymentAdminController.updatePaymentStatus now loads the document, sets adminOverride = true, mutates status, and calls save() so the hook enforces the admin table; audit log records adminOverride: true and the from/to states.
- Controller ALLOWED_TRANSITIONS updated to mirror the admin table.

#803 – Fee cascade remainingBalance recomputation
- Replace the stale s.totalPaid field with a single aggregation query that sums confirmed (status: SUCCESS, deletedAt: null) Payment documents for all affected students at once, eliminating N+1 queries.
- Compute remainingBalance = max(0, newFee − confirmedAmountPaid) per student.
- Perform the student bulk write and StudentFeeHistory insertMany inside a MongoDB session transaction so the operation is atomic: partial updates are rolled back on failure.
- Each affected student gets a StudentFeeHistory record (category: fee_cascade_update) capturing the new fee, amount paid, and resulting balance for audit purposes.

Closes #805
Closes #804
Closes #806
Closes #803