### PR TITLE
fix(security): harden metrics auth, tenant isolation, log redaction, and supply-chain scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,39 @@
+version: 2
+updates:
+  # Root package.json (test/dev tooling)
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+
+  # Backend
+  - package-ecosystem: npm
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - backend
+
+  # Frontend
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - frontend
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,42 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  audit:
+    name: Dependency security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            backend/node_modules
+            frontend/node_modules
+            node_modules
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - run: npm ci
+      - run: cd backend && npm ci && cd ..
+      - run: cd frontend && npm ci && cd ..
+
+      # Fail the build on high or critical advisories.
+      # Triage process: file a GitHub issue, apply `npm audit fix`, or add an
+      # explicit `npm audit --omit` entry with a justification comment.
+      - name: Audit root
+        run: npm audit --audit-level=high
+
+      - name: Audit backend
+        run: cd backend && npm audit --audit-level=high
+
+      - name: Audit frontend
+        run: cd frontend && npm audit --audit-level=high
+
   test:
     runs-on: ubuntu-latest
     env:

--- a/backend/src/middleware/errorHandler.js
+++ b/backend/src/middleware/errorHandler.js
@@ -30,7 +30,14 @@ function globalErrorHandler(err, req, res, next) {
   const statusCode = ERROR_STATUS_MAP[err.code] || err.status || err.statusCode || 500;
   const logCtx = { code: err.code, message: err.message, status: statusCode, path: req.path, method: req.method, requestId: req.requestId, schoolId: req.schoolId, stack: err.stack };
   statusCode >= 500 ? logger.error('Server error', logCtx) : logger.warn('Client error', logCtx);
-  const body = errorResponse(err.message, err.code || 'INTERNAL_ERROR', err.details || null);
+
+  // In production, never expose internal error messages or stack traces for 5xx errors.
+  const isProduction = process.env.NODE_ENV === 'production';
+  const clientMessage = (isProduction && statusCode >= 500)
+    ? 'An internal server error occurred.'
+    : err.message;
+
+  const body = errorResponse(clientMessage, err.code || 'INTERNAL_ERROR', err.details || null);
   if (process.env.NODE_ENV === 'development' && err.stack) body.error.stack = err.stack;
   res.status(statusCode).json(body);
 }

--- a/backend/src/middleware/metricsAuth.js
+++ b/backend/src/middleware/metricsAuth.js
@@ -2,6 +2,21 @@
 
 // Constant-time string comparison to prevent timing-based token enumeration.
 const { timingSafeEqual } = require('crypto');
+const rateLimit = require('express-rate-limit');
+
+// Minimum token entropy: 32 hex chars = 128-bit key; reject obviously weak tokens.
+const MIN_TOKEN_LENGTH = 32;
+
+// Dedicated rate-limiter for /metrics — separate from the main API limiter so
+// Prometheus scrapes are not throttled by normal API traffic and vice-versa.
+// Abuse of the unauthenticated-fast-path is bounded to 60 attempts/minute.
+const metricsRateLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests to metrics endpoint.', code: 'RATE_LIMIT_EXCEEDED' },
+});
 
 function safeCompare(a, b) {
   const bufA = Buffer.from(a);
@@ -15,6 +30,12 @@ function metricsAuth(req, res, next) {
   if (!token) {
     return res.status(500).set('Content-Type', 'text/plain').send(
       '# METRICS_TOKEN is not configured — metrics endpoint is disabled.\n'
+    );
+  }
+
+  if (token.length < MIN_TOKEN_LENGTH) {
+    return res.status(500).set('Content-Type', 'text/plain').send(
+      `# METRICS_TOKEN is too short (min ${MIN_TOKEN_LENGTH} chars) — metrics endpoint is disabled.\n`
     );
   }
 
@@ -36,4 +57,4 @@ function metricsAuth(req, res, next) {
   next();
 }
 
-module.exports = { metricsAuth };
+module.exports = { metricsAuth, metricsRateLimiter };

--- a/backend/src/middleware/requestLogger.js
+++ b/backend/src/middleware/requestLogger.js
@@ -23,6 +23,15 @@ const { httpRequestDurationSeconds } = require('../metrics');
 
 const DEFAULT_REDACT_FIELDS = ['txHash', 'studentId', 'memo', 'senderAddress'];
 
+// Headers that must never appear in logs (auth/session/PII)
+const SENSITIVE_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'x-api-key',
+  'idempotency-key',
+]);
+
 function getRedactFields() {
   if (process.env.LOG_REDACT_FIELDS) {
     return process.env.LOG_REDACT_FIELDS.split(',').map((f) => f.trim()).filter(Boolean);
@@ -40,6 +49,15 @@ function redact(obj) {
     }
   }
   return result;
+}
+
+function redactHeaders(headers) {
+  if (!headers || typeof headers !== 'object') return {};
+  const out = {};
+  for (const [k, v] of Object.entries(headers)) {
+    out[k] = SENSITIVE_HEADERS.has(k.toLowerCase()) ? '[REDACTED]' : v;
+  }
+  return out;
 }
 
 let _counter = 0;
@@ -76,6 +94,9 @@ function requestLogger() {
     if (req.query && Object.keys(req.query).length > 0) {
       logData.query = redact(req.query);
     }
+    if (process.env.LOG_REQUEST_HEADERS === 'true') {
+      logData.headers = redactHeaders(req.headers);
+    }
 
     logger.info('[Request] incoming', logData);
 
@@ -105,4 +126,4 @@ function requestLogger() {
   };
 }
 
-module.exports = { requestLogger, redact };
+module.exports = { requestLogger, redact, redactHeaders };

--- a/backend/src/middleware/schoolContext.js
+++ b/backend/src/middleware/schoolContext.js
@@ -2,6 +2,8 @@
 
 const School = require('../models/schoolModel');
 const cache = require('../cache');
+const jwt = require('jsonwebtoken');
+const { logAudit } = require('../services/auditService');
 
 /**
  * resolveSchool — middleware that identifies the current school from the request.
@@ -10,14 +12,16 @@ const cache = require('../cache');
  *   1. X-School-ID header   — opaque schoolId string (e.g. "SCH-3F2A")
  *   2. X-School-Slug header — human slug (e.g. "lincoln-high")
  *
+ * Security — tenant binding:
+ *   If the request carries a JWT, the resolved school is validated against the
+ *   token's schoolId. Super-admin tokens (role:'admin' or roles:['super_admin'])
+ *   may override any school, but each override is audited.
+ *
  * Results are cached in memory with a 5-minute TTL to reduce DB load.
  *
  * On success: attaches req.school (lean School doc) and req.schoolId (string).
- * On failure: 400 if no header provided, 404 if school not found or inactive.
- *
- * Usage:
- *   router.use(resolveSchool);           // apply to all routes in a router
- *   router.get('/students', resolveSchool, handler);  // apply to one route
+ * On failure: 400 if no header provided, 404 if school not found or inactive,
+ *             403 on tenant mismatch.
  */
 async function resolveSchool(req, res, next) {
   try {
@@ -92,6 +96,54 @@ async function resolveSchool(req, res, next) {
         error: 'School is deactivated.',
         code: 'SCHOOL_INACTIVE',
       });
+    }
+
+    // ── Tenant binding: check JWT schoolId matches resolved school ────────────
+    // Extract token from Authorization header or cookie (no hard failure if absent
+    // — unauthenticated requests are handled by subsequent auth middleware).
+    const secret = process.env.JWT_SECRET;
+    if (secret) {
+      const authHeader = req.headers['authorization'];
+      const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7) : null;
+      const cookieToken = req.cookies?.admin_token || null;
+      const rawToken = cookieToken || bearerToken;
+
+      if (rawToken) {
+        try {
+          const decoded = jwt.verify(rawToken, secret);
+          const isSuperAdmin =
+            decoded.role === 'admin' ||
+            (Array.isArray(decoded.roles) && decoded.roles.includes('super_admin'));
+
+          if (isSuperAdmin) {
+            // Super-admin override is permitted — audit every cross-tenant use.
+            if (decoded.schoolId && decoded.schoolId !== school.schoolId) {
+              const ip = (req.headers['x-forwarded-for'] || '').split(',')[0].trim() ||
+                req.socket?.remoteAddress || 'unknown';
+              await logAudit({
+                schoolId: school.schoolId,
+                action: 'super_admin_school_override',
+                performedBy: decoded.sub || decoded.id || 'super_admin',
+                targetId: school.schoolId,
+                targetType: 'school',
+                details: { tokenSchoolId: decoded.schoolId, requestedSchoolId: school.schoolId, ip },
+                result: 'success',
+                ipAddress: ip,
+                userAgent: req.headers?.['user-agent'],
+              });
+            }
+          } else if (decoded.schoolId && decoded.schoolId !== school.schoolId) {
+            // Non-super-admin token for a different tenant — reject immediately.
+            res.set('Cache-Control', 'no-store');
+            return res.status(403).json({
+              error: 'Forbidden. Token schoolId does not match the requested school.',
+              code: 'TENANT_MISMATCH',
+            });
+          }
+        } catch (_) {
+          // Malformed/expired token — let the auth middleware handle it downstream.
+        }
+      }
     }
 
     req.school   = school;

--- a/backend/src/routes/metricsRoute.js
+++ b/backend/src/routes/metricsRoute.js
@@ -2,11 +2,11 @@
 
 const express = require('express');
 const { registry } = require('../metrics');
-const { metricsAuth } = require('../middleware/metricsAuth');
+const { metricsAuth, metricsRateLimiter } = require('../middleware/metricsAuth');
 
 const router = express.Router();
 
-router.get('/', metricsAuth, async (req, res, next) => {
+router.get('/', metricsRateLimiter, metricsAuth, async (req, res, next) => {
   try {
     const output = await registry.metrics();
     res.set('Content-Type', registry.contentType);

--- a/backend/tests/errorHandlerStackTrace.test.js
+++ b/backend/tests/errorHandlerStackTrace.test.js
@@ -77,4 +77,28 @@ describe('globalErrorHandler — stack trace exposure', () => {
     const body = captureBody(res);
     expect(body.error.stack).toBe(err.stack);
   });
+
+  test('masks internal 5xx error message in production', () => {
+    process.env.NODE_ENV = 'production';
+    const err = new Error('DB connection string: mongodb://admin:secret@host/db');
+
+    const res = makeRes();
+    globalErrorHandler(err, makeReq(), res, jest.fn());
+
+    const body = captureBody(res);
+    expect(body.error.message).toBe('An internal server error occurred.');
+    expect(body.error.message).not.toContain('mongodb://');
+  });
+
+  test('preserves 4xx error message in production (client errors are safe to echo)', () => {
+    process.env.NODE_ENV = 'production';
+    const err = new Error('Validation failed: amount must be positive');
+    err.code = 'VALIDATION_ERROR'; // maps to 400
+
+    const res = makeRes();
+    globalErrorHandler(err, makeReq(), res, jest.fn());
+
+    const body = captureBody(res);
+    expect(body.error.message).toBe('Validation failed: amount must be positive');
+  });
 });

--- a/docs/dependency-triage.md
+++ b/docs/dependency-triage.md
@@ -1,0 +1,38 @@
+# Dependency Security Advisory Triage Process
+
+## Overview
+
+CI runs `npm audit --audit-level=high` for all three packages (root, backend, frontend).
+Any **high** or **critical** advisory will fail the build. Dependabot opens weekly PRs for
+outdated dependencies.
+
+## When CI Fails with a Vulnerability
+
+1. **Check the advisory**: run `npm audit` locally in the affected package directory.
+2. **Apply the fix** if a patched version exists:
+   ```bash
+   npm audit fix          # non-breaking upgrades only
+   npm audit fix --force  # may include semver-major upgrades — review carefully
+   ```
+3. **Review the diff**: confirm the updated package doesn't introduce breaking changes.
+4. **If no fix is available** (zero-day / no upstream patch):
+   - Open a GitHub issue tagged `security` with the advisory CVE/ID and affected paths.
+   - Assess exploitability in context (e.g. a server-side-only dep used only in tests).
+   - If safe to defer, document the exception in `docs/security.md` with the issue link.
+   - Do **not** silence the audit without a written justification.
+
+## Dependabot PRs
+
+- Dependabot opens PRs weekly for outdated dependencies.
+- Each PR runs the full CI suite including the audit job.
+- Merge promptly for patch/minor updates that pass CI.
+- Review carefully for major version bumps — check the package CHANGELOG first.
+
+## Severity Reference
+
+| Level    | Action Required        |
+|----------|------------------------|
+| critical | Fix immediately         |
+| high     | Fix before next release |
+| moderate | Fix within 30 days      |
+| low/info | Fix opportunistically   |

--- a/tests/metricsAuth.test.js
+++ b/tests/metricsAuth.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { metricsAuth } = require('../backend/src/middleware/metricsAuth');
+
+const STRONG_TOKEN = 'a'.repeat(32); // exactly 32 chars — minimum length
+
+function makeReq(authHeader) {
+  return { headers: authHeader ? { authorization: authHeader } : {} };
+}
+
+function makeRes() {
+  let _status;
+  const res = {
+    status: jest.fn().mockImplementation((s) => { _status = s; return res; }),
+    set:    jest.fn().mockReturnThis(),
+    send:   jest.fn().mockReturnThis(),
+    _getStatus: () => _status,
+  };
+  return res;
+}
+
+const originalEnv = process.env.METRICS_TOKEN;
+afterEach(() => {
+  if (originalEnv === undefined) delete process.env.METRICS_TOKEN;
+  else process.env.METRICS_TOKEN = originalEnv;
+});
+
+describe('metricsAuth', () => {
+  test('returns 500 when METRICS_TOKEN is not set', () => {
+    delete process.env.METRICS_TOKEN;
+    const res = makeRes();
+    metricsAuth(makeReq(), res, jest.fn());
+    expect(res._getStatus()).toBe(500);
+  });
+
+  test('returns 500 when METRICS_TOKEN is shorter than 32 chars', () => {
+    process.env.METRICS_TOKEN = 'short';
+    const res = makeRes();
+    metricsAuth(makeReq(), res, jest.fn());
+    expect(res._getStatus()).toBe(500);
+  });
+
+  test('returns 401 when no Authorization header', () => {
+    process.env.METRICS_TOKEN = STRONG_TOKEN;
+    const res = makeRes();
+    metricsAuth(makeReq(), res, jest.fn());
+    expect(res._getStatus()).toBe(401);
+  });
+
+  test('returns 403 when wrong token provided', () => {
+    process.env.METRICS_TOKEN = STRONG_TOKEN;
+    const res = makeRes();
+    metricsAuth(makeReq(`Bearer ${'b'.repeat(32)}`), res, jest.fn());
+    expect(res._getStatus()).toBe(403);
+  });
+
+  test('calls next() when correct token provided', () => {
+    process.env.METRICS_TOKEN = STRONG_TOKEN;
+    const next = jest.fn();
+    metricsAuth(makeReq(`Bearer ${STRONG_TOKEN}`), makeRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  test('returns 401 when Authorization does not start with Bearer', () => {
+    process.env.METRICS_TOKEN = STRONG_TOKEN;
+    const res = makeRes();
+    metricsAuth(makeReq(`Basic ${STRONG_TOKEN}`), res, jest.fn());
+    expect(res._getStatus()).toBe(401);
+  });
+});

--- a/tests/requestLogger.test.js
+++ b/tests/requestLogger.test.js
@@ -5,7 +5,7 @@ jest.mock('../backend/src/utils/logger', () => ({
 }));
 
 const { logger } = require('../backend/src/utils/logger');
-const { requestLogger, redact } = require('../backend/src/middleware/requestLogger');
+const { requestLogger, redact, redactHeaders } = require('../backend/src/middleware/requestLogger');
 
 function makeReq(overrides = {}) {
   return {
@@ -129,5 +129,39 @@ describe('requestLogger middleware', () => {
     requestLogger()(req, res, () => {});
     res._emit('finish');
     expect(logger.info).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('redactHeaders()', () => {
+  test('redacts authorization header', () => {
+    const result = redactHeaders({ authorization: 'Bearer secret-token', 'content-type': 'application/json' });
+    expect(result.authorization).toBe('[REDACTED]');
+    expect(result['content-type']).toBe('application/json');
+  });
+
+  test('redacts cookie and set-cookie headers', () => {
+    const result = redactHeaders({ cookie: 'admin_token=abc', 'set-cookie': 'admin_token=xyz' });
+    expect(result.cookie).toBe('[REDACTED]');
+    expect(result['set-cookie']).toBe('[REDACTED]');
+  });
+
+  test('redacts idempotency-key header', () => {
+    const result = redactHeaders({ 'idempotency-key': 'key-123', 'x-school-id': 'SCH-001' });
+    expect(result['idempotency-key']).toBe('[REDACTED]');
+    expect(result['x-school-id']).toBe('SCH-001');
+  });
+
+  test('returns empty object for null/undefined input', () => {
+    expect(redactHeaders(null)).toEqual({});
+    expect(redactHeaders(undefined)).toEqual({});
+  });
+
+  test('does not log auth headers by default (LOG_REQUEST_HEADERS not set)', () => {
+    delete process.env.LOG_REQUEST_HEADERS;
+    const req = makeReq({ headers: { authorization: 'Bearer secret', 'user-agent': 'test' } });
+    const res = makeRes();
+    requestLogger()(req, res, () => {});
+    const [, loggedData] = logger.info.mock.calls[0];
+    expect(loggedData).not.toHaveProperty('headers');
   });
 });


### PR DESCRIPTION
## Summary

Resolves four security issues in a single PR.

---

### closes #827 — Secrets and PII leaking through logs and error responses

- `requestLogger`: added `SENSITIVE_HEADERS` set (`authorization`, `cookie`, `set-cookie`, `x-api-key`, `idempotency-key`); headers are never logged unless `LOG_REQUEST_HEADERS=true`, and even then auth headers are `[REDACTED]`
- `errorHandler`: 5xx responses in production now return a generic message instead of echoing `err.message` (prevents connection strings / internal paths leaking to clients); 4xx messages still echoed as they are client-safe
- Tests extended: `errorHandlerStackTrace.test.js` (production message masking), `requestLogger.test.js` (`redactHeaders` unit tests)

---

### closes #828 — No dependency/supply-chain scanning in CI

- `ci.yml`: new `audit` job runs `npm audit --audit-level=high` for root, backend, and frontend — build fails on high/critical advisories
- `.github/dependabot.yml`: weekly automated PRs for npm (3 workspaces) and GitHub Actions
- `docs/dependency-triage.md`: triage process with severity/SLA table

---

### closes #829 — Metrics endpoint auth and exposure need hardening

- `metricsAuth`: enforce `MIN_TOKEN_LENGTH=32`; rejects weak tokens with 500 before any comparison
- `metricsAuth`: export `metricsRateLimiter` (60 req/min) — dedicated limiter separate from the main API limiter to bound abuse of the pre-rate-limiter path
- `metricsRoute`: applies `metricsRateLimiter` before `metricsAuth`
- New `tests/metricsAuth.test.js` covering all auth paths

---

### closes #830 — Tenant selection trusts X-School-ID header without binding to principal

- `schoolContext`: decode JWT (if present) at `resolveSchool` time; non-super-admin token with mismatched `schoolId` → `403 TENANT_MISMATCH` immediately, before any route handler runs
- Super-admin overrides permitted but every cross-tenant use is audited via `logAudit()`
- No regression for unauthenticated public routes (no JWT → falls through to existing auth middleware)

---

## Testing

- `errorHandlerStackTrace.test.js` — 6 tests (2 new)
- `requestLogger.test.js` — extended with `redactHeaders` suite
- `tests/metricsAuth.test.js` — 6 new tests