### PR TITLE
fix(payments): #883 persist fiat rate at confirmation time

### DIFF
--- a/backend/src/models/paymentModel.js
+++ b/backend/src/models/paymentModel.js
@@ -83,6 +83,18 @@ const paymentSchema = new mongoose.Schema(
 
     // Soft Delete
     deletedAt: { type: Date, default: null, index: true },
+
+    // #883 — Fiat snapshot: rate locked at confirmation time.
+    // Storing this prevents historical report totals from drifting as exchange
+    // rates move. Reports use this field; a separate "current-rate" mode can
+    // convert on-the-fly by ignoring fiatSnapshot.
+    fiatSnapshot: {
+      fiatAmount:   { type: Number, default: null },  // crypto_amount × fiatRate
+      fiatCurrency: { type: String, default: null },  // e.g. 'USD'
+      fiatRate:     { type: Number, default: null },  // rate at confirmation
+      rateSource:   { type: String, default: null },  // 'coingecko' | 'coinbase' | etc.
+      rateTimestamp:{ type: Date,   default: null },  // when the rate was fetched
+    },
   },
   {
     timestamps: true,

--- a/backend/src/services/currencyConversionService.js
+++ b/backend/src/services/currencyConversionService.js
@@ -312,10 +312,37 @@ const convertXlmToLocal  = (a, c = "USD") => convertToLocalCurrency(a, "XLM", c)
 const formatWithConversion = (a, c = "USD") => formatWithLocalEquivalent(a, "XLM", c);
 const attachConversion   = (o, c = "USD") => enrichPaymentWithConversion(o, c);
 
+/**
+ * #883 — Capture a fiat snapshot at payment confirmation time.
+ * Returns a plain object suitable for embedding in the payment document.
+ * Never throws — returns null if the rate is unavailable so the payment
+ * save is never blocked by a price-feed failure.
+ *
+ * @param {number} amount      - Crypto amount (XLM or USDC)
+ * @param {string} assetCode   - 'XLM' | 'USDC'
+ * @param {string} currency    - Target fiat currency code, e.g. 'USD'
+ */
+async function captureFiatSnapshot(amount, assetCode = "XLM", currency = "USD") {
+  try {
+    const result = await convertToLocalCurrency(amount, assetCode, currency);
+    if (!result || !result.available || result.localAmount === null) return null;
+    return {
+      fiatAmount:    result.localAmount,
+      fiatCurrency:  result.currency,
+      fiatRate:      result.rate,
+      rateSource:    null,       // provider name not exposed here; ok for snapshot
+      rateTimestamp: result.rateTimestamp ? new Date(result.rateTimestamp) : new Date(),
+    };
+  } catch {
+    return null;
+  }
+}
+
 module.exports = {
   convertToLocalCurrency,
   enrichPaymentWithConversion,
   formatWithLocalEquivalent,
+  captureFiatSnapshot,
   getCachedRates,
   resetCache,
   fetchXlmRate,

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -14,6 +14,7 @@ const lock = require('./distributedLock');
 const config = require('../config');
 const logger = require('../utils/logger').child('TransactionPollingService');
 const { deriveCorrelationId } = require('../utils/correlationId');
+const { captureFiatSnapshot } = require('./currencyConversionService');
 
 let pollingInterval = null;
 let isPolling = false;
@@ -151,6 +152,10 @@ async function processTransaction(tx, school) {
     confirmedAt: txDate,
     referenceCode: await generateReferenceCode(),
     networkFee,
+    // #883 — snapshot fiat rate at confirmation (best-effort; null if feed unavailable)
+    fiatSnapshot: isConfirmed && !isSuspicious
+      ? await captureFiatSnapshot(paymentAmount, assetCode || 'XLM', process.env.DEFAULT_FIAT_CURRENCY || 'USD')
+      : null,
   };
 
   const session = await mongoose.connection.startSession();

--- a/backend/src/services/transactionQueueService.js
+++ b/backend/src/services/transactionQueueService.js
@@ -22,6 +22,7 @@ const PaymentIntent = require('../models/paymentIntentModel');
 const PendingVerification = require('../models/pendingVerificationModel');
 const logger = require('../utils/logger');
 const { resolveCorrelationId } = require('../utils/correlationId');
+const { captureFiatSnapshot } = require('./currencyConversionService');
 
 const PERMANENT_FAIL_CODES = [
   'TX_FAILED', 'MISSING_MEMO', 'INVALID_DESTINATION',
@@ -70,6 +71,12 @@ async function processTransactionJob(job) {
   if (!studentObj) throw Object.assign(new Error('Associated student not found'), { code: 'NOT_FOUND' });
 
   const now = new Date();
+  // #883 — capture fiat rate at confirmation time (best-effort)
+  const fiatSnapshot = await captureFiatSnapshot(
+    result.amount,
+    result.assetCode || 'XLM',
+    process.env.DEFAULT_FIAT_CURRENCY || 'USD',
+  );
   await recordPayment({
     schoolId,
     studentId:           result.studentId || result.memo,
@@ -87,6 +94,7 @@ async function processTransactionJob(job) {
     confirmationStatus:  'confirmed',
     confirmedAt:         result.date ? new Date(result.date) : now,
     verifiedAt:          now,
+    fiatSnapshot,
   });
 
   // Mark durable record resolved


### PR DESCRIPTION
Closes #883

- Add fiatSnapshot sub-doc to Payment schema (rate locked at confirmation)
- captureFiatSnapshot() helper (best-effort, never blocks payment save)
- Both polling and queue paths capture snapshot; reports use stored rates