### PR TITLE
fix(#801): exclude soft-deleted payments from all default reads and a…

### DIFF
--- a/backend/src/controllers/studentController.js
+++ b/backend/src/controllers/studentController.js
@@ -349,7 +349,7 @@ async function getPaymentSummary(req, res, next) {
     const [students, payments] = await Promise.all([
       Student.find({ schoolId: req.schoolId }).lean(),
       Payment.aggregate([
-        { $match: { schoolId: req.schoolId, status: 'SUCCESS', isSuspicious: { $ne: true } } },
+        { $match: { schoolId: req.schoolId, status: 'SUCCESS', isSuspicious: { $ne: true }, deletedAt: null } },
         { $group: { _id: '$studentId', totalPaid: { $sum: '$amount' } } },
       ]),
     ]);

--- a/backend/src/services/reportService.js
+++ b/backend/src/services/reportService.js
@@ -10,7 +10,7 @@ const FeeStructure = require('../models/feeStructureModel');
  * @param {{ schoolId: string, startDate?: string, endDate?: string, timezone?: string }} options
  */
 async function aggregateByDate({ schoolId, startDate, endDate, timezone = 'UTC' } = {}) {
-  const match = { schoolId, status: 'SUCCESS', studentDeleted: { $ne: true } };
+  const match = { schoolId, status: 'SUCCESS', studentDeleted: { $ne: true }, deletedAt: null };
 
   if (startDate || endDate) {
     match.confirmedAt = {};

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -762,6 +762,7 @@ async function finalizeConfirmedPayments(schoolId) {
           studentId: payment.studentId,
           confirmationStatus: "confirmed",
           isSuspicious: false,
+          deletedAt: null,
         },
       },
       { $group: { _id: null, total: { $sum: "$amount" } } },
@@ -783,6 +784,7 @@ async function finalizeConfirmedPayments(schoolId) {
             feeCategory: { $ne: null },
             confirmationStatus: "confirmed",
             isSuspicious: false,
+            deletedAt: null,
           },
         },
         {

--- a/backend/src/utils/softDelete.js
+++ b/backend/src/utils/softDelete.js
@@ -47,6 +47,20 @@ const softDelete = (schema) => {
     return await this.updateMany(filter, { deletedAt: null });
   };
 
+  /**
+   * .activeFilter() — return a filter object merged with { deletedAt: null }.
+   *
+   * Use this for operations the pre-hook does not cover (aggregate, distinct)
+   * so that soft-deleted documents are always excluded from default reads.
+   *
+   * Usage:
+   *   const match = Payment.activeFilter({ schoolId, status: 'SUCCESS' });
+   *   Payment.aggregate([{ $match: match }, ...]);
+   */
+  schema.statics.activeFilter = function (filter = {}) {
+    return { ...filter, deletedAt: null };
+  };
+
   // ── Query helper ────────────────────────────────────────────────────────────
 
   /**

--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -88,6 +88,7 @@ jest.mock('../backend/src/models/paymentModel', () => {
     create: jest.fn().mockResolvedValue({}),
     aggregate: jest.fn().mockResolvedValue([]),
     countDocuments: jest.fn((filter) => Promise.resolve(mockPayments.filter((p) => matchesFilter(p, filter)).length)),
+    activeFilter: jest.fn((filter = {}) => ({ ...filter, deletedAt: null })),
   };
 });
 
@@ -529,6 +530,22 @@ describe('Payment API', () => {
     const etag = first.headers['etag'];
     const second = await testApi.get('/api/payments/accepted-assets').set('If-None-Match', etag);
     expect(second.status).toBe(304);
+  });
+
+  test('GET /api/payments/ — excludes soft-deleted payments', async () => {
+    const Payment = require('../backend/src/models/paymentModel');
+    Payment.find.mockClear();
+    Payment.countDocuments.mockClear();
+
+    const res = await testApi.get('/api/payments/');
+    expect(res.status).toBe(200);
+
+    // Assert the query filter includes deletedAt: null
+    const findCallArgs = Payment.find.mock.calls[0][0];
+    expect(findCallArgs).toHaveProperty('deletedAt', null);
+
+    const countCallArgs = Payment.countDocuments.mock.calls[0][0];
+    expect(countCallArgs).toHaveProperty('deletedAt', null);
   });
 });
 

--- a/tests/softDelete.test.js
+++ b/tests/softDelete.test.js
@@ -179,4 +179,29 @@ describe('softDelete utility — query filter (issue #390)', () => {
       expect(typeof schema.statics.restore).toBe('function');
     });
   });
+
+  describe('activeFilter() static method', () => {
+    it('returns a filter with deletedAt: null when no filter is provided', () => {
+      const schema = new mongoose.Schema({ name: String });
+      softDelete(schema);
+      const Model = mongoose.model('TestActiveFilter', schema);
+      expect(Model.activeFilter()).toEqual({ deletedAt: null });
+    });
+
+    it('merges deletedAt: null into an existing filter', () => {
+      const schema = new mongoose.Schema({ name: String });
+      softDelete(schema);
+      const Model = mongoose.model('TestActiveFilterMerge', schema);
+      expect(Model.activeFilter({ schoolId: 'SCH001', status: 'SUCCESS' }))
+        .toEqual({ schoolId: 'SCH001', status: 'SUCCESS', deletedAt: null });
+    });
+
+    it('overrides deletedAt if already present in the input filter', () => {
+      const schema = new mongoose.Schema({ name: String });
+      softDelete(schema);
+      const Model = mongoose.model('TestActiveFilterOverride', schema);
+      expect(Model.activeFilter({ deletedAt: { $ne: null } }))
+        .toEqual({ deletedAt: null });
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Four `Payment.aggregate()` calls across the codebase lacked a `deletedAt` filter, so soft-deleted payments leaked into reports, student summaries, and finalization computations. Queries using `find`/`findOne`/`countDocuments` were covered by the softDelete pre-hook, but `aggregate` pipelines bypass Mongoose query middleware entirely.

## Changes

### 1. Shared query helper — `softDelete.js:activeFilter()`
Added a new static method `activeFilter()` that returns a filter object merged with `{ deletedAt: null }`. This provides a consistent, reusable helper for operations the pre-hook cannot cover (`aggregate`, `distinct`, etc.) and prevents future omissions.

### 2. `studentController.js:351` — `getPaymentSummary`
Added `deletedAt: null` to the aggregate `$match` so soft-deleted payments are excluded from per-student totals.

### 3. `reportService.js:13` — `aggregateByDate`
Added `deletedAt: null` to the base match object so daily report aggregates (total amount, payment count, etc.) exclude soft-deleted records.

### 4. `stellarService.js:762,784` — `finalizeConfirmedPayments`
Added `deletedAt: null` to both aggregate `$match` stages so soft-deleted payments are ignored when computing remaining balances and category breakdowns.

### 5. Tests
- **`tests/softDelete.test.js`** — Added test coverage for the `activeFilter()` static method (empty filter, merged filter, override behavior).
- **`tests/payment.test.js`** — Added assertion that `GET /api/payments/` constructs its query with `deletedAt: null`. Also added `activeFilter` to the Payment mock to match the real model interface.

## Audit Reference
This addresses Issue #12 of the 2026-06-24 StellarEduPay codebase audit (PROJECT_ISSUES.md).

## Related
Closes #801
