### PR TITLE
fix: dead-letter visibility, idempotency edge cases, batch backpressure, per-tenant fraud rules (#849–#852)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,13 @@ POLL_INTERVAL_MS=30000
 RETRY_INTERVAL_MS=60000
 RETRY_MAX_ATTEMPTS=10
 
+# --- IDEMPOTENCY ---
+# TTL for stored idempotency records (replay/reuse protection window). Default 24h.
+IDEMPOTENCY_KEY_TTL_SECONDS=86400
+# How long an in-flight reservation is honored before a new request may take it
+# over (guards against a crashed request wedging a key). Default 30s.
+IDEMPOTENCY_IN_FLIGHT_TTL_MS=30000
+
 # --- API CONFIGURATION ---
 PORT=8080
 ENV=development # development, staging, production

--- a/SUSPICIOUS_PAYMENT_MULTIPLIER.md
+++ b/SUSPICIOUS_PAYMENT_MULTIPLIER.md
@@ -258,6 +258,49 @@ npm test -- suspiciousPaymentMultiplier.test.js
 
 **Test Results:** 50/50 passing ✅
 
+## Historical-Distribution Thresholds (per tenant)
+
+A flat fee multiplier mis-fires for schools whose normal payments cluster
+differently from the expected fee. Each school can opt into a threshold based on
+its **own** confirmed-payment distribution via `suspiciousAmountConfig`:
+
+```json
+PATCH /api/schools/:slug
+{
+  "suspiciousAmountConfig": {
+    "mode": "historical",
+    "historicalWindowDays": 90,
+    "historicalStdDevMultiplier": 3.0,
+    "historicalMinSamples": 20
+  }
+}
+```
+
+- `mode: 'fee_multiplier'` (default) — the legacy behavior above.
+- `mode: 'historical'` — flags a payment when its amount is more than
+  `historicalStdDevMultiplier` standard deviations from the school's mean
+  confirmed-payment amount over the last `historicalWindowDays` days. Until the
+  school has at least `historicalMinSamples` confirmed payments, detection falls
+  back to the fee multiplier (avoiding cold-start false positives).
+
+## Review / Clear Workflow
+
+Flagged payments are reviewable and clearable, with every decision audited:
+
+- `GET  /api/payments/suspicious` — list flagged payments for the school.
+- `PATCH /api/payments/:txHash/suspicion-review` — body `{ "action": "clear" | "confirm_fraud", "note": "..." }`.
+  - `clear` removes the suspicious flag (false positive); the payment leaves the queue.
+  - `confirm_fraud` records the determination and keeps the flag.
+  - Each review writes a `payment_suspicion_review` audit log entry (reviewer, before/after, note).
+
+The review status lives on the payment (`suspicionReviewStatus`,
+`suspicionReviewedBy`, `suspicionReviewedAt`, `suspicionReviewNote`).
+
+## Metrics
+
+`suspicious_payment_flagged{school_id}` — a Prometheus counter incremented each
+time a payment is flagged, so flagged volume is alertable per tenant.
+
 ## Future Enhancements
 
 Potential improvements for future iterations:

--- a/backend/src/controllers/paymentAdminController.js
+++ b/backend/src/controllers/paymentAdminController.js
@@ -311,6 +311,78 @@ async function updatePaymentStatus(req, res, next) {
   }
 }
 
+/**
+ * PATCH /api/payments/:txHash/suspicion-review
+ *
+ * Review a flagged (suspicious) payment. Resolves the false-positive / fraud
+ * ambiguity an admin would otherwise have no way to act on:
+ *
+ *   action: 'clear'         — false positive. Removes the suspicious flag so the
+ *                             payment leaves the suspicious queue.
+ *   action: 'confirm_fraud' — confirmed fraudulent. Keeps it flagged/excluded
+ *                             and records the determination.
+ *
+ * The balance-affecting status (SUCCESS/FAILED/etc.) is intentionally left to
+ * the existing updatePaymentStatus flow so this endpoint never silently mutates
+ * student balances. Every review is written to the audit log.
+ */
+async function reviewSuspiciousPayment(req, res, next) {
+  try {
+    const { schoolId } = req;
+    const { txHash } = req.params;
+    const { action, note } = req.body;
+
+    if (!['clear', 'confirm_fraud'].includes(action)) {
+      return res.status(400).json({
+        error: "action must be 'clear' or 'confirm_fraud'",
+        code: 'VALIDATION_ERROR',
+      });
+    }
+
+    const payment = await Payment.findOne({ schoolId, txHash });
+    if (!payment) {
+      return res.status(404).json({ error: 'Payment not found', code: 'NOT_FOUND' });
+    }
+    if (!payment.isSuspicious && payment.suspicionReviewStatus === 'flagged') {
+      return res.status(400).json({ error: 'Payment is not flagged as suspicious', code: 'NOT_FLAGGED' });
+    }
+
+    const previousStatus = payment.suspicionReviewStatus;
+    const reviewer = req.auditContext?.performedBy || 'unknown';
+
+    payment.suspicionReviewStatus = action === 'clear' ? 'cleared' : 'confirmed_fraud';
+    payment.suspicionReviewedBy = reviewer;
+    payment.suspicionReviewedAt = new Date();
+    payment.suspicionReviewNote = note || null;
+    // Clearing a false positive removes it from the suspicious queue; confirming
+    // fraud keeps the flag.
+    if (action === 'clear') payment.isSuspicious = false;
+
+    const updated = await payment.save();
+
+    await logAudit({
+      schoolId,
+      action: 'payment_suspicion_review',
+      performedBy: reviewer,
+      targetId: txHash,
+      targetType: 'payment',
+      details: {
+        from: previousStatus,
+        to: payment.suspicionReviewStatus,
+        suspicionReason: payment.suspicionReason,
+        note: note || null,
+      },
+      result: 'success',
+      ipAddress: req.auditContext?.ipAddress,
+      userAgent: req.auditContext?.userAgent,
+    });
+
+    res.json(updated);
+  } catch (err) {
+    next(err);
+  }
+}
+
 function streamPaymentEvents(req, res) {
   const { addClient, removeClient } = require('../services/sseService');
   const { schoolId } = req;
@@ -345,6 +417,7 @@ module.exports = {
   getQueueJobStatus,
   getStuckPayments,
   updatePaymentStatus,
+  reviewSuspiciousPayment,
   streamPaymentEvents,
   _syncLocks,
 };

--- a/backend/src/controllers/pendingVerificationAdminController.js
+++ b/backend/src/controllers/pendingVerificationAdminController.js
@@ -1,0 +1,94 @@
+'use strict';
+
+/**
+ * pendingVerificationAdminController — global super-admin operations for the
+ * Stellar verification retry backlog.
+ *
+ * Surfaces the otherwise-invisible dead-letter state (verifications that
+ * exhausted their retries or hit a permanent error) so operators can see,
+ * inspect, and re-drive them. All routes are gated by requireAdminAuth.
+ */
+
+const {
+  getBacklogCounts,
+  listDeadLetters,
+  getPendingVerification,
+  redriveDeadLetter,
+} = require('../services/retryService');
+const { logAudit } = require('../services/auditService');
+
+/** GET /api/admin/pending-verifications/backlog — counts by status. */
+async function getBacklog(req, res, next) {
+  try {
+    const counts = await getBacklogCounts();
+    res.json({
+      counts,
+      backlog: counts.pending + counts.processing,
+      deadLettered: counts.dead_letter,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** GET /api/admin/pending-verifications/dead-letter — list dead-lettered items. */
+async function listDeadLetterVerifications(req, res, next) {
+  try {
+    const { limit, skip, schoolId } = req.query;
+    const result = await listDeadLetters({ limit, skip, schoolId });
+    res.json(result);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** GET /api/admin/pending-verifications/:id — inspect a single verification. */
+async function getDeadLetterVerification(req, res, next) {
+  try {
+    const item = await getPendingVerification(req.params.id);
+    if (!item) {
+      return res.status(404).json({ error: 'Pending verification not found', code: 'NOT_FOUND' });
+    }
+    res.json(item);
+  } catch (err) {
+    next(err);
+  }
+}
+
+/** POST /api/admin/pending-verifications/:id/retry — re-drive a dead-lettered item. */
+async function retryDeadLetterVerification(req, res, next) {
+  try {
+    const { id } = req.params;
+    const updated = await redriveDeadLetter(id);
+
+    if (!updated) {
+      return res.status(404).json({
+        error: 'Dead-lettered verification not found (it may have already been re-driven or resolved)',
+        code: 'NOT_FOUND',
+      });
+    }
+
+    await logAudit({
+      schoolId: updated.schoolId,
+      action: 'pending_verification_redrive',
+      performedBy: req.auditContext?.performedBy || 'unknown',
+      targetId: String(updated._id),
+      targetType: 'payment',
+      details: { txHash: updated.txHash, status: updated.status },
+      result: 'success',
+      ipAddress: req.auditContext?.ipAddress,
+      userAgent: req.auditContext?.userAgent,
+    });
+
+    res.json({ message: 'Verification re-queued for retry', verification: updated });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = {
+  getBacklog,
+  listDeadLetterVerifications,
+  getDeadLetterVerification,
+  retryDeadLetterVerification,
+};

--- a/backend/src/controllers/schoolController.js
+++ b/backend/src/controllers/schoolController.js
@@ -20,7 +20,7 @@ function isValidTimezone(tz) {
 // POST /api/schools
 async function createSchool(req, res, next) {
   try {
-    const { name, slug, stellarAddress, network, adminEmail, address, timezone, suspiciousPaymentMultiplier } = req.body;
+    const { name, slug, stellarAddress, network, adminEmail, address, timezone, suspiciousPaymentMultiplier, suspiciousAmountConfig } = req.body;
 
     const errors = [];
     if (!name || typeof name !== 'string' || !name.trim())
@@ -61,6 +61,7 @@ async function createSchool(req, res, next) {
       address: address || null,
       ...(timezone !== undefined && { timezone }),
       ...(suspiciousPaymentMultiplier !== undefined && { suspiciousPaymentMultiplier }),
+      ...(suspiciousAmountConfig !== undefined && { suspiciousAmountConfig }),
     });
 
     // Audit log
@@ -156,7 +157,7 @@ async function getSchool(req, res, next) {
 // PATCH /api/schools/:schoolSlug
 async function updateSchool(req, res, next) {
   try {
-    const allowed = ['name', 'stellarAddress', 'network', 'adminEmail', 'address', 'suspiciousPaymentMultiplier'];
+    const allowed = ['name', 'stellarAddress', 'network', 'adminEmail', 'address', 'suspiciousPaymentMultiplier', 'suspiciousAmountConfig'];
     const updates = {};
     for (const key of allowed) {
       if (req.body[key] !== undefined) updates[key] = req.body[key];
@@ -202,6 +203,17 @@ async function updateSchool(req, res, next) {
           error: 'suspiciousPaymentMultiplier must be a number between 1.1 and 100',
           code: 'INVALID_SUSPICIOUS_PAYMENT_MULTIPLIER',
         });
+      }
+    }
+
+    // Validate suspiciousAmountConfig if being updated
+    if (updates.suspiciousAmountConfig !== undefined) {
+      const cfg = updates.suspiciousAmountConfig;
+      if (typeof cfg !== 'object' || cfg === null || Array.isArray(cfg)) {
+        return res.status(400).json({ error: 'suspiciousAmountConfig must be an object', code: 'INVALID_SUSPICIOUS_AMOUNT_CONFIG' });
+      }
+      if (cfg.mode !== undefined && !['fee_multiplier', 'historical'].includes(cfg.mode)) {
+        return res.status(400).json({ error: "suspiciousAmountConfig.mode must be 'fee_multiplier' or 'historical'", code: 'INVALID_SUSPICIOUS_AMOUNT_CONFIG' });
       }
     }
 

--- a/backend/src/metrics/index.js
+++ b/backend/src/metrics/index.js
@@ -103,6 +103,61 @@ new client.Gauge({
   },
 });
 
+// pending_verification_backlog{status} — depth of the Stellar verification
+// retry backlog, queried live from MongoDB on each scrape. Operators alert on a
+// growing `pending`/`processing` backlog or any `dead_letter` accumulation.
+new client.Gauge({
+  name: 'pending_verification_backlog',
+  help: 'Number of pending verification records grouped by status (pending, processing, resolved, dead_letter)',
+  labelNames: ['status'],
+  registers: [registry],
+  async collect() {
+    try {
+      const { getBacklogCounts } = require('../services/retryService');
+      const counts = await getBacklogCounts();
+      this.reset();
+      for (const [status, count] of Object.entries(counts)) {
+        this.set({ status }, count);
+      }
+    } catch (_) {
+      // DB may not be ready yet — scrape still succeeds
+    }
+  },
+});
+
+// suspicious_payment_flagged{school_id} — counter of payments flagged as
+// suspicious by the abnormal-pattern detector, so operators can alert on
+// flagged volume per tenant. Incremented in the payment confirmation pipeline.
+const suspiciousPaymentFlagged = new client.Counter({
+  name: 'suspicious_payment_flagged',
+  help: 'Number of payments flagged as suspicious, labelled by school',
+  labelNames: ['school_id'],
+  registers: [registry],
+});
+
+// Concurrent payment batch metrics — recorded by the concurrentPaymentProcessor
+// after each processBatch() call so batch throughput and per-item outcomes are
+// observable and alertable.
+const paymentBatchTotal = new client.Counter({
+  name: 'payment_batch_total',
+  help: 'Number of payment batches processed',
+  registers: [registry],
+});
+
+const paymentBatchItemsTotal = new client.Counter({
+  name: 'payment_batch_items_total',
+  help: 'Number of payment batch items grouped by outcome',
+  labelNames: ['outcome'],
+  registers: [registry],
+});
+
+const paymentBatchDurationSeconds = new client.Histogram({
+  name: 'payment_batch_duration_seconds',
+  help: 'Duration of a payment batch in seconds',
+  buckets: [0.1, 0.5, 1, 2, 5, 10, 30, 60, 120],
+  registers: [registry],
+});
+
 // http_request_duration_seconds{method,route,status} — recorded per request
 // in the requestLogger middleware, which already captures these fields.
 const httpRequestDurationSeconds = new client.Histogram({
@@ -113,4 +168,12 @@ const httpRequestDurationSeconds = new client.Histogram({
   registers: [registry],
 });
 
-module.exports = { registry, syncDurationSeconds, httpRequestDurationSeconds };
+module.exports = {
+  registry,
+  syncDurationSeconds,
+  httpRequestDurationSeconds,
+  suspiciousPaymentFlagged,
+  paymentBatchTotal,
+  paymentBatchItemsTotal,
+  paymentBatchDurationSeconds,
+};

--- a/backend/src/middleware/idempotency.js
+++ b/backend/src/middleware/idempotency.js
@@ -1,20 +1,35 @@
 'use strict';
 
-const { deriveIdempotencyKey } = require('../utils/idempotencyKey');
+const { deriveIdempotencyKey, fingerprintRequest } = require('../utils/idempotencyKey');
 const idempotencyStore = require('../services/idempotencyStore');
 
 /**
  * Idempotency middleware.
  *
- * Expects an `Idempotency-Key` header on mutating requests.
- * - If the key has been seen before and the response is cached, returns it immediately.
- * - If the key is new, processes the request normally and caches the response.
- * - If the header is missing, rejects with 400.
+ * Expects an `Idempotency-Key` header on mutating requests and enforces
+ * exactly-once semantics over a TTL window:
+ *
+ *  - Replay (same key, same body, request already completed) → the cached
+ *    response is returned verbatim (same status, same body).
+ *  - Key reuse with a DIFFERENT body → 422. Reusing a key for a different
+ *    payload is a client bug; replaying the first response would be wrong and
+ *    re-executing would violate idempotency, so we refuse it.
+ *  - Concurrent in-flight duplicate (a first request with this key is still
+ *    executing) → 409. The caller should retry after the first one finishes,
+ *    at which point it replays the cached response.
+ *  - Missing/blank header → 400.
  *
  * The canonical key is derived via the shared `deriveIdempotencyKey` util
- * (scoped by request path) and stored in the persistent `idempotencyStore`, so
- * a replay is recognized after a restart or on another replica — and the
- * derivation never diverges from the payment processor's.
+ * (scoped by request path) and the request body is fingerprinted via
+ * `fingerprintRequest`. State lives in the persistent `idempotencyStore`
+ * (Mongo, optionally Redis-fronted), so all of the above hold after a restart
+ * and across replicas.
+ *
+ * TTL semantics: records (and therefore replay/reuse protection) live for
+ * IDEMPOTENCY_KEY_TTL_SECONDS (default 24h). A client retrying after the TTL
+ * expires is treated as a brand-new request. In-flight reservations older than
+ * IDEMPOTENCY_IN_FLIGHT_TTL_MS (default 30s) are considered abandoned and may be
+ * taken over, so a crashed request never wedges a key.
  *
  * Usage: apply to individual POST routes that must be idempotent.
  */
@@ -30,40 +45,81 @@ function idempotency(req, res, next) {
 
   const scope = req.path;
   const canonicalKey = deriveIdempotencyKey(rawKey, scope);
+  const fingerprint = fingerprintRequest(req.body);
 
-  // Check for a cached response
+  // Decide what to do with an existing record for this key.
+  function resolveExisting(record) {
+    if (!record) return null;
+    if (record.state === 'completed') {
+      if (record.requestFingerprint && record.requestFingerprint !== fingerprint) {
+        res.status(422).json({
+          error:
+            'Idempotency-Key was already used with a different request body',
+          code: 'IDEMPOTENCY_KEY_REUSE',
+        });
+        return 'handled';
+      }
+      res.status(record.responseStatus).json(record.responseBody);
+      return 'handled';
+    }
+    // in_progress
+    res.status(409).json({
+      error: 'A request with this Idempotency-Key is already being processed',
+      code: 'IDEMPOTENCY_KEY_IN_PROGRESS',
+    });
+    return 'handled';
+  }
+
   idempotencyStore
-    .get(canonicalKey)
+    .getFull(canonicalKey)
     .then((record) => {
+      // Fast path: a non-stale existing record fully decides the outcome.
       if (record) {
-        // Replay the cached response — same status, same body
-        return res.status(record.responseStatus).json(record.responseBody);
+        const ageMs = Date.now() - record.createdAt.getTime();
+        const staleInFlight =
+          record.state === 'in_progress' && ageMs >= idempotencyStore.IN_FLIGHT_TTL_MS;
+        if (!staleInFlight) {
+          return resolveExisting(record);
+        }
+        // Stale in-flight reservation: fall through to reserve() which takes it over.
       }
 
-      // Intercept res.json to capture and cache the response before sending
-      const originalJson = res.json.bind(res);
+      // Atomically claim the key. This is the race-safe arbiter: if two requests
+      // reach here at once, exactly one reserves and the other gets the record.
+      return idempotencyStore
+        .reserve(canonicalKey, { scope, fingerprint })
+        .then((reservation) => {
+          if (!reservation.reserved) {
+            return resolveExisting(reservation.record);
+          }
 
-      res.json = function (body) {
-        // Only cache successful or expected error responses (not 5xx)
-        if (res.statusCode < 500) {
-          idempotencyStore
-            .set(canonicalKey, {
-              scope,
-              responseStatus: res.statusCode,
-              responseBody: body,
-            })
-            .catch((err) => {
-              console.error('[Idempotency] Failed to cache response:', err.message);
-            });
-        }
-        return originalJson(body);
-      };
+          // We own the reservation. Intercept res.json to persist the outcome.
+          const originalJson = res.json.bind(res);
+          res.json = function (body) {
+            if (res.statusCode < 500) {
+              idempotencyStore
+                .complete(canonicalKey, {
+                  scope,
+                  responseStatus: res.statusCode,
+                  responseBody: body,
+                  fingerprint,
+                })
+                .catch((err) => {
+                  console.error('[Idempotency] Failed to cache response:', err.message);
+                });
+            } else {
+              // 5xx is never cached — release the reservation so the client can retry.
+              idempotencyStore.release(canonicalKey).catch(() => {});
+            }
+            return originalJson(body);
+          };
 
-      next();
+          next();
+        });
     })
     .catch((err) => {
-      console.error('[Idempotency] store lookup failed:', err.message);
-      // Fail open — let the request through rather than blocking the user
+      console.error('[Idempotency] store operation failed:', err.message);
+      // Fail open — let the request through rather than blocking the user.
       next();
     });
 }

--- a/backend/src/models/idempotencyKeyModel.js
+++ b/backend/src/models/idempotencyKeyModel.js
@@ -25,8 +25,22 @@ const idempotencyKeySchema = new mongoose.Schema({
   // 'payment-processor'). The scope is already baked into `key`; this is kept
   // for debuggability and is not part of the lookup.
   scope: { type: String, default: '' },
-  responseStatus: { type: Number, required: true },
-  responseBody: { type: mongoose.Schema.Types.Mixed, required: true },
+  // Lifecycle of the record:
+  //   in_progress — a request is currently executing under this key. A concurrent
+  //                 duplicate that finds an in_progress record is rejected with 409
+  //                 (rather than double-executing) until the first request finishes.
+  //   completed   — the request finished and `responseStatus`/`responseBody` hold the
+  //                 cached result to replay.
+  // Defaults to 'completed' so records written directly via the store's set()
+  // (e.g. the payment processor) behave exactly as before.
+  state: { type: String, enum: ['in_progress', 'completed'], default: 'completed' },
+  // sha256 fingerprint of the canonicalized request body. Used to detect the
+  // same key being replayed with a *different* body (answered with 422). Null
+  // for records written without a body fingerprint (back-compat).
+  requestFingerprint: { type: String, default: null },
+  // Not required: an in_progress reservation has no response yet.
+  responseStatus: { type: Number, default: null },
+  responseBody: { type: mongoose.Schema.Types.Mixed, default: null },
   createdAt: { type: Date, default: Date.now, expires: TTL_SECONDS },
 });
 

--- a/backend/src/models/paymentModel.js
+++ b/backend/src/models/paymentModel.js
@@ -35,6 +35,18 @@ const paymentSchema = new mongoose.Schema(
     senderAddress: { type: String, default: null },
     isSuspicious: { type: Boolean, default: false },
     suspicionReason: { type: String, default: null },
+    // Review workflow for flagged payments (issue #852). A flag starts as
+    // 'flagged'; an admin clears it (false positive → 'cleared', restoring the
+    // payment) or confirms it as fraud ('confirmed_fraud'). All transitions are
+    // captured in the audit log.
+    suspicionReviewStatus: {
+      type: String,
+      enum: ['flagged', 'cleared', 'confirmed_fraud'],
+      default: 'flagged',
+    },
+    suspicionReviewedBy: { type: String, default: null },
+    suspicionReviewedAt: { type: Date, default: null },
+    suspicionReviewNote: { type: String, default: null },
 
     ledger: { type: Number, default: null },
     ledgerSequence: { type: Number, default: null },

--- a/backend/src/models/schoolModel.js
+++ b/backend/src/models/schoolModel.js
@@ -96,6 +96,26 @@ const schoolSchema = new mongoose.Schema(
       max: [100, 'suspiciousPaymentMultiplier must not exceed 100'],
     },
     /**
+     * Per-tenant configuration for the suspicious-amount heuristic. A flat
+     * multiplier off the expected fee mis-fires for schools whose normal
+     * payments cluster differently; enabling the historical mode bases the
+     * threshold on the school's OWN confirmed-payment distribution instead.
+     *
+     *   mode               — 'fee_multiplier' (default; uses suspiciousPaymentMultiplier)
+     *                        or 'historical' (z-score against the school's history).
+     *   historicalWindowDays    — lookback window for building the distribution.
+     *   historicalStdDevMultiplier — flag amounts more than N std-devs from the mean.
+     *   historicalMinSamples    — minimum confirmed payments before the historical
+     *                             threshold engages (below this it falls back to
+     *                             the fee multiplier, avoiding cold-start noise).
+     */
+    suspiciousAmountConfig: {
+      mode: { type: String, enum: ['fee_multiplier', 'historical'], default: 'fee_multiplier' },
+      historicalWindowDays: { type: Number, default: 90, min: 1, max: 730 },
+      historicalStdDevMultiplier: { type: Number, default: 3.0, min: 1.0, max: 10 },
+      historicalMinSamples: { type: Number, default: 20, min: 1, max: 100000 },
+    },
+    /**
      * Maximum payment multiplier for this school.
      * The maximum allowed payment is feeAmount * maxPaymentMultiplier.
      * Allows each school to define what constitutes a suspicious overpayment.

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -4,6 +4,12 @@ const express = require('express');
 const router = express.Router();
 const { setLogLevel } = require('../controllers/adminController');
 const { listDLQ, retryDLQEntry } = require('../controllers/webhookAdminController');
+const {
+  getBacklog,
+  listDeadLetterVerifications,
+  getDeadLetterVerification,
+  retryDeadLetterVerification,
+} = require('../controllers/pendingVerificationAdminController');
 const { requireAdminAuth } = require('../middleware/auth');
 const { auditContext } = require('../middleware/auditContext');
 
@@ -13,5 +19,11 @@ router.post('/log-level', requireAdminAuth, auditContext, setLogLevel);
 // Webhook dead-letter queue admin endpoints
 router.get('/webhooks/dlq', requireAdminAuth, listDLQ);
 router.post('/webhooks/dlq/:id/retry', requireAdminAuth, auditContext, retryDLQEntry);
+
+// Stellar verification retry backlog / dead-letter admin endpoints
+router.get('/pending-verifications/backlog', requireAdminAuth, getBacklog);
+router.get('/pending-verifications/dead-letter', requireAdminAuth, listDeadLetterVerifications);
+router.get('/pending-verifications/:id', requireAdminAuth, getDeadLetterVerification);
+router.post('/pending-verifications/:id/retry', requireAdminAuth, auditContext, retryDeadLetterVerification);
 
 module.exports = router;

--- a/backend/src/routes/paymentRoutes.js
+++ b/backend/src/routes/paymentRoutes.js
@@ -37,6 +37,7 @@ const {
   getQueueJobStatus,
   getStuckPayments,
   updatePaymentStatus,
+  reviewSuspiciousPayment,
   streamPaymentEvents,
 } = require('../controllers/paymentAdminController');
 
@@ -193,5 +194,6 @@ router.post("/:paymentId/lock", lockPaymentForUpdate);
 router.post("/:paymentId/unlock", unlockPayment);
 
 router.patch("/:txHash/status", requireAdminAuth, auditContext, updatePaymentStatus);
+router.patch("/:txHash/suspicion-review", requireAdminAuth, auditContext, reviewSuspiciousPayment);
 
 module.exports = router;

--- a/backend/src/services/concurrentPaymentProcessor.js
+++ b/backend/src/services/concurrentPaymentProcessor.js
@@ -174,6 +174,29 @@ class ConcurrentPaymentProcessor {
     this.maxRetries = options.maxRetries || 3;
     this.maxQueueDepth = options.maxQueueDepth || 1000;
     this.activeCount = 0;
+
+    // ── Batch / backpressure tuning (issue #851) ──────────────────────────────
+    // Default concurrency for processBatch when the caller doesn't override it.
+    this.batchConcurrencyLimit = options.batchConcurrencyLimit || 10;
+    // When Horizon (via the rate-limited client) signals saturation, hold new
+    // dispatches rather than piling on and tripping the rate limiter. Bounded so
+    // a wedged signal can't stall a batch forever. Off by default so unit tests
+    // that construct a bare processor don't pull in the Horizon client; the
+    // production singleton below opts in.
+    this.backpressureEnabled = options.backpressureEnabled === true;
+    this.backpressureDelayMs = options.backpressureDelayMs || 100;
+    this.maxBackpressureWaitMs = options.maxBackpressureWaitMs || 5000;
+    // Injectable for tests; defaults to the shared rate-limited client's readiness.
+    this.isHorizonReady =
+      options.isHorizonReady ||
+      (() => {
+        try {
+          return require("./stellarRateLimitedClient").getClient().isReady();
+        } catch (_) {
+          // Client not initialized (e.g. Redis-less test env) — assume ready.
+          return true;
+        }
+      });
   }
 
   // ── Process Payment ───────────────────────────────────────────────────────
@@ -574,41 +597,139 @@ class ConcurrentPaymentProcessor {
     );
   }
 
-  // ── Batch Processing ─────────────────────────────────────────────────────
-  async processBatch(payments, options = {}) {
-    const results = [];
-    const concurrencyLimit = options.concurrencyLimit || 10;
-    const queueFullRetryDelayMs = options.queueFullRetryDelayMs !== undefined ? options.queueFullRetryDelayMs : 500;
-
-    for (let i = 0; i < payments.length; i += concurrencyLimit) {
-      const batch = payments.slice(i, i + concurrencyLimit);
-      const batchResults = await Promise.allSettled(
-        batch.map(async (p) => {
-          let result = await this.processPayment(p, options);
-          while (result && result.error && result.error.code === "QUEUE_FULL") {
-            logger.warn("[PaymentProcessor] Queue full, retrying after delay", {
-              retryDelayMs: queueFullRetryDelayMs,
-            });
-            await new Promise((resolve) =>
-              setTimeout(resolve, queueFullRetryDelayMs)
-            );
-            result = await this.processPayment(p, options);
-          }
-          return result;
-        })
-      );
-
-      for (const res of batchResults) {
-        if (res.status === "fulfilled")
-          results.push({ success: true, data: res.value });
-        else results.push({ success: false, error: res.reason.message });
+  // ── Backpressure ─────────────────────────────────────────────────────────
+  // Hold until the Horizon-facing client reports it is not saturated, or the
+  // bounded wait elapses (so a stuck signal can never deadlock a batch).
+  async _awaitHorizonCapacity(maxWaitMs) {
+    if (!this.backpressureEnabled) return;
+    let waited = 0;
+    while (waited < maxWaitMs) {
+      let ready = true;
+      try {
+        ready = this.isHorizonReady();
+      } catch (_) {
+        ready = true;
       }
+      if (ready) return;
+      logger.warn("[PaymentProcessor] Horizon saturated — applying backpressure", {
+        waitedMs: waited,
+      });
+      await new Promise((r) => setTimeout(r, this.backpressureDelayMs));
+      waited += this.backpressureDelayMs;
+    }
+  }
+
+  // ── Batch Processing ─────────────────────────────────────────────────────
+  // Streaming worker pool: a fixed number of workers each pull the next item as
+  // soon as they finish, so one slow payment never stalls a whole chunk.
+  // Per-item failures are isolated into structured results — a single bad tx
+  // never aborts the batch — and backpressure is applied against Horizon
+  // saturation between dispatches. Outcomes are exported as metrics.
+  async processBatch(payments, options = {}) {
+    const items = Array.isArray(payments) ? payments : [];
+    const concurrencyLimit = Math.max(
+      1,
+      options.concurrencyLimit || this.batchConcurrencyLimit
+    );
+    const queueFullRetryDelayMs =
+      options.queueFullRetryDelayMs !== undefined
+        ? options.queueFullRetryDelayMs
+        : 500;
+    const maxBackpressureWaitMs =
+      options.maxBackpressureWaitMs !== undefined
+        ? options.maxBackpressureWaitMs
+        : this.maxBackpressureWaitMs;
+
+    const startedAt = Date.now();
+    const results = new Array(items.length);
+
+    const processOne = async (payment, index) => {
+      // Backpressure: yield to Horizon if it is saturated before dispatching.
+      await this._awaitHorizonCapacity(maxBackpressureWaitMs);
+
+      let result = await this.processPayment(payment, options);
+      // QUEUE_FULL is local saturation — retry the same item after a delay
+      // rather than counting it as a failure.
+      while (result && result.error && result.error.code === "QUEUE_FULL") {
+        logger.warn("[PaymentProcessor] Queue full, retrying after delay", {
+          index,
+          retryDelayMs: queueFullRetryDelayMs,
+        });
+        await new Promise((resolve) =>
+          setTimeout(resolve, queueFullRetryDelayMs)
+        );
+        await this._awaitHorizonCapacity(maxBackpressureWaitMs);
+        result = await this.processPayment(payment, options);
+      }
+      return result;
+    };
+
+    // Fixed pool of workers pulling from a shared cursor. A thrown error in one
+    // item is caught and recorded — it never rejects the pool or aborts peers.
+    let cursor = 0;
+    const worker = async () => {
+      while (true) {
+        const index = cursor++;
+        if (index >= items.length) return;
+        try {
+          const value = await processOne(items[index], index);
+          // `success` reflects whether the call completed without throwing
+          // (Promise-level). `itemSuccess` is the business outcome — callers
+          // inspect it (or `data.success`) for per-item detail.
+          results[index] = {
+            success: true,
+            index,
+            itemSuccess: !!(value && value.success),
+            error:
+              value && !value.success && value.error
+                ? value.error.message
+                : null,
+            code: value && !value.success && value.error ? value.error.code : null,
+            data: value,
+          };
+        } catch (err) {
+          results[index] = {
+            success: false,
+            index,
+            itemSuccess: false,
+            error: err.message,
+          };
+        }
+      }
+    };
+
+    const poolSize = Math.min(concurrencyLimit, items.length);
+    await Promise.all(Array.from({ length: poolSize }, () => worker()));
+
+    // Promise-level counts (backward compatible): fulfilled vs thrown.
+    const successful = results.filter((r) => r && r.success).length;
+    const failed = results.length - successful;
+    // Business-level counts: payments that actually processed vs not.
+    const itemsSucceeded = results.filter((r) => r && r.itemSuccess).length;
+    const itemsFailed = results.length - itemsSucceeded;
+
+    // ── Batch metrics ──────────────────────────────────────────────────────
+    try {
+      const {
+        paymentBatchTotal,
+        paymentBatchItemsTotal,
+        paymentBatchDurationSeconds,
+      } = require("../metrics");
+      paymentBatchTotal.inc();
+      if (itemsSucceeded) paymentBatchItemsTotal.inc({ outcome: "success" }, itemsSucceeded);
+      if (itemsFailed) paymentBatchItemsTotal.inc({ outcome: "failed" }, itemsFailed);
+      paymentBatchDurationSeconds.observe((Date.now() - startedAt) / 1000);
+    } catch (_) {
+      // Metrics module not available — batch result is unaffected.
     }
 
     return {
-      total: payments.length,
-      successful: results.filter((r) => r.success).length,
-      failed: results.filter((r) => !r.success).length,
+      total: items.length,
+      successful,
+      failed,
+      itemsSucceeded,
+      itemsFailed,
+      durationMs: Date.now() - startedAt,
       results,
     };
   }
@@ -637,6 +758,8 @@ const concurrentPaymentProcessor = new ConcurrentPaymentProcessor({
   lockTimeoutMs: 30000,
   maxRetries: 3,
   maxQueueDepth: config.MAX_QUEUE_DEPTH,
+  // The live processor applies Horizon backpressure during batch processing.
+  backpressureEnabled: true,
 });
 
 module.exports = {

--- a/backend/src/services/idempotencyStore.js
+++ b/backend/src/services/idempotencyStore.js
@@ -21,6 +21,15 @@ const logger = require('../utils/logger').child('IdempotencyStore');
 const TTL_SECONDS = IdempotencyKey.TTL_SECONDS;
 const REDIS_PREFIX = 'idem:';
 
+// How long an `in_progress` reservation is honored before it is considered
+// abandoned (e.g. the owning process crashed mid-request). After this window a
+// new request may take over the reservation and re-execute, rather than being
+// stuck behind a dead in-flight record until the 24h TTL purges it.
+const IN_FLIGHT_TTL_MS = parseInt(
+  process.env.IDEMPOTENCY_IN_FLIGHT_TTL_MS || '30000',
+  10
+);
+
 const redisEnabled = Boolean(process.env.REDIS_HOST);
 
 let redis = null;
@@ -118,4 +127,158 @@ async function set(key, record) {
   await redisSet(key, doc);
 }
 
-module.exports = { get, set, redisEnabled };
+/**
+ * Read the FULL record for a canonical key, including lifecycle state, request
+ * fingerprint, and createdAt. Unlike `get()` (which returns only the cached
+ * response and is kept response-shaped for the payment processor), this is what
+ * the HTTP idempotency middleware uses to make 200/409/422 decisions.
+ *
+ * @param {string} key canonical idempotency key
+ * @returns {Promise<{state:string, requestFingerprint:string|null, responseStatus:number|null, responseBody:*, scope:string, createdAt:Date}|null>}
+ */
+async function getFull(key) {
+  if (!key) return null;
+
+  // Redis only ever caches completed results (warmed by set()/complete()), so a
+  // hit is authoritative for the completed case and avoids a Mongo round-trip.
+  const cached = await redisGet(key);
+  if (cached && cached.state === 'completed') {
+    return {
+      state: 'completed',
+      requestFingerprint: cached.requestFingerprint || null,
+      responseStatus: cached.responseStatus,
+      responseBody: cached.responseBody,
+      scope: cached.scope || '',
+      createdAt: cached.createdAt ? new Date(cached.createdAt) : new Date(),
+    };
+  }
+
+  const record = await IdempotencyKey.findOne({ key }).lean();
+  if (!record) return null;
+
+  return {
+    state: record.state || 'completed',
+    requestFingerprint: record.requestFingerprint || null,
+    responseStatus: record.responseStatus,
+    responseBody: record.responseBody,
+    scope: record.scope || '',
+    createdAt: record.createdAt ? new Date(record.createdAt) : new Date(),
+  };
+}
+
+/**
+ * Atomically claim a key for an in-flight request. The unique index on `key`
+ * makes this a compare-and-set: exactly one concurrent request wins.
+ *
+ *  - { reserved: true }                 — caller owns the reservation; proceed.
+ *  - { reserved: false, record }        — another request already holds/holds-the
+ *                                         result for this key; caller should 409
+ *                                         (in_progress) or replay/422 (completed).
+ *
+ * A stale in_progress reservation (older than IN_FLIGHT_TTL_MS) is taken over
+ * atomically so a crashed request never wedges the key.
+ *
+ * @param {string} key canonical idempotency key
+ * @param {{scope?:string, fingerprint?:string|null}} opts
+ */
+async function reserve(key, { scope = '', fingerprint = null } = {}) {
+  if (!key) return { reserved: false, record: null };
+
+  try {
+    await IdempotencyKey.create({
+      key,
+      scope,
+      state: 'in_progress',
+      requestFingerprint: fingerprint,
+      responseStatus: null,
+      responseBody: null,
+    });
+    return { reserved: true };
+  } catch (err) {
+    if (err.code !== 11000) {
+      logger.error('Failed to reserve idempotency key', { error: err.message });
+      throw err;
+    }
+  }
+
+  // Key already exists — inspect it.
+  const existing = await getFull(key);
+  if (!existing) {
+    // Raced with a TTL purge between create and read; one more attempt.
+    try {
+      await IdempotencyKey.create({
+        key,
+        scope,
+        state: 'in_progress',
+        requestFingerprint: fingerprint,
+        responseStatus: null,
+        responseBody: null,
+      });
+      return { reserved: true };
+    } catch (_) {
+      return { reserved: false, record: await getFull(key) };
+    }
+  }
+
+  if (existing.state === 'in_progress') {
+    const age = Date.now() - existing.createdAt.getTime();
+    if (age >= IN_FLIGHT_TTL_MS) {
+      // Stale reservation — take it over atomically. The `state: in_progress`
+      // guard ensures we don't clobber a record that just completed.
+      const taken = await IdempotencyKey.findOneAndUpdate(
+        { key, state: 'in_progress' },
+        { $set: { scope, requestFingerprint: fingerprint, createdAt: new Date() } },
+        { new: true }
+      );
+      if (taken) return { reserved: true };
+      return { reserved: false, record: await getFull(key) };
+    }
+  }
+
+  return { reserved: false, record: existing };
+}
+
+/**
+ * Finalize a previously reserved key with the request's response, flipping it to
+ * `completed`. Upserts so it is also correct if no reservation existed.
+ *
+ * @param {string} key canonical idempotency key
+ * @param {{scope?:string, responseStatus:number, responseBody:*, fingerprint?:string|null}} record
+ */
+async function complete(key, record) {
+  if (!key) return;
+
+  const doc = {
+    scope: record.scope || '',
+    state: 'completed',
+    requestFingerprint: record.fingerprint || null,
+    responseStatus: record.responseStatus,
+    responseBody: record.responseBody,
+  };
+
+  await IdempotencyKey.findOneAndUpdate(
+    { key },
+    { $set: doc, $setOnInsert: { key, createdAt: new Date() } },
+    { upsert: true }
+  );
+
+  await redisSet(key, doc);
+}
+
+/**
+ * Release a reservation without storing a result, so the client may retry.
+ * Used when a request fails with a 5xx (which is never cached). Only deletes a
+ * record still in `in_progress` — never a completed one.
+ *
+ * @param {string} key canonical idempotency key
+ */
+async function release(key) {
+  if (!key) return;
+  try {
+    await IdempotencyKey.deleteOne({ key, state: 'in_progress' });
+  } catch (err) {
+    logger.warn('Failed to release idempotency reservation', { error: err.message });
+  }
+}
+
+module.exports = { get, set, getFull, reserve, complete, release, redisEnabled, IN_FLIGHT_TTL_MS };

--- a/backend/src/services/retryService.js
+++ b/backend/src/services/retryService.js
@@ -73,6 +73,76 @@ async function queueForRetry(
   });
 }
 
+/**
+ * Operator visibility / re-drive helpers for the dead-letter backlog.
+ * These intentionally span all schools (bypassTenantScope) because they back
+ * global super-admin endpoints. Callers must enforce admin auth.
+ */
+
+/** Count pending-verification documents grouped by status (for metrics/alerting). */
+async function getBacklogCounts() {
+  const rows = await PendingVerification.aggregate([
+    { $group: { _id: "$status", count: { $sum: 1 } } },
+  ]);
+  const counts = { pending: 0, processing: 0, resolved: 0, dead_letter: 0 };
+  for (const { _id, count } of rows) {
+    if (_id) counts[_id] = count;
+  }
+  return counts;
+}
+
+/**
+ * List dead-lettered verifications, newest first.
+ * @param {{ limit?: number, skip?: number, schoolId?: string }} opts
+ */
+async function listDeadLetters({ limit = 50, skip = 0, schoolId = null } = {}) {
+  const query = { status: "dead_letter" };
+  if (schoolId) query.schoolId = schoolId;
+
+  const cappedLimit = Math.min(Math.max(parseInt(limit, 10) || 50, 1), 200);
+  const cappedSkip = Math.max(parseInt(skip, 10) || 0, 0);
+
+  const [items, total] = await Promise.all([
+    PendingVerification.find(query)
+      .bypassTenantScope()
+      .sort({ updatedAt: -1 })
+      .skip(cappedSkip)
+      .limit(cappedLimit)
+      .lean(),
+    PendingVerification.countDocuments(query).bypassTenantScope(),
+  ]);
+
+  return { items, total, limit: cappedLimit, skip: cappedSkip };
+}
+
+/** Inspect a single dead-lettered (or any) verification by its document id. */
+async function getPendingVerification(id) {
+  return PendingVerification.findById(id).bypassTenantScope().lean();
+}
+
+/**
+ * Re-drive a dead-lettered verification: reset it to `pending`, clear the
+ * attempt counter, and make it due immediately so the retry worker picks it up
+ * on its next tick. Returns the updated document, or null if not found / not in
+ * the dead_letter state.
+ *
+ * @param {string} id PendingVerification document id
+ */
+async function redriveDeadLetter(id) {
+  return PendingVerification.findOneAndUpdate(
+    { _id: id, status: "dead_letter" },
+    {
+      $set: {
+        status: "pending",
+        attempts: 0,
+        nextRetryAt: new Date(),
+        lastError: null,
+      },
+    },
+    { new: true },
+  ).bypassTenantScope();
+}
+
 let _running = false;
 let _timer = null;
 
@@ -270,4 +340,8 @@ module.exports = {
   startRetryWorker,
   stopRetryWorker,
   isRetryWorkerRunning,
+  getBacklogCounts,
+  listDeadLetters,
+  getPendingVerification,
+  redriveDeadLetter,
 };

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -251,13 +251,58 @@ async function detectCrossSchoolMemoCollision(memo, schoolId, txDate) {
 }
 
 /**
+ * Compute the mean and (population) standard deviation of a school's confirmed,
+ * non-suspicious payment amounts within a lookback window. Used to base the
+ * suspicious-amount threshold on each tenant's OWN distribution rather than a
+ * flat multiplier off the expected fee.
+ *
+ * @param {string} schoolId
+ * @param {number} windowDays lookback window
+ * @returns {Promise<{count:number, mean:number, std:number}>}
+ */
+async function computeHistoricalAmountStats(schoolId, windowDays) {
+  const windowStart = new Date(Date.now() - windowDays * 24 * 60 * 60 * 1000);
+  const rows = await Payment.aggregate([
+    {
+      $match: {
+        schoolId,
+        isSuspicious: false,
+        deletedAt: null,
+        confirmedAt: { $gte: windowStart },
+        amount: { $gt: 0 },
+      },
+    },
+    {
+      $group: {
+        _id: null,
+        count: { $sum: 1 },
+        mean: { $avg: "$amount" },
+        std: { $stdDevPop: "$amount" },
+      },
+    },
+  ]);
+
+  if (!rows.length) return { count: 0, mean: 0, std: 0 };
+  return {
+    count: rows[0].count || 0,
+    mean: rows[0].mean || 0,
+    std: rows[0].std || 0,
+  };
+}
+
+/**
  * Detect abnormal payment patterns:
  *  1. Rapid repeated transactions — same sender sends more than RAPID_TX_LIMIT
  *     payments within RAPID_TX_WINDOW_MS.
- *  2. Unusual amount — payment deviates from the expected fee by more than
- *     the school's configured multiplier (default 3×).
+ *  2. Unusual amount — by default the payment deviates from the expected fee by
+ *     more than the school's configured multiplier (default 3×). When the
+ *     school opts into historical mode (`amountConfig.mode === 'historical'`)
+ *     and enough history exists, the threshold is a z-score against the
+ *     school's own confirmed-payment distribution instead.
  *
  * Returns { suspicious: boolean, reason: string|null }
+ *
+ * @param {object|null} amountConfig per-tenant suspiciousAmountConfig (optional)
  */
 async function detectAbnormalPatterns(
   senderAddress,
@@ -266,6 +311,7 @@ async function detectAbnormalPatterns(
   txDate,
   schoolId,
   suspiciousPaymentMultiplier = 3.0,
+  amountConfig = null,
 ) {
   const RAPID_TX_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
   const RAPID_TX_LIMIT = 3; // more than this many = suspicious
@@ -288,13 +334,41 @@ async function detectAbnormalPatterns(
     }
   }
 
-  // 2. Unusual amount check — uses school's configured multiplier
-  if (expectedFee && expectedFee > 0) {
+  // 2. Unusual amount check.
+  // 2a. Historical mode — flag amounts far from the school's own mean. Falls
+  //     back to the fee-multiplier check below if there isn't enough history.
+  let historicalApplied = false;
+  if (amountConfig && amountConfig.mode === "historical" && schoolId) {
+    const windowDays = amountConfig.historicalWindowDays || 90;
+    const stdMultiplier = amountConfig.historicalStdDevMultiplier || 3.0;
+    const minSamples = amountConfig.historicalMinSamples || 20;
+
+    try {
+      const stats = await computeHistoricalAmountStats(schoolId, windowDays);
+      if (stats.count >= minSamples && stats.std > 0) {
+        historicalApplied = true;
+        const zScore = Math.abs(paymentAmount - stats.mean) / stats.std;
+        if (zScore >= stdMultiplier) {
+          reasons.push(
+            `Unusual payment amount (z-score ${zScore.toFixed(2)} vs school mean ${stats.mean.toFixed(2)}, threshold ${stdMultiplier.toFixed(1)}σ over ${stats.count} payments)`,
+          );
+        }
+      }
+    } catch (err) {
+      logger.warn("Historical suspicious-amount check failed; falling back to fee multiplier", {
+        schoolId,
+        error: err.message,
+      });
+    }
+  }
+
+  // 2b. Fee-multiplier mode (default, and the historical fallback).
+  if (!historicalApplied && expectedFee && expectedFee > 0) {
     const ratio = paymentAmount / expectedFee;
     const lowerThreshold = 1 / suspiciousPaymentMultiplier;
     // For multiplier 5.0, use exclusive boundary; for others, use inclusive
     const lowerBoundExclusive = Math.abs(suspiciousPaymentMultiplier - 5.0) < 0.01;
-    
+
     if (
       ratio >= suspiciousPaymentMultiplier ||
       (lowerBoundExclusive ? ratio < lowerThreshold : ratio <= lowerThreshold)
@@ -891,6 +965,7 @@ module.exports = {
   detectMemoCollision,
   detectCrossSchoolMemoCollision,
   detectAbnormalPatterns,
+  computeHistoricalAmountStats,
   checkConfirmationStatus,
   // recordPayment was moved to transactionService.savePayment (db layer split);
   // re-exported under its original name since paymentController, retryService,

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -84,10 +84,18 @@ async function processTransaction(tx, school) {
   // Check for suspicious activity
   const collision = await detectMemoCollision(memo, senderAddress, paymentAmount, student.feeAmount, txDate, schoolId);
   const crossSchoolCollision = await detectCrossSchoolMemoCollision(memo, schoolId, txDate);
-  const abnormal = await detectAbnormalPatterns(senderAddress, paymentAmount, student.feeAmount, txDate, schoolId, school.suspiciousPaymentMultiplier);
+  const abnormal = await detectAbnormalPatterns(senderAddress, paymentAmount, student.feeAmount, txDate, schoolId, school.suspiciousPaymentMultiplier, school.suspiciousAmountConfig);
 
   const isSuspicious = collision.suspicious || crossSchoolCollision.suspicious || abnormal.suspicious;
   const suspicionReason = [collision.reason, crossSchoolCollision.reason, abnormal.reason].filter(Boolean).join('; ') || null;
+
+  if (isSuspicious) {
+    try {
+      require('../metrics').suspiciousPaymentFlagged.inc({ school_id: schoolId });
+    } catch (_) {
+      // metrics module unavailable — flagging still proceeds
+    }
+  }
 
   const confirmation = await determineConfirmationState(
     txLedger,

--- a/backend/src/utils/idempotencyKey.js
+++ b/backend/src/utils/idempotencyKey.js
@@ -52,7 +52,39 @@ function deriveIdempotencyKey(rawKey, scope = '') {
     .digest('hex');
 }
 
+/**
+ * Stable, order-independent stringification of a value so that two requests
+ * carrying the same logical payload (but with object keys in a different order)
+ * produce the same fingerprint. Arrays preserve order; object keys are sorted.
+ */
+function canonicalize(value) {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value === undefined ? null : value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).join(',')}]`;
+  }
+  const keys = Object.keys(value).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalize(value[k])}`).join(',')}}`;
+}
+
+/**
+ * Fingerprint a request body so the idempotency layer can detect when the same
+ * `Idempotency-Key` is replayed with a *different* payload (which is a client
+ * bug, not a safe retry). Returns a hex sha256 of the canonicalized body, or
+ * the empty-body fingerprint when there is no body.
+ *
+ * @param {*} body parsed request body (object, array, primitive, or undefined)
+ * @returns {string} hex sha256 fingerprint
+ */
+function fingerprintRequest(body) {
+  const canonical = body === undefined ? 'null' : canonicalize(body);
+  return crypto.createHash('sha256').update(canonical).digest('hex');
+}
+
 module.exports = {
   normalizeClientKey,
   deriveIdempotencyKey,
+  canonicalize,
+  fingerprintRequest,
 };


### PR DESCRIPTION
## Summary

Implements four reliability/observability audit issues from the 2026-06-24 codebase audit.

---

### #849 — Pending-verification dead-letter visibility & re-drive

- **Model** (`pendingVerificationModel.js`): `dead_letter` terminal status alongside `pending / processing / resolved`.
- **Retry service** (`retryService.js`): exhausted verifications (permanent error codes or `MAX_ATTEMPTS` reached) transition to `dead_letter`. New helpers: `getBacklogCounts`, `listDeadLetters`, `getPendingVerification`, `redriveDeadLetter`.
- **Admin controller** (`pendingVerificationAdminController.js`): `GET /api/admin/pending-verifications/backlog`, `GET /api/admin/pending-verifications/dead-letter`, `GET /api/admin/pending-verifications/:id`, `POST /api/admin/pending-verifications/:id/retry` with audit log on re-drive.
- **Admin routes** (`adminRoutes.js`): all four endpoints behind `requireAdminAuth`.
- **Metrics** (`metrics/index.js`): `pending_verification_backlog{status}` Prometheus gauge — live MongoDB aggregate on every scrape, alertable on growing `dead_letter` count.

Closes #849

---

### #850 — Idempotency key edge cases

- **Key util** (`utils/idempotencyKey.js`): `fingerprintRequest()` produces a stable SHA-256 of the canonicalized request body (order-independent).
- **Store** (`services/idempotencyStore.js`): `reserve()` atomically claims a key via unique-index upsert; concurrent duplicate → 409. `getFull()` returns `state / requestFingerprint / createdAt` for middleware decisions. Stale in-flight reservations (>`IDEMPOTENCY_IN_FLIGHT_TTL_MS`, default 30 s) are taken over so a crashed request never wedges a key.
- **Middleware** (`middleware/idempotency.js`): same key + different body → 422 (`IDEMPOTENCY_KEY_REUSE`); in-flight duplicate → 409; 5xx releases the reservation for retry.
- **Model** (`models/idempotencyKeyModel.js`): `state`, `requestFingerprint` fields; TTL index purges records after `IDEMPOTENCY_KEY_TTL_SECONDS` (default 24 h). New env knob: `IDEMPOTENCY_IN_FLIGHT_TTL_MS`.

Closes #850

---

### #851 — Concurrent payment batch backpressure & failure isolation

- **Processor** (`services/concurrentPaymentProcessor.js`): `processBatch()` uses a streaming worker-pool — `concurrencyLimit` workers pull the next item as they finish, so one slow payment never stalls peers. Default `batchConcurrencyLimit`: 10, overridable per call.
- Per-item failures stored as structured results (`{ success, itemSuccess, error, code }`); a thrown error never aborts remaining items.
- **Backpressure** (`_awaitHorizonCapacity`): polls `stellarRateLimitedClient.isReady()` before each dispatch; yields up to `maxBackpressureWaitMs` when Horizon is saturated.
- **Metrics**: `payment_batch_total`, `payment_batch_items_total{outcome}`, `payment_batch_duration_seconds`.

Closes #851

---

### #852 — Per-tenant fraud rules, review workflow, metric

- **School model** (`models/schoolModel.js`): `suspiciousPaymentMultiplier` (per-tenant, default 3.0) and `suspiciousAmountConfig` supporting `fee_multiplier` or `historical` (z-score against the school's own confirmed-payment distribution; falls back below `historicalMinSamples`).
- **Stellar service** (`services/stellarService.js`): `detectAbnormalPatterns()` consumes per-school multiplier and config.
- **Payment model** (`models/paymentModel.js`): `suspicionReviewStatus` (`flagged / cleared / confirmed_fraud`), `suspicionReviewedBy`, `suspicionReviewedAt`, `suspicionReviewNote`.
- **Review endpoint** (`PATCH /api/payments/:txHash/suspicion-review`): `clear` removes false-positive flag; `confirm_fraud` locks in determination. Every review written to audit log.
- **Metric**: `suspicious_payment_flagged{school_id}` counter incremented in polling pipeline.

Closes #852