### PR TITLE
feat(consistency): add student balance consistency check and update logic

### DIFF
--- a/backend/src/services/consistencyService.js
+++ b/backend/src/services/consistencyService.js
@@ -2,6 +2,7 @@
 
 const { server } = require('../config/stellarConfig');
 const Payment = require('../models/paymentModel');
+const Student = require('../models/studentModel');
 const School = require('../models/schoolModel');
 
 /**
@@ -82,6 +83,9 @@ async function checkSchoolConsistency({ schoolId, stellarAddress }) {
     }
   }
 
+  const balanceMismatches = await checkStudentBalanceConsistency(schoolId);
+  mismatches.push(...balanceMismatches);
+
   return {
     schoolId,
     totalDbPayments: dbPayments.length,
@@ -99,6 +103,49 @@ async function checkSchoolConsistency({ schoolId, stellarAddress }) {
  *  - amount_mismatch  : DB amount differs from on-chain amount
  *  - student_mismatch : DB studentId doesn't match the tx memo
  */
+async function checkStudentBalanceConsistency(schoolId) {
+  const students = await Student.find({ schoolId, deletedAt: null }).lean();
+  const mismatches = [];
+
+  for (const student of students) {
+    const [agg] = await Payment.aggregate([
+      { $match: { schoolId, studentId: student.studentId, status: 'SUCCESS', deletedAt: null } },
+      { $group: { _id: null, computedTotal: { $sum: '$amount' } } },
+    ]);
+
+    const computedTotal = agg?.computedTotal ?? 0;
+    const computedRemaining = Math.max(0, student.feeAmount - computedTotal);
+
+    const totalDrift = Math.abs(computedTotal - (student.totalPaid || 0));
+    const remainingDrift = Math.abs(computedRemaining - (student.remainingBalance || 0));
+
+    if (totalDrift > 0.0000001 || remainingDrift > 0.0000001) {
+      mismatches.push({
+        type: 'student_balance_drift',
+        schoolId,
+        studentId: student.studentId,
+        storedTotal: student.totalPaid || 0,
+        computedTotal,
+        storedRemaining: student.remainingBalance || 0,
+        computedRemaining,
+        diff: computedTotal - (student.totalPaid || 0),
+        message: `Student ${student.studentId} balance drift detected and repaired`,
+      });
+
+      await Student.findOneAndUpdate(
+        { schoolId, studentId: student.studentId },
+        {
+          totalPaid: computedTotal,
+          remainingBalance: computedRemaining,
+          feePaid: computedTotal >= student.feeAmount,
+        }
+      );
+    }
+  }
+
+  return mismatches;
+}
+
 async function checkConsistency() {
   const schools = await School.find({ isActive: true }).lean();
 

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -7,6 +7,7 @@ const {
   CONFIRMATION_THRESHOLD,
   FINALIZATION_THRESHOLD,
 } = require("../config/stellarConfig");
+const mongoose = require("mongoose");
 const Payment = require("../models/paymentModel");
 const Student = require("../models/studentModel");
 const PaymentIntent = require("../models/paymentIntentModel");
@@ -686,27 +687,83 @@ async function syncPaymentsForSchool(school) {
           ? parseFloat((cumulativeTotal - student.feeAmount).toFixed(7))
           : 0;
 
+      let session;
       try {
-        await savePayment({
-          schoolId,
-          studentId,
-          txHash: tx.hash,
-          correlationId: deriveCorrelationId(tx.hash),
-          amount: paymentAmount,
-          feeAmount: feeAmountForRecord,
-          feeCategory,
-          feeValidationStatus: cumulativeStatus,
-          excessAmount,
-          status: "SUCCESS",
-          memo,
-          senderAddress,
-          isSuspicious,
-          suspicionReason,
-          ledger: txLedger,
-          ledgerSequence: txLedger,
-          confirmationStatus,
-          confirmationState: confirmation.state,
-          confirmedAt: txDate,
+        session = await mongoose.connection.startSession();
+        await session.withTransaction(async () => {
+          await savePayment({
+            schoolId,
+            studentId,
+            txHash: tx.hash,
+            correlationId: deriveCorrelationId(tx.hash),
+            amount: paymentAmount,
+            feeAmount: feeAmountForRecord,
+            feeCategory,
+            feeValidationStatus: cumulativeStatus,
+            excessAmount,
+            status: "SUCCESS",
+            memo,
+            senderAddress,
+            isSuspicious,
+            suspicionReason,
+            ledger: txLedger,
+            ledgerSequence: txLedger,
+            confirmationStatus,
+            confirmationState: confirmation.state,
+            confirmedAt: txDate,
+          }, { session });
+
+          if (isConfirmed && !isSuspicious) {
+            const updateData = {
+              totalPaid: cumulativeTotal,
+              remainingBalance: parseFloat(Math.max(0, student.feeAmount - cumulativeTotal).toFixed(7)),
+              feePaid: cumulativeTotal >= student.feeAmount,
+            };
+
+            if (feeCategory && student.fees && student.fees.length > 0) {
+              const feeIndex = student.fees.findIndex(f => f.category === feeCategory);
+              if (feeIndex !== -1) {
+                const categoryPayments = await Payment.aggregate([
+                  {
+                    $match: {
+                      schoolId,
+                      studentId,
+                      feeCategory,
+                      confirmationStatus: "confirmed",
+                      isSuspicious: false,
+                      deletedAt: null,
+                    },
+                  },
+                  { $group: { _id: null, total: { $sum: "$amount" } } },
+                ]).session(session);
+                const categoryTotalPaid = categoryPayments.length
+                  ? parseFloat(categoryPayments[0].total.toFixed(7))
+                  : 0;
+
+                student.fees[feeIndex].totalPaid = categoryTotalPaid;
+                student.fees[feeIndex].remainingBalance = Math.max(
+                  0,
+                  student.fees[feeIndex].amount - categoryTotalPaid
+                );
+                student.fees[feeIndex].paid = categoryTotalPaid >= student.fees[feeIndex].amount;
+                updateData.fees = student.fees;
+              }
+            }
+
+            await Student.findOneAndUpdate(
+              { schoolId, studentId },
+              updateData,
+              { session }
+            );
+          }
+
+          if (intent) {
+            await PaymentIntent.findByIdAndUpdate(
+              intent._id,
+              { status: "completed" },
+              { session }
+            );
+          }
         });
       } catch (saveErr) {
         if (saveErr.code === 'DUPLICATE_TX') {
@@ -720,6 +777,8 @@ async function syncPaymentsForSchool(school) {
           continue;
         }
         throw saveErr;
+      } finally {
+        if (session) await session.endSession();
       }
       newPayments++;
 
@@ -734,50 +793,6 @@ async function syncPaymentsForSchool(school) {
         confirmationState: confirmation.state,
         intentMatched: Boolean(intent),
       });
-
-      if (isConfirmed && !isSuspicious) {
-        const updateData = {
-          totalPaid: cumulativeTotal,
-          remainingBalance: parseFloat(Math.max(0, student.feeAmount - cumulativeTotal).toFixed(7)),
-          feePaid: cumulativeTotal >= student.feeAmount,
-        };
-
-        if (feeCategory && student.fees && student.fees.length > 0) {
-          const feeIndex = student.fees.findIndex(f => f.category === feeCategory);
-          if (feeIndex !== -1) {
-            const categoryPayments = await Payment.aggregate([
-              {
-                $match: {
-                  schoolId,
-                  studentId,
-                  feeCategory,
-                  confirmationStatus: "confirmed",
-                  isSuspicious: false,
-                  deletedAt: null,
-                },
-              },
-              { $group: { _id: null, total: { $sum: "$amount" } } },
-            ]);
-            const categoryTotalPaid = categoryPayments.length
-              ? parseFloat(categoryPayments[0].total.toFixed(7))
-              : 0;
-
-            student.fees[feeIndex].totalPaid = categoryTotalPaid;
-            student.fees[feeIndex].remainingBalance = Math.max(
-              0,
-              student.fees[feeIndex].amount - categoryTotalPaid
-            );
-            student.fees[feeIndex].paid = categoryTotalPaid >= student.fees[feeIndex].amount;
-            updateData.fees = student.fees;
-          }
-        }
-
-        await Student.findOneAndUpdate({ schoolId, studentId }, updateData);
-      }
-
-      if (intent) {
-        await PaymentIntent.findByIdAndUpdate(intent._id, { status: "completed" });
-      }
     }
 
     if (!done) {

--- a/backend/src/services/transactionService.js
+++ b/backend/src/services/transactionService.js
@@ -22,12 +22,14 @@ const { v4: uuidv4 } = require("uuid");
  *
  * Throws DUPLICATE_TX if the transaction was already recorded by any concurrent path.
  */
-async function savePayment(data) {
+async function savePayment(data, options = {}) {
+  const { session = null } = options;
+
   if (!data.referenceCode) {
     data = { ...data, referenceCode: await generateReferenceCode() };
   }
   try {
-    const payment = await Payment.create(data);
+    const payment = await Payment.create(data, { session });
 
     const eventId = uuidv4();
     await Outbox.create({
@@ -36,7 +38,7 @@ async function savePayment(data) {
       aggregateId: payment.txHash,
       aggregateType: "payment",
       payload: payment.toObject(),
-    });
+    }, { session });
 
     logger.debug("Payment saved with outbox event", {
       txHash: payment.txHash,


### PR DESCRIPTION
Closes #877

The updates have been completed in this implementation.
 
What changed:
transactionService.js

Added optional options.session support to savePayment
Persisted both Payment and Outbox writes under the same session when provided
stellarService.js

Wrapped syncPaymentsForSchool payment save + student balance update + payment intent completion in session.withTransaction(...)
Ensured student updates and category aggregation are executed inside the same transaction when recording a sync payment
Preserved duplicate tx handling while still marking a matched intent completed
consistencyService.js

Added student balance drift detection during consistency checks
Repairs Student.totalPaid, Student.remainingBalance, and Student.feePaid when they diverge from confirmed success payments
Verification
get_errors reports no syntax/model errors in the changed files
Notes
The fix uses MongoDB transaction sessions for the sync path where applicable
Existing payment.saved outbox/workflow remains unchanged except now it can participate in the same transaction via savePayment(..., { sess