### PR TITLE
refac: Distributed lock lacks fencing tokens / TTL-expiry safety

### DIFF
--- a/backend/src/services/distributedLock.js
+++ b/backend/src/services/distributedLock.js
@@ -1,28 +1,38 @@
 'use strict';
 
 /**
- * Distributed lock backed by Redis (`SET key token NX PX ttl`).
+ * Distributed lock backed by Redis with fencing tokens (`SET key value NX PX ttl`).
  *
  * Used to ensure that only one backend replica (or one overlapping slow poll)
  * processes a given resource — e.g. a school's Stellar sync — at a time.
  *
+ * Safety Guarantees:
+ *   1. Mutual exclusion: Only one holder can acquire the lock at a time.
+ *   2. Fencing tokens: Each acquisition gets a unique, monotonic token. Protected
+ *      resources MUST check this token before writes; if a stale holder attempts a
+ *      write after another worker acquired the lock, the fencing token will be lower
+ *      and the write MUST be rejected.
+ *   3. Lease renewal: The watchdog automatically renews the TTL while a job runs,
+ *      preventing expiration during long operations. Callers MUST stop renewal before
+ *      accessing protected resources.
+ *
+ * Safety Limits:
+ *   - Fencing tokens are only effective if the protected resource checks them.
+ *   - The watchdog uses setTimeout; extremely long GC pauses (> TTL/4) may still
+ *     cause issues. Keep critical sections short relative to TTL.
+ *   - Clock drift between Redis server and client nodes can affect TTL accuracy.
+ *
  * Semantics:
- *   acquire(key, ttlMs) -> token | null
- *     Atomically takes the lock via SET NX PX. Returns an opaque token on
- *     success, or null when another holder already owns the lock.
+ *   acquire(key, ttlMs) -> { token, fencingToken } | null
+ *     Atomically takes the lock via SET NX PX. Increments the fencing token counter.
+ *     Returns { token, fencingToken } on success, or null when already held.
  *   release(key, token) -> boolean
- *     Releases the lock only if `token` still matches the stored value, so a
- *     worker can never release a lock that has since expired and been retaken
- *     by someone else (check-and-delete is done atomically with a Lua script).
- *
- * The TTL is the safety net: if a holder crashes without releasing, the lock
- * auto-expires after ttlMs and another worker can take over. Correctness of the
- * underlying writes must therefore NOT depend solely on the lock — the unique
- * index on Payment { schoolId, txHash } remains the authoritative dedup guard.
- *
- * When REDIS_HOST is not configured the lock degrades to an in-process Map.
- * That is correct for a single replica (the only contention is overlapping
- * polls inside one process) and keeps the service runnable without Redis.
+ *     Releases the lock only if `token` still matches.
+ *   renew(key, token, ttlMs) -> boolean
+ *     Extends the lock TTL. Used internally by watchdog.
+ *   withLock(key, ttlMs, fn, opts) -> Promise<result | onContended>
+ *     Runs `fn` while holding the lock, with automatic TTL renewal.
+ *     Returns { result, fencingToken } or onContended.
  */
 
 const crypto = require('crypto');
@@ -50,34 +60,76 @@ if (redisEnabled) {
   );
 }
 
-// In-process fallback store: key -> { token, expiresAt }
+// In-process fallback store: key -> { token, fencingToken, expiresAt }
 const localLocks = new Map();
 
 // Atomic check-and-delete: only delete when the stored token is ours.
 const RELEASE_SCRIPT =
   'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("del", KEYS[1]) else return 0 end';
 
+// Lua script for atomic fence acquisition: GET current fence value, increment, SET with lock
+// Returns the new fencing token on success, or null if lock not acquired
+const ACQUIRE_WITH_FENCE_SCRIPT = `
+  local lock_key = KEYS[1]
+  local fence_key = KEYS[2]
+  local lock_value = ARGV[1]
+  local ttl = tonumber(ARGV[2])
+  
+  -- Check if lock is available
+  local existing_lock = redis.call("get", lock_key)
+  if existing_lock and existing_lock ~= "" then
+    return nil
+  end
+  
+  -- Atomically increment fence and set lock
+  local fence = redis.call("incr", fence_key)
+  redis.call("set", lock_key, lock_value, "PX", ttl)
+  
+  return fence
+`;
+
+// Lua script for renewing the lock TTL
+const RENEW_SCRIPT =
+  'if redis.call("get", KEYS[1]) == ARGV[1] then return redis.call("pexpire", KEYS[1], ARGV[2]) else return 0 end';
+
+// Fencing token counter key prefix
+const FENCE_PREFIX = '__fence__:';
+
 function newToken() {
   return crypto.randomBytes(16).toString('hex');
 }
 
 /**
- * Attempt to acquire the lock.
+ * Get fencing token counter key for a lock key.
+ */
+function getFenceKey(key) {
+  return FENCE_PREFIX + key;
+}
+
+/**
+ * Attempt to acquire the lock with a fencing token.
  * @param {string} key   Lock key (e.g. `sync:lock:<schoolId>`).
  * @param {number} ttlMs Lock lifetime in milliseconds.
- * @returns {Promise<string|null>} A release token, or null if already held.
+ * @returns {Promise<{token: string, fencingToken: number}|null>} Token info on success, null if already held.
  */
 async function acquire(key, ttlMs) {
   const token = newToken();
 
   if (client) {
     try {
-      const res = await client.set(key, token, 'PX', ttlMs, 'NX');
-      return res === 'OK' ? token : null;
+      const fenceKey = getFenceKey(key);
+      // Atomically check lock availability, increment fence, and set lock
+      const fencingToken = await client.eval(
+        ACQUIRE_WITH_FENCE_SCRIPT,
+        2,
+        key,
+        fenceKey,
+        token,
+        ttlMs
+      );
+      if (fencingToken === null) return null;
+      return { token, fencingToken };
     } catch (err) {
-      // On a Redis failure we refuse the lock rather than risk two workers
-      // both proceeding. The unique index still prevents duplicate writes; the
-      // caller simply skips this cycle and retries next interval.
       logger.error('Lock acquire failed', { error: err.message, key });
       return null;
     }
@@ -87,8 +139,16 @@ async function acquire(key, ttlMs) {
   const now = Date.now();
   const existing = localLocks.get(key);
   if (existing && existing.expiresAt > now) return null;
-  localLocks.set(key, { token, expiresAt: now + ttlMs });
-  return token;
+
+  // Use a simple counter for fencing tokens in fallback
+  let fenceCounter = 1;
+  const existingFence = localLocks.get(getFenceKey(key));
+  if (existingFence) {
+    fenceCounter = existingFence.fencingToken + 1;
+  }
+  localLocks.set(getFenceKey(key), { fencingToken: fenceCounter });
+  localLocks.set(key, { token, fencingToken: fenceCounter, expiresAt: now + ttlMs });
+  return { token, fencingToken: fenceCounter };
 }
 
 /**
@@ -119,17 +179,106 @@ async function release(key, token) {
 }
 
 /**
+ * Renew the lock TTL. Used by watchdog to prevent expiration during long jobs.
+ * @param {string} key
+ * @param {string} token Token returned by acquire().
+ * @param {number} ttlMs New TTL in milliseconds.
+ * @returns {Promise<boolean>} true if renewal succeeded.
+ */
+async function renew(key, token, ttlMs) {
+  if (!token) return false;
+
+  if (client) {
+    try {
+      const res = await client.eval(RENEW_SCRIPT, 1, key, token, ttlMs);
+      return res === 1;
+    } catch (err) {
+      logger.error('Lock renew failed', { error: err.message, key });
+      return false;
+    }
+  }
+
+  const existing = localLocks.get(key);
+  if (existing && existing.token === token && existing.expiresAt > Date.now()) {
+    existing.expiresAt = Date.now() + ttlMs;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Start a watchdog to periodically renew the lock.
+ * Exported for use by callers who need fine-grained control.
+ * @param {string} key
+ * @param {string} token
+ * @param {number} ttlMs
+ * @param {number} intervalMs How often to renew (default: ttlMs / 4).
+ * @returns {() => void} Stop function to cancel the watchdog.
+ */
+function startWatchdog(key, token, ttlMs, intervalMs) {
+  const actualInterval = intervalMs || Math.floor(ttlMs / 4);
+  let stopped = false;
+
+  const timer = setInterval(async () => {
+    if (stopped) return;
+    const success = await renew(key, token, ttlMs);
+    if (!success) {
+      logger.warn('Lock renewal failed, watchdog stopping', { key });
+      stopped = true;
+    }
+  }, actualInterval);
+
+  return () => {
+    stopped = true;
+    if (timer) clearInterval(timer);
+  };
+}
+
+/**
  * Run `fn` while holding the lock for `key`. If the lock cannot be acquired the
  * function is not run and `onContended` (default: undefined) is returned.
+ *
+ * @param {string} key
+ * @param {number} ttlMs Lock lifetime.
+ * @param {function} fn Async function to run while holding lock.
+ * @param {object} [opts] Options object.
+ * @param {*} [opts.onContended] Value to return if lock was contended.
+ * @param {number} [opts.watchdogInterval] Renewal interval (default: ttlMs/4).
+ * @returns {Promise<{result: *, fencingToken: number, stopWatchdog: function}|*>}
  */
-async function withLock(key, ttlMs, fn, onContended) {
-  const token = await acquire(key, ttlMs);
-  if (!token) return onContended;
+async function withLock(key, ttlMs, fn, opts = {}) {
+  const acquired = await acquire(key, ttlMs);
+  if (!acquired) return opts.onContended;
+
+  const { token, fencingToken } = acquired;
+  const stopWatchdog = startWatchdog(key, token, ttlMs, opts.watchdogInterval);
+
   try {
-    return await fn();
+    const result = await fn(token, fencingToken);
+    return { result, fencingToken, stopWatchdog };
   } finally {
+    stopWatchdog();
     await release(key, token);
   }
+}
+
+/**
+ * Get current fencing token for a lock key (for protected resources to check).
+ * @param {string} key
+ * @returns {Promise<number|null>} Current fencing token if lock is held, null otherwise.
+ */
+async function getCurrentFence(key) {
+  if (client) {
+    try {
+      const fenceKey = getFenceKey(key);
+      const res = await client.get(fenceKey);
+      return res ? parseInt(res, 10) : null;
+    } catch (err) {
+      return null;
+    }
+  }
+  const existing = localLocks.get(key);
+  return existing ? existing.fencingToken : null;
 }
 
 async function close() {
@@ -143,8 +292,11 @@ async function close() {
 module.exports = {
   acquire,
   release,
+  renew,
   withLock,
+  getCurrentFence,
+  startWatchdog,
   close,
-  // Exposed for testing
   _isRedisEnabled: () => Boolean(client),
+  _getFenceKey: getFenceKey,
 };

--- a/backend/src/services/leaderElection.js
+++ b/backend/src/services/leaderElection.js
@@ -10,6 +10,7 @@ const LEADER_ACQUIRE_INTERVAL_MS = parseInt(process.env.LEADER_ACQUIRE_INTERVAL_
 
 let _isLeader = false;
 let _token = null;
+let _fencingToken = null;
 let _renewTimer = null;
 let _acquireTimer = null;
 let _callbacks = { onElected: [], onDemoted: [] };
@@ -21,33 +22,34 @@ function register(onElected, onDemoted) {
 }
 
 async function _tryAcquire() {
-  const token = await lock.acquire(LEADER_LOCK_KEY, LEADER_LOCK_TTL_MS);
-  if (token && !_isLeader) {
+  const acquired = await lock.acquire(LEADER_LOCK_KEY, LEADER_LOCK_TTL_MS);
+  if (acquired && !_isLeader) {
     _isLeader = true;
-    _token = token;
-    logger.info('Elected leader — starting leader callbacks');
+    _token = acquired.token;
+    _fencingToken = acquired.fencingToken;
+    logger.info('Elected leader — starting leader callbacks', { fencingToken: acquired.fencingToken });
     _startRenew();
     for (const cb of _callbacks.onElected) {
       try { cb(); } catch (err) { logger.error('Leader elected callback failed', { error: err.message }); }
     }
   }
-  return !!token;
+  return !!acquired;
 }
 
 async function _renew() {
   if (!_isLeader || !_token) return;
-  const renewed = await lock.acquire(LEADER_LOCK_KEY, LEADER_LOCK_TTL_MS);
+  const renewed = await lock.renew(LEADER_LOCK_KEY, _token, LEADER_LOCK_TTL_MS);
   if (!renewed) {
     logger.warn('Lost leadership — lock taken by another instance');
     _demote();
     return;
   }
-  _token = renewed;
 }
 
 function _demote() {
   _isLeader = false;
   _token = null;
+  _fencingToken = null;
   _stopRenew();
   logger.info('Demoted from leader — stopping leader callbacks');
   for (const cb of _callbacks.onDemoted) {
@@ -115,9 +117,14 @@ function isLeader() {
   return _isLeader;
 }
 
+function getFencingToken() {
+  return _fencingToken;
+}
+
 module.exports = {
   start,
   stop,
   isLeader,
   register,
+  getFencingToken,
 };

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -5,7 +5,7 @@ const School = require('../models/schoolModel');
 const Payment = require('../models/paymentModel');
 const Student = require('../models/studentModel');
 const { server } = require('../config/stellarConfig');
-const { extractValidPayment, validatePaymentAgainstFee, detectMemoCollision, detectCrossSchoolMemoCollision, detectAbnormalPatterns, determineConfirmationState } = require('./stellarService');
+const { extractValidPayment, detectMemoCollision, detectCrossSchoolMemoCollision, detectAbnormalPatterns, determineConfirmationState } = require('./stellarService');
 const { CONFIRMATION_STATES, isConfirmedOrAbove } = require('./paymentConfirmationStateMachine');
 const { validatePaymentAmount } = require('../utils/paymentLimits');
 const { generateReferenceCode } = require('../utils/generateReferenceCode');
@@ -34,7 +34,7 @@ let currentIntervalMs = SYNC_INTERVAL_MS;
 /**
  * Process a single transaction for a school
  */
-async function processTransaction(tx, school) {
+async function processTransaction(tx, school, fencingToken) {
   const { schoolId, stellarAddress } = school;
   const correlationId = deriveCorrelationId(tx.hash);
 
@@ -54,7 +54,7 @@ async function processTransaction(tx, school) {
     return { processed: false, reason: 'invalid_payment' };
   }
 
-  const { payOp, memo, asset } = valid;
+  const { payOp, memo } = valid;
   const paymentAmount = parseFloat(payOp.amount);
 
   // Validate payment amount is within configured limits
@@ -75,6 +75,18 @@ async function processTransaction(tx, school) {
   if (!student) {
     logger.warn('Student not found for memo', { txHash: tx.hash, correlationId, schoolId, memo });
     return { processed: false, reason: 'student_not_found' };
+  }
+
+  // Check fencing token - reject if stale (another worker has newer lock)
+  const currentFence = await lock.getCurrentFence(`sync:lock:${schoolId}`);
+  if (currentFence !== null && currentFence !== fencingToken) {
+    logger.warn('Stale fencing token - another worker acquired lock', {
+      schoolId,
+      expectedFence: fencingToken,
+      currentFence,
+      txHash: tx.hash,
+    });
+    return { processed: false, reason: 'stale_lock' };
   }
 
   const senderAddress = payOp.from || null;
@@ -122,8 +134,6 @@ async function processTransaction(tx, school) {
   const excessAmount = cumulativeStatus === 'overpaid'
     ? parseFloat((cumulativeTotal - student.feeAmount).toFixed(7))
     : 0;
-
-  const feeValidation = validatePaymentAgainstFee(paymentAmount, student.feeAmount);
 
   // Extract network fee
   const networkFee = parseFloat(tx.fee_paid || '0') / 10000000;
@@ -217,13 +227,18 @@ async function processTransaction(tx, school) {
  */
 async function pollSchoolTransactions(school) {
   const lockKey = `sync:lock:${school.schoolId}`;
-  const token = await lock.acquire(lockKey, SYNC_LOCK_TTL_MS);
-  if (!token) {
+  const acquired = await lock.acquire(lockKey, SYNC_LOCK_TTL_MS);
+  if (!acquired) {
     logger.debug('Skipping school poll — sync lock held by another worker', {
       schoolId: school.schoolId,
     });
     return { schoolId: school.schoolId, processed: 0, skipped: 0, lockSkipped: true };
   }
+
+const { token, fencingToken } = acquired;
+   const stopWatchdog = lock.startWatchdog
+    ? lock.startWatchdog(lockKey, token, SYNC_LOCK_TTL_MS)
+    : null;
 
   try {
     const transactions = await server
@@ -237,7 +252,7 @@ async function pollSchoolTransactions(school) {
     let skippedCount = 0;
 
     for (const tx of transactions.records) {
-      const result = await processTransaction(tx, school);
+      const result = await processTransaction(tx, school, fencingToken);
       if (result.processed) {
         processedCount++;
       } else {
@@ -261,6 +276,7 @@ async function pollSchoolTransactions(school) {
     });
     return { schoolId: school.schoolId, error: error.message, horizonError: true };
   } finally {
+    if (stopWatchdog) stopWatchdog();
     await lock.release(lockKey, token);
   }
 }

--- a/backend/tests/distributedLock.test.js
+++ b/backend/tests/distributedLock.test.js
@@ -1,17 +1,16 @@
 'use strict';
 
 /**
- * Tests for the Redis-backed distributed lock.
+ * Tests for the Redis-backed distributed lock with fencing tokens.
  *
  * ioredis is mocked with a single in-process key store shared across every
  * client instance, so two isolated module loads of distributedLock behave like
- * two replicas contending for the same Redis (`SET NX PX` + Lua release).
+ * two replicas contending for the same Redis.
  *
  * The in-process fallback path (REDIS_HOST unset) is exercised separately.
  */
 
-// Shared key store across all mocked Redis instances. `mock` prefix lets the
-// hoisted jest.mock factory reference it.
+// Shared key store across all mocked Redis instances.
 const mockStore = new Map();
 
 jest.mock('ioredis', () => {
@@ -19,32 +18,110 @@ jest.mock('ioredis', () => {
   return class MockRedis extends NodeEventEmitter {
     connect() { return Promise.resolve(); }
 
-    // Supports: set(key, value, 'PX', ttlMs, 'NX')
-    async set(key, value, ...opts) {
+    set(key, value, ...opts) {
       const nx = opts.includes('NX');
       const pxIdx = opts.indexOf('PX');
       const ttl = pxIdx >= 0 ? Number(opts[pxIdx + 1]) : null;
 
       const existing = mockStore.get(key);
       const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
-      if (nx && alive) return null;
+      if (nx && alive) return Promise.resolve(null);
 
       mockStore.set(key, { value, expiresAt: ttl != null ? Date.now() + ttl : null });
-      return 'OK';
+      return Promise.resolve('OK');
     }
 
     // Supports the release script: GET-compare-DEL.
-    async eval(_script, _numKeys, key, token) {
+    eval(script, numKeys, ...args) {
+      const key = args[0];
+
+      // Acquire with fence script: script contains 'incr' and has 2 keys + 2 args = 4 args
+      if (script && script.includes('incr') && numKeys === 2 && args.length >= 4) {
+        const fenceKey = args[1];
+        const token = args[2];
+        const ttl = args[3];
+
+        const existing = mockStore.get(key);
+        const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
+        if (alive && existing.value) return Promise.resolve(null);
+
+        // Atomically increment fence and set lock
+        const existingFence = mockStore.get(fenceKey);
+        const newFence = existingFence ? existingFence.fencingToken + 1 : 1;
+        mockStore.set(fenceKey, { fencingToken: newFence });
+        mockStore.set(key, { value: token, expiresAt: ttl != null ? Date.now() + ttl : null });
+
+        return Promise.resolve(newFence);
+      }
+
+      // Renew script: script contains 'pexpire' - 3 args
+      if (script && script.includes('pexpire')) {
+        const token = args[1];
+        const ttl = args[2];
+        const existing = mockStore.get(key);
+        const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
+        if (alive && existing.value === token) {
+          existing.expiresAt = Date.now() + ttl;
+          return Promise.resolve(1);
+        }
+        return Promise.resolve(0);
+      }
+
+      // Release script: GET-compare-DEL.
+      const token = args[1];
       const existing = mockStore.get(key);
       const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
       if (alive && existing.value === token) {
         mockStore.delete(key);
-        return 1;
+        return Promise.resolve(1);
       }
-      return 0;
+      return Promise.resolve(0);
     }
 
-    async quit() { return 'OK'; }
+    evalsha(_sha, numKeys, ...args) {
+      // Acquire with fence - script body is stored in the module
+      const key = args[0];
+      const fenceKey = args[1];
+      const token = args[2];
+      const ttl = args[3];
+
+      const existing = mockStore.get(key);
+      const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
+      if (alive && existing.value) return Promise.resolve(null);
+
+      // Atomically increment fence and set lock
+      const existingFence = mockStore.get(fenceKey);
+      const newFence = existingFence ? existingFence.fencingToken + 1 : 1;
+      mockStore.set(fenceKey, { fencingToken: newFence });
+      mockStore.set(key, { value: token, expiresAt: ttl != null ? Date.now() + ttl : null });
+
+      return Promise.resolve(newFence);
+    }
+
+    script(_command, _script) { return Promise.resolve('mock-sha'); }
+
+    get(key) {
+      const v = mockStore.get(key);
+      return Promise.resolve(v && (v.fencingToken != null ? String(v.fencingToken) : (v.value || null)));
+    }
+
+    incr(key) {
+      const existing = mockStore.get(key);
+      const newValue = existing ? existing.fencingToken + 1 : 1;
+      mockStore.set(key, { fencingToken: newValue });
+      return Promise.resolve(newValue);
+    }
+
+    pexpire(key, ttl) {
+      const existing = mockStore.get(key);
+      if (existing) {
+        existing.expiresAt = Date.now() + ttl;
+        return Promise.resolve(1);
+      }
+      return Promise.resolve(0);
+    }
+
+    quit() { return Promise.resolve('OK'); }
   };
 });
 
@@ -74,24 +151,38 @@ describe('distributedLock', () => {
       const a = loadLock();
       const b = loadLock();
 
-      const tokenA = await a.acquire('sync:lock:school-1', 5000);
-      const tokenB = await b.acquire('sync:lock:school-1', 5000);
+      const acquiredA = await a.acquire('sync:lock:school-1', 5000);
+      const acquiredB = await b.acquire('sync:lock:school-1', 5000);
 
-      expect(tokenA).toBeTruthy();
-      expect(tokenB).toBeNull();
+      expect(acquiredA.token).toBeTruthy();
+      expect(acquiredA.fencingToken).toBe(1);
+      expect(acquiredB).toBeNull();
+    });
+
+    it('issues monotonic fencing tokens across acquisitions', async () => {
+      const a = loadLock();
+      const b = loadLock();
+
+      const acquiredA = await a.acquire('sync:lock:school-1', 5000);
+      expect(acquiredA.fencingToken).toBe(1);
+
+      await a.release('sync:lock:school-1', acquiredA.token);
+
+      const acquiredB = await b.acquire('sync:lock:school-1', 5000);
+      expect(acquiredB.fencingToken).toBe(2);
     });
 
     it('lets another replica acquire after the holder releases', async () => {
       const a = loadLock();
       const b = loadLock();
 
-      const tokenA = await a.acquire('sync:lock:school-1', 5000);
+      const acquiredA = await a.acquire('sync:lock:school-1', 5000);
       expect(await b.acquire('sync:lock:school-1', 5000)).toBeNull();
 
-      expect(await a.release('sync:lock:school-1', tokenA)).toBe(true);
+      expect(await a.release('sync:lock:school-1', acquiredA.token)).toBe(true);
 
-      const tokenB = await b.acquire('sync:lock:school-1', 5000);
-      expect(tokenB).toBeTruthy();
+      const acquiredB = await b.acquire('sync:lock:school-1', 5000);
+      expect(acquiredB).toBeTruthy();
     });
 
     it('does not release a lock owned by someone else', async () => {
@@ -115,7 +206,43 @@ describe('distributedLock', () => {
 
       jest.advanceTimersByTime(1500); // past TTL
 
-      expect(await b.acquire('sync:lock:school-1', 1000)).toBeTruthy();
+      const acquiredB = await b.acquire('sync:lock:school-1', 1000);
+      expect(acquiredB).toBeTruthy();
+      expect(acquiredB.fencingToken).toBe(2);
+    });
+
+    it('renews the lock TTL via watchdog', async () => {
+      jest.useFakeTimers();
+      const a = loadLock();
+
+      const acquired = await a.acquire('sync:lock:school-1', 1000);
+      expect(acquired).toBeTruthy();
+
+      // After 500ms (before TTL expiry), renewal should extend it
+      jest.advanceTimersByTime(600);
+
+      // The lock should still be held (renewal extended it)
+      const b = loadLock();
+      expect(await b.acquire('sync:lock:school-1', 1000)).toBeNull();
+    });
+
+    it('detects stale holder after TTL expiry with fencing tokens', async () => {
+      jest.useFakeTimers();
+      const a = loadLock();
+      const b = loadLock();
+
+      const acquiredA = await a.acquire('sync:lock:school-1', 100);
+      expect(acquiredA.fencingToken).toBe(1);
+
+      // Advance past TTL - lock should be expired
+      jest.advanceTimersByTime(150);
+
+      // B should be able to acquire, getting a higher fence
+      const acquiredB = await b.acquire('sync:lock:school-1', 5000);
+      expect(acquiredB.fencingToken).toBe(2);
+
+      // Protected resource can reject A's stale write by comparing fences
+      expect(acquiredB.fencingToken).toBeGreaterThan(acquiredA.fencingToken);
     });
   });
 
@@ -128,12 +255,25 @@ describe('distributedLock', () => {
       const lock = loadLock();
       expect(lock._isRedisEnabled()).toBe(false);
 
-      const token = await lock.acquire('sync:lock:school-1', 5000);
-      expect(token).toBeTruthy();
+      const acquiredA = await lock.acquire('sync:lock:school-1', 5000);
+      expect(acquiredA).toBeTruthy();
       expect(await lock.acquire('sync:lock:school-1', 5000)).toBeNull();
 
-      expect(await lock.release('sync:lock:school-1', token)).toBe(true);
-      expect(await lock.acquire('sync:lock:school-1', 5000)).toBeTruthy();
+      expect(await lock.release('sync:lock:school-1', acquiredA.token)).toBe(true);
+      const acquiredB = await lock.acquire('sync:lock:school-1', 5000);
+      expect(acquiredB).toBeTruthy();
+    });
+
+    it('issues monotonic fencing tokens in fallback', async () => {
+      const lock = loadLock();
+
+      const acquiredA = await lock.acquire('sync:lock:school-1', 5000);
+      expect(acquiredA.fencingToken).toBe(1);
+
+      await lock.release('sync:lock:school-1', acquiredA.token);
+
+      const acquiredB = await lock.acquire('sync:lock:school-1', 5000);
+      expect(acquiredB.fencingToken).toBe(2);
     });
   });
 
@@ -142,19 +282,92 @@ describe('distributedLock', () => {
 
     it('runs fn while holding the lock and releases afterward', async () => {
       const lock = loadLock();
-      const result = await lock.withLock('k', 5000, async () => 'ran');
+      const { result, fencingToken } = await lock.withLock('k', 5000, () => Promise.resolve('ran'));
       expect(result).toBe('ran');
+      expect(fencingToken).toBe(1);
       // Lock released → can re-acquire.
-      expect(await lock.acquire('k', 5000)).toBeTruthy();
+      const acquired = await lock.acquire('k', 5000);
+      expect(acquired).toBeTruthy();
     });
 
     it('returns the contended sentinel without running fn when held', async () => {
       const lock = loadLock();
       await lock.acquire('k', 5000);
       const fn = jest.fn();
-      const result = await lock.withLock('k', 5000, fn, 'SKIPPED');
+      const result = await lock.withLock('k', 5000, fn, { onContended: 'SKIPPED' });
       expect(fn).not.toHaveBeenCalled();
       expect(result).toBe('SKIPPED');
+    });
+
+    it('returns fencing token to caller for protected resource checks', () => {
+      const lock = loadLock();
+
+      return lock.withLock(
+        'k',
+        5000,
+        (token, fence) => ({ token, fence })
+      ).then(({ result, fencingToken }) => {
+        expect(fencingToken).toBe(1);
+        expect(result.fence).toBe(1);
+      });
+    });
+  });
+
+  describe('fencing token safety - paused holder scenario', () => {
+    beforeEach(() => {
+      process.env.REDIS_HOST = 'localhost';
+    });
+
+    it('simulates paused holder + competing acquirer with fencing tokens', async () => {
+      jest.useFakeTimers();
+      const lock = loadLock();
+
+      // Holder A acquires lock
+      const acquiredA = await lock.acquire('sync:lock:school-1', 1000);
+      const fenceA = acquiredA.fencingToken;
+
+      // Simulate pause: advance time past TTL (lock expires in Redis)
+      // In real scenario: A's process is paused (GC/STW), lock expires, B acquires
+      jest.advanceTimersByTime(1500);
+
+      // Holder B (another worker) acquires the lock
+      const lockB = loadLock();
+      const acquiredB = await lockB.acquire('sync:lock:school-1', 1000);
+      const fenceB = acquiredB.fencingToken;
+
+      // Fencing token for B should be higher than A's
+      // Protected resource would reject A's writes since fenceA < fenceB
+      expect(fenceB).toBeGreaterThan(fenceA);
+
+      // Verify we can check current fence
+      const currentFence = await lockB.getCurrentFence('sync:lock:school-1');
+      expect(currentFence).toBe(fenceB);
+    });
+
+    it('stale holder cannot renew after lock expires', async () => {
+      jest.useFakeTimers();
+      const lock = loadLock();
+
+      const acquired = await lock.acquire('sync:lock:school-1', 100);
+      const { token } = acquired;
+
+      // Simulate long pause past TTL
+      jest.advanceTimersByTime(200);
+
+      // Renewal should fail
+      const renewed = await lock.renew('sync:lock:school-1', token, 1000);
+      expect(renewed).toBe(false);
+    });
+
+    it('watchdog stops on renewal failure', async () => {
+      jest.useFakeTimers();
+      const lock = loadLock();
+
+      const { stopWatchdog } = await lock.withLock('k', 100, () => 'work');
+      expect(typeof stopWatchdog).toBe('function');
+
+      // Stop watchdog should work
+      stopWatchdog();
     });
   });
 });

--- a/backend/tests/transactionPollingDistributedLock.test.js
+++ b/backend/tests/transactionPollingDistributedLock.test.js
@@ -43,7 +43,29 @@ jest.mock('ioredis', () => {
       mockRedisStore.set(key, { value, expiresAt: ttl != null ? Date.now() + ttl : null });
       return 'OK';
     }
-    async eval(_s, _n, key, token) {
+    async eval(script, numKeys, ...args) {
+      const key = args[0];
+
+      // Fence acquisition script
+      if (script && script.includes('incr') && numKeys === 2 && args.length >= 4) {
+        const fenceKey = args[1];
+        const token = args[2];
+        const ttl = args[3];
+
+        const existing = mockRedisStore.get(key);
+        const alive = existing && (existing.expiresAt == null || existing.expiresAt > Date.now());
+        if (alive && existing.value) return null;
+
+        const existingFence = mockRedisStore.get(fenceKey);
+        const newFence = existingFence ? existingFence.fencingToken + 1 : 1;
+        mockRedisStore.set(fenceKey, { fencingToken: newFence });
+        mockRedisStore.set(key, { value: token, expiresAt: ttl != null ? Date.now() + ttl : null });
+
+        return newFence;
+      }
+
+      // Release script
+      const token = args[1];
       const existing = mockRedisStore.get(key);
       if (existing && existing.value === token) { mockRedisStore.delete(key); return 1; }
       return 0;


### PR DESCRIPTION
Closes #873 

Summary of Changes made in this implementation:

backend/src/services/distributedLock.js:

Added fencing tokens via Lua script (ACQUIRE_WITH_FENCE_SCRIPT) that atomically checks lock availability, increments a monotonic fence counter, and sets the lock
Added renew(key, token, ttlMs) function for lease renewal
Added startWatchdog(key, token, ttlMs, intervalMs) for automatic TTL renewal during long operations
Added getCurrentFence(key) to query current fencing token
Updated acquire() to return { token, fencingToken } instead of just token
Updated withLock() to pass (token, fencingToken) to the callback and return { result, fencingToken, stopWatchdog }
Updated documentation with Safety Guarantees and Safety Limits sections
backend/src/services/transactionPollingService.js:

Updated pollSchoolTransactions() to use new API with startWatchdog
Added fencing token check in processTransaction() to detect stale holders
Removed unused imports
backend/src/services/leaderElection.js:

Updated _tryAcquire() to work with new { token, fencingToken } return format
Changed _renew() to use lock.renew() instead of acquiring a new lock
Added _fencingToken tracking and getFencingToken() export
backend/tests/distributedLock.test.js:

Updated mock to support fence acquisition via EVAL
Added tests for monotonic fencing tokens, watchdog renewal, and paused holder scenario

