### PR TITLE
feat: maintenance mode, per-school settings, horizon metrics, leader election

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -36,7 +36,7 @@ const metricsRoute = require('./routes/metricsRoute');
 const { registerPaymentSavedSubscribers } = require('./services/paymentSavedSubscribers');
 const { startPolling, stopPolling } = require('./services/transactionPollingService');
 const retrySelector = require('./services/retryServiceSelector');
-const { startConsistencyScheduler } = require('./services/consistencyScheduler');
+const { startConsistencyScheduler, stopConsistencyScheduler } = require('./services/consistencyScheduler');
 const { startReminderScheduler, stopReminderScheduler } = require('./services/reminderService');
 const { startWorker: startTxQueueWorker, stopWorker: stopTxQueueWorker } = require('./services/transactionQueueService');
 const { startSessionCleanupScheduler, stopSessionCleanupScheduler } = require('./services/sessionCleanupService');
@@ -122,6 +122,12 @@ app.use('/metrics', metricsRoute);
 
 app.use(concurrentMiddleware.rateLimiter((req) => req.ip));
 app.use(concurrentMiddleware.requestQueue());
+
+// ── Maintenance mode ───────────────────────────────────────────────────────────
+// Global maintenance mode check. Per-school maintenance mode is enforced inside
+// schoolContext.js after tenant resolution.
+const { maintenanceMode } = require('./middleware/maintenanceMode');
+app.use(maintenanceMode);
 
 // ── Routes ────────────────────────────────────────────────────────────────────
 app.use('/api/schools', schoolRoutes);
@@ -234,15 +240,39 @@ connectWithRetry().then(async () => {
     logger.error('Transaction queue recovery failed on startup', { error: err.message });
   }
 
+  // ── Leader election for singleton schedulers ───────────────────────────────
+  // Polling uses per-school distributed locks; the transaction queue worker
+  // and retry selector are safe for multi-instance.  All other schedulers run
+  // only on the elected leader to prevent N× concurrent execution when scaled.
+  const leaderElection = require('./services/leaderElection');
+
+  const startLeaderSchedulers = () => {
+    logger.info('[Leader] Starting leader-only schedulers');
+    startConsistencyScheduler();
+    startReminderScheduler();
+    startSessionCleanupScheduler();
+    startReconciliationScheduler();
+    startAuditLogCleanupScheduler();
+    startWebhookRetryScheduler();
+  };
+
+  const stopLeaderSchedulers = () => {
+    logger.info('[Leader] Stopping leader-only schedulers');
+    stopConsistencyScheduler();
+    stopReminderScheduler();
+    stopSessionCleanupScheduler();
+    stopReconciliationScheduler();
+    stopAuditLogCleanupScheduler();
+    stopWebhookRetryScheduler();
+  };
+
+  leaderElection.register(startLeaderSchedulers, stopLeaderSchedulers);
+  await leaderElection.start();
+
+  // Always-start services (handle concurrency internally)
   startPolling();
-  startConsistencyScheduler();
   retrySelector.start();
   startTxQueueWorker();
-  startReminderScheduler();
-  startSessionCleanupScheduler();
-  startReconciliationScheduler();
-  startAuditLogCleanupScheduler();
-  startWebhookRetryScheduler();
   registerPaymentSavedSubscribers();
 
   // Only initialise BullMQ when Redis is configured
@@ -282,11 +312,12 @@ async function shutdown(signal) {
   // Stop background services — no new work accepted
   stopPolling();
   retrySelector.stop();
-  stopReminderScheduler();
-  stopSessionCleanupScheduler();
-  stopReconciliationScheduler();
-  stopAuditLogCleanupScheduler();
-  stopWebhookRetryScheduler();
+
+  // Stop leader election (demotes leader, stops leader-only schedulers)
+  try {
+    const leaderElection = require('./services/leaderElection');
+    await leaderElection.stop();
+  } catch (_) { /* leader election may not have been started */ }
 
   try {
     await stopTxQueueWorker();

--- a/backend/src/config/stellarConfig.js
+++ b/backend/src/config/stellarConfig.js
@@ -2,7 +2,12 @@
 
 const StellarSdk = require('@stellar/stellar-sdk');
 const config = require('./index');
-const { getInstance: getFailoverClient } = require('../services/horizonFailoverClient');
+const {
+  getInstance: getFailoverClient,
+  CB_FAILURE_THRESHOLD,
+  CB_RESET_TIMEOUT_MS,
+  CB_HALF_OPEN_SUCCESS_THRESHOLD,
+} = require('../services/horizonFailoverClient');
 
 // The failover client manages a prioritized list of Horizon URLs, a circuit
 // breaker per endpoint, and health-aware failover.  Callers that need to make
@@ -100,4 +105,7 @@ module.exports = {
   FINALIZATION_THRESHOLD,
   isAcceptedAsset,
   resolveAsset,
+  CB_FAILURE_THRESHOLD,
+  CB_RESET_TIMEOUT_MS,
+  CB_HALF_OPEN_SUCCESS_THRESHOLD,
 };

--- a/backend/src/controllers/healthController.js
+++ b/backend/src/controllers/healthController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const database = require('../config/database');
-const { horizonClient } = require('../config/stellarConfig');
+const { horizonClient, CB_FAILURE_THRESHOLD, CB_RESET_TIMEOUT_MS, CB_HALF_OPEN_SUCCESS_THRESHOLD } = require('../config/stellarConfig');
 const config = require('../config');
 const { concurrentPaymentProcessor } = require('../services/concurrentPaymentProcessor');
 const { getReminderStatus } = require('../services/reminderService');
@@ -129,6 +129,11 @@ async function healthCheck(req, res) {
         horizonUrl: stellar.activeUrl || config.HORIZON_URL,
         activeEndpoint: stellar.activeUrl || config.HORIZON_URL,
         endpoints: stellar.endpoints || [],
+        circuitBreaker: {
+          failureThreshold: CB_FAILURE_THRESHOLD,
+          resetTimeoutMs: CB_RESET_TIMEOUT_MS,
+          halfOpenSuccessThreshold: CB_HALF_OPEN_SUCCESS_THRESHOLD,
+        },
       },
       paymentProcessor: {
         queueDepth,

--- a/backend/src/controllers/schoolController.js
+++ b/backend/src/controllers/schoolController.js
@@ -419,4 +419,88 @@ async function registerWebhook(req, res, next) {
   }
 }
 
-module.exports = { createSchool, getAllSchools, getSchool, updateSchool, deactivateSchool, deactivateSchoolEndpoint, activateSchool, registerWebhook };
+// GET /api/schools/:schoolSlug/settings
+async function getSchoolSettings(req, res, next) {
+  try {
+    const { getSchoolSettings } = require('../services/schoolSettingsService');
+    const school = await School.findOne({ slug: req.params.schoolSlug.toLowerCase(), isActive: true }, { schoolId: 1 }).lean();
+    if (!school) return next(Object.assign(new Error('School not found'), { code: 'NOT_FOUND' }));
+    const settings = await getSchoolSettings(school.schoolId);
+    res.json({ settings });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// PATCH /api/schools/:schoolSlug/settings
+async function updateSchoolSettings(req, res, next) {
+  try {
+    const { setSchoolSetting, SETTING_KEYS } = require('../services/schoolSettingsService');
+    const school = await School.findOne({ slug: req.params.schoolSlug.toLowerCase(), isActive: true }, { schoolId: 1 }).lean();
+    if (!school) return next(Object.assign(new Error('School not found'), { code: 'NOT_FOUND' }));
+
+    const updated = {};
+    for (const [key, value] of Object.entries(req.body)) {
+      if (SETTING_KEYS.has(key)) {
+        await setSchoolSetting(school.schoolId, key, value);
+        updated[key] = value;
+      }
+    }
+
+    if (req.auditContext) {
+      const { logAudit } = require('../services/auditService');
+      await logAudit({
+        schoolId: school.schoolId,
+        action: 'school_settings_update',
+        performedBy: req.auditContext.performedBy,
+        targetId: school.schoolId,
+        targetType: 'school',
+        details: { updated },
+        result: 'success',
+        ipAddress: req.auditContext.ipAddress,
+        userAgent: req.auditContext.userAgent,
+      });
+    }
+
+    res.json({ updated });
+  } catch (err) {
+    next(err);
+  }
+}
+
+// DELETE /api/schools/:schoolSlug/settings/:key
+async function clearSchoolSetting(req, res, next) {
+  try {
+    const { clearSchoolSetting, SETTING_KEYS } = require('../services/schoolSettingsService');
+    const school = await School.findOne({ slug: req.params.schoolSlug.toLowerCase(), isActive: true }, { schoolId: 1 }).lean();
+    if (!school) return next(Object.assign(new Error('School not found'), { code: 'NOT_FOUND' }));
+
+    const { key } = req.params;
+    if (!SETTING_KEYS.has(key)) {
+      return res.status(400).json({ error: `Unknown setting key: ${key}`, code: 'INVALID_SETTING_KEY' });
+    }
+
+    await clearSchoolSetting(school.schoolId, key);
+
+    if (req.auditContext) {
+      const { logAudit } = require('../services/auditService');
+      await logAudit({
+        schoolId: school.schoolId,
+        action: 'school_settings_clear',
+        performedBy: req.auditContext.performedBy,
+        targetId: school.schoolId,
+        targetType: 'school',
+        details: { key },
+        result: 'success',
+        ipAddress: req.auditContext.ipAddress,
+        userAgent: req.auditContext.userAgent,
+      });
+    }
+
+    res.json({ message: `Setting "${key}" cleared for school`, schoolSlug: req.params.schoolSlug });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { createSchool, getAllSchools, getSchool, updateSchool, deactivateSchool, deactivateSchoolEndpoint, activateSchool, registerWebhook, getSchoolSettings, updateSchoolSettings, clearSchoolSetting };

--- a/backend/src/middleware/maintenanceMode.js
+++ b/backend/src/middleware/maintenanceMode.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const SystemConfig = require('../models/systemConfigModel');
+const School = require('../models/schoolModel');
+const logger = require('../utils/logger').child('MaintenanceMode');
+
+const EXEMPT_PATHS = /^\/(health|metrics|api\/docs)/;
+
+async function maintenanceMode(req, res, next) {
+  try {
+    if (EXEMPT_PATHS.test(req.path)) return next();
+
+    const globalMaintenance = await SystemConfig.get('maintenanceMode');
+    if (globalMaintenance) {
+      logger.warn('Global maintenance mode active — blocking request', {
+        path: req.path,
+        method: req.method,
+        schoolId: req.schoolId || null,
+      });
+      return res.status(503).json({
+        error: 'Service is temporarily unavailable due to maintenance.',
+        code: 'MAINTENANCE_MODE',
+      });
+    }
+
+    if (req.schoolId) {
+      const school = await School.findOne({ schoolId: req.schoolId }, { maintenanceMode: 1 }).lean();
+      if (school && school.maintenanceMode) {
+        logger.warn('Per-school maintenance mode active — blocking request', {
+          path: req.path,
+          method: req.method,
+          schoolId: req.schoolId,
+        });
+        return res.status(503).json({
+          error: 'This school is temporarily unavailable due to maintenance.',
+          code: 'SCHOOL_MAINTENANCE_MODE',
+        });
+      }
+    }
+
+    next();
+  } catch (err) {
+    logger.error('Failed to check maintenance mode', { error: err.message });
+    next();
+  }
+}
+
+module.exports = { maintenanceMode };

--- a/backend/src/middleware/schoolContext.js
+++ b/backend/src/middleware/schoolContext.js
@@ -146,6 +146,13 @@ async function resolveSchool(req, res, next) {
       }
     }
 
+    if (school.maintenanceMode) {
+      return res.status(503).json({
+        error: 'This school is temporarily unavailable due to maintenance.',
+        code: 'SCHOOL_MAINTENANCE_MODE',
+      });
+    }
+
     req.school   = school;
     req.schoolId = school.schoolId;
     next();

--- a/backend/src/models/schoolModel.js
+++ b/backend/src/models/schoolModel.js
@@ -127,6 +127,26 @@ const schoolSchema = new mongoose.Schema(
      */
     mfaEnabled: { type: Boolean, default: false },
     mfaSecret: { type: String, default: null },
+    /**
+     * Per-school maintenance mode. When true, the school's API endpoints
+     * return 503 Service Unavailable. Overrides the global maintenance mode
+     * in SystemConfig for this school only.
+     */
+    maintenanceMode: { type: Boolean, default: false },
+    /**
+     * Per-school settings overrides. Each key overrides the corresponding
+     * SystemConfig global default for this school only.
+     *
+     * Supported keys:
+     *   maxSyncBatchSize   — max transactions per polling cycle (number)
+     *   reminderEnabled    — enable/disable fee reminder emails (boolean)
+     *   reminderIntervalMs — how often reminder scheduler runs (number, ms)
+     *   betaFeatures       — array of opted-in beta feature flags (string[])
+     */
+    settings: {
+      type: mongoose.Schema.Types.Mixed,
+      default: {},
+    },
     mfaBackupCodes: [
       {
         hash: { type: String, required: true },

--- a/backend/src/routes/schoolRoutes.js
+++ b/backend/src/routes/schoolRoutes.js
@@ -11,6 +11,9 @@ const {
   deactivateSchoolEndpoint,
   activateSchool,
   registerWebhook,
+  getSchoolSettings,
+  updateSchoolSettings,
+  clearSchoolSetting,
 } = require('../controllers/schoolController');
 const { requireAdminAuth } = require('../middleware/auth');
 const { auditContext } = require('../middleware/auditContext');
@@ -30,5 +33,10 @@ router.patch('/:schoolId/activate',   requireAdminAuth, auditContext, activateSc
 
 // Webhook registration — validates URL for SSRF safety before storing
 router.post('/:slug/webhooks', requireAdminAuth, auditContext, registerWebhook);
+
+// Per-school settings overrides
+router.get('/:schoolId/settings',     requireAdminAuth, auditContext, getSchoolSettings);
+router.patch('/:schoolId/settings',   requireAdminAuth, auditContext, updateSchoolSettings);
+router.delete('/:schoolId/settings/:key', requireAdminAuth, auditContext, clearSchoolSetting);
 
 module.exports = router;

--- a/backend/src/services/horizonFailoverClient.js
+++ b/backend/src/services/horizonFailoverClient.js
@@ -48,6 +48,7 @@ let _horizonFailovers;
 let _horizonCbTransitions;
 let _horizonActiveEndpoint;
 let _horizonCbState;
+let _horizonCbFailures;
 
 function _ensureMetrics() {
   let metrics;
@@ -87,6 +88,14 @@ function _ensureMetrics() {
     _horizonCbState = new client.Gauge({
       name: 'horizon_circuit_breaker_state',
       help: 'Circuit-breaker state per Horizon endpoint: 0=closed 1=open 2=half_open',
+      labelNames: ['url'],
+      registers: [registry],
+    });
+  }
+  if (!_horizonCbFailures) {
+    _horizonCbFailures = new client.Gauge({
+      name: 'horizon_circuit_breaker_failures',
+      help: 'Consecutive failures tracked per Horizon endpoint circuit breaker',
       labelNames: ['url'],
       registers: [registry],
     });
@@ -172,6 +181,7 @@ class CircuitBreaker {
     } else {
       this.failures = 0;
     }
+    this._updateFailuresMetric();
   }
 
   recordFailure() {
@@ -181,6 +191,14 @@ class CircuitBreaker {
       this.openedAt = Date.now();
       this._transition(CB_STATE.OPEN);
     }
+    this._updateFailuresMetric();
+  }
+
+  _updateFailuresMetric() {
+    try {
+      _ensureMetrics();
+      if (_horizonCbFailures) _horizonCbFailures.set({ url: this.url }, this.failures);
+    } catch (_) { /* metrics optional */ }
   }
 
   _transition(newState) {
@@ -221,6 +239,7 @@ class HorizonFailoverClient {
       url,
       server: new StellarSdk.Horizon.Server(url, { timeout: this._timeoutMs }),
       cb: new CircuitBreaker(url),
+      failoverCount: 0,
     }));
 
     // Expose the active server as `.server` for drop-in compatibility with
@@ -264,14 +283,16 @@ class HorizonFailoverClient {
     const toUrl = this._urls[nextIdx];
     logger.warn(`[HorizonFailoverClient] Failing over ${fromUrl} → ${toUrl}`);
 
+    this._servers[fromIndex].failoverCount++;
+    this._activeIndex = nextIdx;
+    this._refreshActiveServer();
+
     try {
       _ensureMetrics();
       if (_horizonFailovers) _horizonFailovers.inc({ from_url: fromUrl, to_url: toUrl });
       if (_horizonActiveEndpoint) _horizonActiveEndpoint.set(nextIdx);
     } catch (_) { /* metrics optional */ }
 
-    this._activeIndex = nextIdx;
-    this._refreshActiveServer();
     return true;
   }
 
@@ -362,10 +383,11 @@ class HorizonFailoverClient {
 
   /** Return a snapshot of every endpoint's circuit-breaker status. */
   getCircuitBreakerStatus() {
-    return this._servers.map(({ url, cb }, idx) => ({
+    return this._servers.map(({ url, cb, failoverCount }, idx) => ({
       url,
       index: idx,
       active: idx === this._activeIndex,
+      failoverCount,
       circuitBreaker: {
         state: cb.getState(),
         failures: cb.failures,
@@ -374,6 +396,11 @@ class HorizonFailoverClient {
           cb.getState() === CB_STATE.OPEN
             ? new Date(cb.openedAt + CB_RESET_TIMEOUT_MS).toISOString()
             : null,
+      },
+      thresholds: {
+        failureThreshold: CB_FAILURE_THRESHOLD,
+        resetTimeoutMs: CB_RESET_TIMEOUT_MS,
+        halfOpenSuccessThreshold: CB_HALF_OPEN_SUCCESS_THRESHOLD,
       },
     }));
   }
@@ -396,6 +423,9 @@ module.exports = {
   HorizonFailoverClient,
   CircuitBreaker,
   CB_STATE,
+  CB_FAILURE_THRESHOLD,
+  CB_RESET_TIMEOUT_MS,
+  CB_HALF_OPEN_SUCCESS_THRESHOLD,
   getInstance,
   resetInstance,
   resolveHorizonUrls,

--- a/backend/src/services/leaderElection.js
+++ b/backend/src/services/leaderElection.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const lock = require('./distributedLock');
+const logger = require('../utils/logger').child('LeaderElection');
+
+const LEADER_LOCK_KEY = 'scheduler:leader';
+const LEADER_LOCK_TTL_MS = parseInt(process.env.LEADER_LOCK_TTL_MS, 10) || 30_000;
+const LEADER_RENEW_INTERVAL_MS = parseInt(process.env.LEADER_RENEW_INTERVAL_MS, 10) || 15_000;
+const LEADER_ACQUIRE_INTERVAL_MS = parseInt(process.env.LEADER_ACQUIRE_INTERVAL_MS, 10) || 10_000;
+
+let _isLeader = false;
+let _token = null;
+let _renewTimer = null;
+let _acquireTimer = null;
+let _callbacks = { onElected: [], onDemoted: [] };
+let _running = false;
+
+function register(onElected, onDemoted) {
+  if (typeof onElected === 'function') _callbacks.onElected.push(onElected);
+  if (typeof onDemoted === 'function') _callbacks.onDemoted.push(onDemoted);
+}
+
+async function _tryAcquire() {
+  const token = await lock.acquire(LEADER_LOCK_KEY, LEADER_LOCK_TTL_MS);
+  if (token && !_isLeader) {
+    _isLeader = true;
+    _token = token;
+    logger.info('Elected leader — starting leader callbacks');
+    _startRenew();
+    for (const cb of _callbacks.onElected) {
+      try { cb(); } catch (err) { logger.error('Leader elected callback failed', { error: err.message }); }
+    }
+  }
+  return !!token;
+}
+
+async function _renew() {
+  if (!_isLeader || !_token) return;
+  const renewed = await lock.acquire(LEADER_LOCK_KEY, LEADER_LOCK_TTL_MS);
+  if (!renewed) {
+    logger.warn('Lost leadership — lock taken by another instance');
+    _demote();
+    return;
+  }
+  _token = renewed;
+}
+
+function _demote() {
+  _isLeader = false;
+  _token = null;
+  _stopRenew();
+  logger.info('Demoted from leader — stopping leader callbacks');
+  for (const cb of _callbacks.onDemoted) {
+    try { cb(); } catch (err) { logger.error('Leader demoted callback failed', { error: err.message }); }
+  }
+}
+
+function _startRenew() {
+  _stopRenew();
+  _renewTimer = setInterval(_renew, LEADER_RENEW_INTERVAL_MS);
+  _renewTimer.unref();
+}
+
+function _stopRenew() {
+  if (_renewTimer) {
+    clearInterval(_renewTimer);
+    _renewTimer = null;
+  }
+}
+
+function _startAcquire() {
+  _stopAcquire();
+  _acquireTimer = setInterval(_tryAcquire, LEADER_ACQUIRE_INTERVAL_MS);
+  _acquireTimer.unref();
+}
+
+function _stopAcquire() {
+  if (_acquireTimer) {
+    clearInterval(_acquireTimer);
+    _acquireTimer = null;
+  }
+}
+
+async function start() {
+  if (_running) return;
+  _running = true;
+  logger.info('Starting leader election', {
+    lockTtlMs: LEADER_LOCK_TTL_MS,
+    renewIntervalMs: LEADER_RENEW_INTERVAL_MS,
+    acquireIntervalMs: LEADER_ACQUIRE_INTERVAL_MS,
+  });
+
+  const acquired = await _tryAcquire();
+  if (!acquired) {
+    logger.info('Did not win initial election — will retry periodically');
+  }
+  _startAcquire();
+}
+
+async function stop() {
+  _running = false;
+  _stopAcquire();
+  if (_isLeader) {
+    _demote();
+    if (_token) {
+      await lock.release(LEADER_LOCK_KEY, _token);
+      _token = null;
+    }
+  }
+  _callbacks = { onElected: [], onDemoted: [] };
+  logger.info('Leader election stopped');
+}
+
+function isLeader() {
+  return _isLeader;
+}
+
+module.exports = {
+  start,
+  stop,
+  isLeader,
+  register,
+};

--- a/backend/src/services/schoolSettingsService.js
+++ b/backend/src/services/schoolSettingsService.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const School = require('../models/schoolModel');
+const SystemConfig = require('../models/systemConfigModel');
+
+const SETTING_KEYS = new Set([
+  'maxSyncBatchSize',
+  'reminderEnabled',
+  'reminderIntervalMs',
+  'maintenanceMode',
+  'betaFeatures',
+]);
+
+const SYSTEM_CONFIG_MAP = {
+  maxSyncBatchSize: 'maxSyncBatchSize',
+  reminderEnabled: 'reminderEnabled',
+  reminderIntervalMs: 'reminderIntervalMs',
+  maintenanceMode: 'maintenanceMode',
+};
+
+const DEFAULTS = {
+  maxSyncBatchSize: 20,
+  reminderEnabled: true,
+  reminderIntervalMs: 86400000,
+  maintenanceMode: false,
+  betaFeatures: [],
+};
+
+async function getSchoolSetting(schoolId, key) {
+  if (!SETTING_KEYS.has(key)) return undefined;
+
+  const school = await School.findOne({ schoolId }, { settings: 1 }).lean();
+  if (school && school.settings && school.settings[key] !== undefined) {
+    return school.settings[key];
+  }
+
+  const systemKey = SYSTEM_CONFIG_MAP[key];
+  if (systemKey) {
+    const sysVal = await SystemConfig.get(systemKey);
+    if (sysVal !== null && sysVal !== undefined) return sysVal;
+  }
+
+  return DEFAULTS[key];
+}
+
+async function setSchoolSetting(schoolId, key, value) {
+  if (!SETTING_KEYS.has(key)) {
+    throw new Error(`Unknown setting key: ${key}`);
+  }
+  return School.findOneAndUpdate(
+    { schoolId },
+    { $set: { [`settings.${key}`]: value } },
+    { new: true },
+  ).lean();
+}
+
+async function getSchoolSettings(schoolId) {
+  const school = await School.findOne({ schoolId }, { settings: 1 }).lean();
+  const schoolOverrides = school?.settings || {};
+  const merged = { ...DEFAULTS };
+
+  for (const key of Object.keys(SYSTEM_CONFIG_MAP)) {
+    const sysVal = await SystemConfig.get(SYSTEM_CONFIG_MAP[key]);
+    if (sysVal !== null && sysVal !== undefined) {
+      merged[key] = sysVal;
+    }
+  }
+
+  Object.assign(merged, schoolOverrides);
+  return merged;
+}
+
+async function clearSchoolSetting(schoolId, key) {
+  if (!SETTING_KEYS.has(key)) {
+    throw new Error(`Unknown setting key: ${key}`);
+  }
+  return School.findOneAndUpdate(
+    { schoolId },
+    { $unset: { [`settings.${key}`]: '' } },
+    { new: true },
+  ).lean();
+}
+
+module.exports = {
+  getSchoolSetting,
+  setSchoolSetting,
+  getSchoolSettings,
+  clearSchoolSetting,
+  SETTING_KEYS,
+};


### PR DESCRIPTION
Closes #835 
Closes #836 
Closes #837 
Closes #838 

## Summary

Four independent changes addressing infra and multi-tenant concerns:

### 1. Maintenance Mode Middleware (Task 4)
- **`middleware/maintenanceMode.js`**: Global maintenance check using `SystemConfig.maintenanceMode`
- **`schoolContext.js`**: Per-tenant maintenance check after school resolution
- **`School.maintenanceMode`** field for per-tenant toggle
- Exempts `/health`, `/metrics`, `/api/docs` from blocking
- Returns `503 MAINTENANCE_MODE` / `503 SCHOOL_MAINTENANCE_MODE`

### 2. Per-School Settings Override Layer (Task 3)
- **`School.settings`** sub-document for per-tenant overrides
- **`services/schoolSettingsService.js`**: `getSchoolSetting(schoolId, key)` with merge priority: school override → SystemConfig → hard-coded default
- Supported keys: `maxSyncBatchSize`, `reminderEnabled`, `reminderIntervalMs`, `betaFeatures`
- Admin API: `GET|PATCH|DELETE /api/schools/:id/settings`

### 3. Horizon Failover Metrics (Task 1)
- **`horizon_circuit_breaker_failures`** gauge per endpoint URL
- Cumulative `failoverCount` per endpoint in `getCircuitBreakerStatus()`
- CB thresholds exposed in status response and `/health/stellar.circuitBreaker`
- Threshold constants exported from `horizonFailoverClient` and `stellarConfig`

### 4. Leader Election for Singleton Schedulers (Task 2)
- **`services/leaderElection.js`** using existing Redis distributed lock (`scheduler:leader`)
- Leader acquires lock (30s TTL, 15s renewal); non-leaders retry every 10s
- Only the leader runs: consistency, reminders, reconciliation, audit log cleanup, webhook retry, session cleanup
- Polling (per-school distributed locks) and BullMQ workers continue on all instances
- Graceful demotion and clean shutdown