### PR TITLE
fix: resolve four payment/school reliability and security issues

### DIFF
--- a/backend/src/controllers/paymentAdminController.js
+++ b/backend/src/controllers/paymentAdminController.js
@@ -31,7 +31,6 @@ async function syncAllPayments(req, res, next) {
   const stopSyncTimer = syncDurationSeconds.startTimer();
   try {
     const summary = await syncPaymentsForSchool(req.school);
-    stopSyncTimer();
 
     if (req.auditContext) {
       await logAudit({
@@ -74,9 +73,9 @@ async function syncAllPayments(req, res, next) {
         userAgent: req.auditContext.userAgent,
       });
     }
-    stopSyncTimer();
     next(wrapStellarError(err));
   } finally {
+    stopSyncTimer();
     _syncLocks.delete(schoolId);
   }
 }

--- a/backend/src/models/schoolModel.js
+++ b/backend/src/models/schoolModel.js
@@ -57,7 +57,18 @@ const schoolSchema = new mongoose.Schema(
      * Used for date grouping in reports and dashboard metrics.
      * Defaults to UTC.
      */
-    timezone:       { type: String, default: 'UTC', trim: true },
+    timezone: {
+      type: String,
+      default: 'UTC',
+      trim: true,
+      validate: {
+        validator(tz) {
+          if (!tz) return true;
+          try { Intl.DateTimeFormat(undefined, { timeZone: tz }); return true; } catch { return false; }
+        },
+        message: props => `'${props.value}' is not a valid IANA timezone identifier`,
+      },
+    },
     /**
      * Per-school webhook endpoint URL. Must be an https:// URL that resolves
      * to a public IP address (RFC 1918, loopback, and link-local are rejected).

--- a/backend/src/services/reportService.js
+++ b/backend/src/services/reportService.js
@@ -230,19 +230,19 @@ function reportToCsv(report) {
  * @param {{ schoolId: string, timezone?: string }} options
  */
 async function getDashboardMetrics({ schoolId, timezone = 'UTC' } = {}) {
-  // Calculate start of today in the school's timezone
   const now = new Date();
-  const formatter = new Intl.DateTimeFormat('en-CA', {
+
+  // Compute start of today in the school's timezone as the correct UTC epoch.
+  // Strategy: subtract how many ms have elapsed in the current day (measured in
+  // the school's timezone) from now. This handles any UTC offset including DST.
+  const timeParts = new Intl.DateTimeFormat('en-US', {
     timeZone: timezone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  });
-  const parts = formatter.formatToParts(now);
-  const dateMap = {};
-  parts.forEach(p => { dateMap[p.type] = p.value; });
-  const todayStr = `${dateMap.year}-${dateMap.month}-${dateMap.day}`;
-  const startOfToday = new Date(todayStr + 'T00:00:00.000Z');
+    hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false,
+  }).formatToParts(now);
+  const tp = {};
+  timeParts.forEach(p => { tp[p.type] = parseInt(p.value, 10) || 0; });
+  const msIntoDay = tp.hour * 3600000 + tp.minute * 60000 + tp.second * 1000;
+  const startOfToday = new Date(now.getTime() - msIntoDay - (now.getTime() % 1000));
 
   const [
     totalStudents,

--- a/backend/tests/cross-school-isolation.test.js
+++ b/backend/tests/cross-school-isolation.test.js
@@ -1,0 +1,259 @@
+'use strict';
+
+/**
+ * Cross-school data isolation tests (Issue #2).
+ *
+ * Seeds two schools with an overlapping studentId (STU001) and asserts that
+ * payments, balance, and instructions endpoints never return data belonging
+ * to another school.
+ */
+
+jest.mock('../src/config/index', () => ({
+  MONGO_URI: 'mongodb://localhost/test',
+  PORT: 5000,
+  STELLAR_NETWORK: 'testnet',
+  IS_TESTNET: true,
+  HORIZON_URL: 'https://horizon-testnet.stellar.org',
+  STELLAR_TIMEOUT_MS: 3000,
+}));
+
+jest.mock('../src/config/stellarConfig', () => ({
+  server: {},
+  networkPassphrase: 'Test SDF Network ; September 2015',
+  SCHOOL_WALLET: null,
+  ACCEPTED_ASSETS: {
+    XLM: { code: 'XLM', type: 'native', displayName: 'Stellar Lumens', issuer: null },
+  },
+  isAcceptedAsset: () => ({ accepted: true }),
+  configuredAsset: {},
+}));
+
+jest.mock('../src/models/paymentModel');
+jest.mock('../src/models/studentModel');
+jest.mock('../src/models/pendingVerificationModel');
+jest.mock('../src/services/currencyConversionService', () => ({
+  convertToLocalCurrency: jest.fn().mockResolvedValue({ available: false, localAmount: null, currency: 'USD', rate: null, rateTimestamp: null }),
+  enrichPaymentWithConversion: jest.fn().mockImplementation(async (p) => p),
+}));
+jest.mock('../src/utils/paymentLimits', () => ({
+  getPaymentLimits: () => ({ min: 1, max: 10000 }),
+  validatePaymentAmount: () => ({ valid: true }),
+}));
+
+const Payment = require('../src/models/paymentModel');
+const Student = require('../src/models/studentModel');
+const { getStudentPayments, getStudentBalance } = require('../src/controllers/paymentQueryController');
+const { getPaymentInstructions } = require('../src/controllers/paymentController');
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SCHOOL_A = { schoolId: 'SCH-AAA', stellarAddress: 'GAAA1111111111111111111111111111111111111111111111111111', localCurrency: 'USD' };
+const SCHOOL_B = { schoolId: 'SCH-BBB', stellarAddress: 'GBBB2222222222222222222222222222222222222222222222222222', localCurrency: 'USD' };
+
+const STUDENT_ID = 'STU001';
+
+const paymentA = { _id: 'pa1', schoolId: 'SCH-AAA', studentId: STUDENT_ID, txHash: 'aaaa', amount: 100, status: 'SUCCESS', deletedAt: null, confirmedAt: new Date() };
+const paymentB = { _id: 'pb1', schoolId: 'SCH-BBB', studentId: STUDENT_ID, txHash: 'bbbb', amount: 200, status: 'SUCCESS', deletedAt: null, confirmedAt: new Date() };
+
+const studentA = { schoolId: 'SCH-AAA', studentId: STUDENT_ID, feeAmount: 500, feePaid: false, fees: [] };
+const studentB = { schoolId: 'SCH-BBB', studentId: STUDENT_ID, feeAmount: 800, feePaid: false, fees: [] };
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockReq(school, studentId, query = {}) {
+  return {
+    school,
+    schoolId: school.schoolId,
+    params: { studentId },
+    query,
+    headers: {},
+  };
+}
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+// ─── getStudentPayments isolation ─────────────────────────────────────────────
+
+describe('getStudentPayments — cross-school isolation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns only School B payments when queried under School B', async () => {
+    Student.findOne.mockResolvedValue(studentB);
+    Payment.countDocuments.mockResolvedValue(1);
+    // Only paymentB is in the result set for SCH-BBB
+    Payment.find.mockReturnValue({
+      sort: () => ({ skip: () => ({ limit: () => ({ lean: async () => [paymentB] }) }) }),
+    });
+
+    const req = mockReq(SCHOOL_B, STUDENT_ID);
+    const res = mockRes();
+    await getStudentPayments(req, res, jest.fn());
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ total: 1 })
+    );
+    const { payments } = res.json.mock.calls[0][0];
+    expect(payments).toHaveLength(1);
+    expect(payments[0].schoolId).toBe('SCH-BBB');
+    expect(payments[0].txHash).toBe('bbbb');
+  });
+
+  it('queries Payment with the requesting school\'s schoolId, never the other school\'s', async () => {
+    Student.findOne.mockResolvedValue(studentA);
+    Payment.countDocuments.mockResolvedValue(1);
+    Payment.find.mockReturnValue({
+      sort: () => ({ skip: () => ({ limit: () => ({ lean: async () => [paymentA] }) }) }),
+    });
+
+    const req = mockReq(SCHOOL_A, STUDENT_ID);
+    await getStudentPayments(req, mockRes(), jest.fn());
+
+    // The filter passed to Payment.find must include schoolId: SCH-AAA
+    const findFilter = Payment.find.mock.calls[0][0];
+    expect(findFilter.schoolId).toBe('SCH-AAA');
+    expect(findFilter.studentId).toBe(STUDENT_ID);
+
+    // Symmetrically, the countDocuments filter must also scope to SCH-AAA
+    const countFilter = Payment.countDocuments.mock.calls[0][0];
+    expect(countFilter.schoolId).toBe('SCH-AAA');
+  });
+
+  it('returns 404 when the student does not exist in the requesting school', async () => {
+    // STU001 exists in SCHOOL_A but not SCHOOL_B
+    Student.findOne.mockResolvedValue(null);
+
+    const req = mockReq(SCHOOL_B, STUDENT_ID);
+    const res = mockRes();
+    await getStudentPayments(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_FOUND' }));
+    // Payment.find must NOT be called — no data leak even before the not-found response
+    expect(Payment.find).not.toHaveBeenCalled();
+  });
+});
+
+// ─── getStudentBalance isolation ───────────────────────────────────────────────
+
+describe('getStudentBalance — cross-school isolation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('aggregates payments scoped to the requesting school only', async () => {
+    Student.findOne.mockResolvedValue(studentB);
+    // studentB.fees is empty, so only the main aggregate runs (no category breakdown call)
+    Payment.aggregate.mockResolvedValueOnce([{ totalPaid: 200, count: 1 }]);
+    Payment.countDocuments.mockResolvedValue(0);
+
+    const req = mockReq(SCHOOL_B, STUDENT_ID);
+    const res = mockRes();
+    await getStudentBalance(req, res, jest.fn());
+
+    // Verify both aggregation pipelines are scoped to SCH-BBB
+    const [firstAgg] = Payment.aggregate.mock.calls;
+    const matchStage = firstAgg[0].find(s => s.$match);
+    expect(matchStage.$match.schoolId).toBe('SCH-BBB');
+    expect(matchStage.$match.studentId).toBe(STUDENT_ID);
+  });
+
+  it('returns 404 for a student that exists only in another school', async () => {
+    Student.findOne.mockResolvedValue(null);
+
+    const req = mockReq(SCHOOL_B, STUDENT_ID);
+    const res = mockRes();
+    await getStudentBalance(req, res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(Payment.aggregate).not.toHaveBeenCalled();
+  });
+
+  it('does not include School A payments in School B balance', async () => {
+    Student.findOne.mockResolvedValue(studentB);
+    // studentB.fees is empty so only the main aggregate runs; no category breakdown call
+    Payment.aggregate.mockResolvedValueOnce([{ totalPaid: 200, count: 1 }]);
+    Payment.countDocuments.mockResolvedValue(0);
+
+    const req = mockReq(SCHOOL_B, STUDENT_ID);
+    const res = mockRes();
+    await getStudentBalance(req, res, jest.fn());
+
+    const body = res.json.mock.calls[0][0];
+    // studentB feeAmount=800, totalPaid=200, remainingBalance=600
+    expect(body.totalPaid).toBe(200);
+    expect(body.remainingBalance).toBe(600);
+  });
+});
+
+// ─── getPaymentInstructions isolation ─────────────────────────────────────────
+
+describe('getPaymentInstructions — cross-school isolation', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns School B wallet address, not School A\'s', async () => {
+    Student.findOne.mockResolvedValue(studentB);
+
+    const req = mockReq(SCHOOL_B, STUDENT_ID);
+    const res = mockRes();
+    await getPaymentInstructions(req, res, jest.fn());
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.walletAddress).toBe(SCHOOL_B.stellarAddress);
+    expect(body.walletAddress).not.toBe(SCHOOL_A.stellarAddress);
+  });
+
+  it('returns the plain student ID as memo (≤ 28 bytes, never encrypted)', async () => {
+    Student.findOne.mockResolvedValue(studentB);
+
+    const req = mockReq(SCHOOL_B, STUDENT_ID);
+    const res = mockRes();
+    await getPaymentInstructions(req, res, jest.fn());
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.memo).toBe(STUDENT_ID);
+    expect(Buffer.byteLength(body.memo, 'utf8')).toBeLessThanOrEqual(28);
+  });
+
+  it('student lookup is scoped to the requesting school', async () => {
+    Student.findOne.mockResolvedValue(null);
+
+    const req = mockReq(SCHOOL_B, STUDENT_ID);
+    await getPaymentInstructions(req, mockRes(), jest.fn());
+
+    // Even when student not found, the lookup must have been scoped to SCH-BBB
+    const findFilter = Student.findOne.mock.calls[0][0];
+    expect(findFilter.schoolId).toBe('SCH-BBB');
+  });
+});
+
+// ─── Guard: schoolId required ──────────────────────────────────────────────────
+
+describe('tenant-scoped handlers — missing schoolId guard', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('getStudentPayments passes next(err) when req.schoolId is absent', async () => {
+    // Simulate a misconfigured router where resolveSchool was skipped
+    const req = { school: SCHOOL_B, params: { studentId: STUDENT_ID }, query: {} };
+    // schoolId is deliberately omitted from req
+
+    Student.findOne.mockResolvedValue(null);
+    const next = jest.fn();
+    const res = mockRes();
+
+    // The handler must not throw uncaught; it may 404 or call next — either way
+    // it must never expose data from an unscoped query
+    await getStudentPayments(req, res, next);
+
+    // If schoolId is undefined the filter { schoolId: undefined } will never
+    // match real documents, so no data leak is possible even without an explicit guard.
+    const countFilter = Payment.countDocuments.mock.calls[0]?.[0] ?? {};
+    expect(countFilter.schoolId).toBeUndefined();
+    // And no payments should have been returned
+    expect(res.json).not.toHaveBeenCalledWith(
+      expect.objectContaining({ payments: expect.arrayContaining([expect.objectContaining({ schoolId: expect.any(String) })]) })
+    );
+  });
+});

--- a/backend/tests/paymentMemoPlaintext.test.js
+++ b/backend/tests/paymentMemoPlaintext.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * Issue #4 — Confirm payment memo is plaintext student ID end-to-end.
+ *
+ * Stellar MEMO_TEXT is limited to 28 bytes. getPaymentInstructions must always
+ * return the raw student ID (not AES-GCM ciphertext) so that:
+ *   1. Wallets can include it without hitting MemoTooLongError.
+ *   2. The sync engine can match the on-chain memo to a student record.
+ */
+
+jest.mock('../src/config/index', () => ({
+  MONGO_URI: 'mongodb://localhost/test',
+  PORT: 5000,
+  STELLAR_NETWORK: 'testnet',
+  IS_TESTNET: true,
+  HORIZON_URL: 'https://horizon-testnet.stellar.org',
+  STELLAR_TIMEOUT_MS: 3000,
+}));
+
+jest.mock('../src/config/stellarConfig', () => ({
+  server: {},
+  networkPassphrase: 'Test SDF Network ; September 2015',
+  SCHOOL_WALLET: null,
+  ACCEPTED_ASSETS: {
+    XLM: { code: 'XLM', type: 'native', displayName: 'Stellar Lumens', issuer: null },
+  },
+  isAcceptedAsset: () => ({ accepted: true }),
+}));
+
+jest.mock('../src/models/studentModel');
+jest.mock('../src/services/currencyConversionService', () => ({
+  convertToLocalCurrency: jest.fn().mockResolvedValue({ available: false, localAmount: null, currency: 'USD', rate: null, rateTimestamp: null }),
+}));
+jest.mock('../src/utils/paymentLimits', () => ({
+  getPaymentLimits: () => ({ min: 1, max: 10000 }),
+  validatePaymentAmount: () => ({ valid: true }),
+}));
+
+const Student = require('../src/models/studentModel');
+const { getPaymentInstructions } = require('../src/controllers/paymentController');
+
+const SCHOOL = {
+  schoolId: 'SCH-TEST',
+  stellarAddress: 'GABC1111111111111111111111111111111111111111111111111111',
+  localCurrency: 'USD',
+};
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+}
+
+function buildReq(studentId) {
+  return { school: SCHOOL, schoolId: SCHOOL.schoolId, params: { studentId }, query: {} };
+}
+
+describe('getPaymentInstructions — memo is always plaintext student ID', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  const cases = [
+    'STU001',
+    'STU-2024-0042',
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZ12', // exactly 28 ASCII bytes
+  ];
+
+  test.each(cases)('memo equals studentId and fits in 28 bytes for "%s"', async (studentId) => {
+    Student.findOne.mockResolvedValue(null); // no student record needed for instructions
+
+    const req = buildReq(studentId);
+    const res = mockRes();
+    await getPaymentInstructions(req, res, jest.fn());
+
+    expect(res.json).toHaveBeenCalled();
+    const body = res.json.mock.calls[0][0];
+
+    // Memo must be the raw student ID, not encrypted ciphertext
+    expect(body.memo).toBe(studentId);
+
+    // Must fit within Stellar's hard MEMO_TEXT limit
+    expect(Buffer.byteLength(body.memo, 'utf8')).toBeLessThanOrEqual(28);
+  });
+
+  it('memo type is declared as "text"', async () => {
+    Student.findOne.mockResolvedValue(null);
+    const res = mockRes();
+    await getPaymentInstructions(buildReq('STU001'), res, jest.fn());
+    expect(res.json.mock.calls[0][0].memoType).toBe('text');
+  });
+
+  it('memo is not base64url (i.e. not encrypted AES-GCM output)', async () => {
+    Student.findOne.mockResolvedValue(null);
+    const res = mockRes();
+    await getPaymentInstructions(buildReq('STU001'), res, jest.fn());
+
+    const { memo } = res.json.mock.calls[0][0];
+    // AES-256-GCM output for any input is ≥ 40 chars in base64url.
+    // A memo that equals the original student ID cannot be encrypted.
+    expect(memo.length).toBeLessThan(40);
+    expect(memo).toBe('STU001');
+  });
+});

--- a/tests/payment-instructions-asset-validation.test.js
+++ b/tests/payment-instructions-asset-validation.test.js
@@ -128,6 +128,18 @@ jest.mock('../backend/src/services/auditService', () => ({
   logAudit: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock('../backend/src/config/stellarConfig', () => ({
+  server: { transactions: jest.fn(), ledgers: jest.fn() },
+  SCHOOL_WALLET: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5',
+  isAcceptedAsset: jest.fn((code) => ({ accepted: ['XLM', 'USDC'].includes(code) })),
+  ACCEPTED_ASSETS: {
+    XLM: { code: 'XLM', type: 'native', displayName: 'Stellar Lumens' },
+    USDC: { code: 'USDC', type: 'credit_alphanum4', displayName: 'USD Coin', issuer: 'GBUQWP3BOUZX34ULNQG23RQ6F4YUSXHTQSXUSMIQSTBE2EURIDVXL6B' },
+  },
+  CONFIRMATION_THRESHOLD: 3,
+  FINALIZATION_THRESHOLD: 10,
+}));
+
 const app = require('../backend/src/app');
 
 const SCHOOL_HEADERS = { 'X-School-ID': 'SCH001' };

--- a/tests/payment.test.js
+++ b/tests/payment.test.js
@@ -653,6 +653,8 @@ describe('Duplicate Student Detection', () => {
 
   test('POST /api/students — 201 without warning for unique student', async () => {
     const Student = require('../backend/src/models/studentModel');
+    const FeeStructure = require('../backend/src/models/feeStructureModel');
+    FeeStructure.findOne.mockResolvedValueOnce({ className: '7A', feeAmount: 300 });
     Student.findOne.mockResolvedValueOnce(null); // no exact match
     Student.findOne.mockResolvedValueOnce(null); // no soft-deleted match
     Student.findOne.mockResolvedValueOnce(null); // no fuzzy match


### PR DESCRIPTION
## Summary

- **syncAllPayments double timer-stop** — `stopSyncTimer()` was called in both the `try` and `catch` blocks; if `logAudit` threw after a successful sync the Prometheus histogram was observed twice and the real error was masked. Moved to `finally` so it fires exactly once.
- **Dashboard timezone bug** — `getDashboardMetrics` computed `startOfToday` as UTC midnight (`new Date(todayStr + 'T00:00:00.000Z')`), breaking the "today's payments" window for non-UTC schools. Fixed by subtracting the elapsed ms in the school's local day from `now` via `Intl.DateTimeFormat`.
- **IANA timezone validation** — the `School.timezone` field accepted any string; invalid values silently corrupted all date aggregations. Added an `Intl`-based validator that rejects on construction failure.
- **Cross-school isolation tests** — added 10 unit tests covering `getStudentPayments`, `getStudentBalance`, and `getPaymentInstructions`; all assert that queries are scoped to `req.schoolId` and that a student in School A is invisible to School B.
- **Memo plaintext tests** — added 5 tests asserting `getPaymentInstructions` always returns `memo === studentId`, `memoType === 'text'`, and `Buffer.byteLength(memo) ≤ 28`.

## Test plan

- [ ] Run `./node_modules/.bin/jest backend/tests/cross-school-isolation backend/tests/paymentMemoPlaintext` — all 15 tests pass
- [ ] Run full suite — no new failures introduced (4 pre-existing failures in `confirmationStateRepollAndCrossSchoolCollision.test.js` are unrelated)
- [ ] Manually trigger a payment sync for a school and confirm Prometheus records exactly one histogram observation
- [ ] Create a school with `timezone: "Not/ATimezone"` and confirm a 400 validation error is returned
- [ ] Verify dashboard "today's payments" count is correct for a UTC+10 school after the fix

closes #790 
closes #791 
closes #792 
closes #793 