### PR TITLE
fix(#888): bound currency cache with LRU + fiat allowlist

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -449,6 +449,17 @@ PRICE_CACHE_TTL_MS=60000
 # Rates older than this threshold are considered too stale and unavailable: false is returned
 PRICE_STALE_THRESHOLD_MS=3600000
 
+# Maximum number of distinct fiat currencies to keep in the in-process LRU cache (default: 50).
+# When the limit is reached the least-recently-used entry is evicted.
+# Only affects the per-replica fallback cache — Redis is shared across replicas.
+CURRENCY_LRU_MAX_SIZE=50
+
+# Comma-separated allowlist of supported fiat currency codes (default: ~55 major currencies).
+# Requests for currencies outside this list are rejected immediately without hitting the
+# price feed.  Set this to restrict accepted currencies in a multi-school deployment.
+# Example: ALLOWED_FIAT_CURRENCIES=USD,EUR,GBP,AUD,CAD,JPY,PGK
+# ALLOWED_FIAT_CURRENCIES=
+
 # ── Backup Configuration ─────────────────────────────────────────────────────
 # Directory to store database backups (default: ./backups)
 BACKUP_DIR=./backups

--- a/backend/src/services/currencyConversionService.js
+++ b/backend/src/services/currencyConversionService.js
@@ -8,13 +8,23 @@
  *   - Secondary provider: Coinbase Exchange (/exchange-rates) — used
  *     automatically when CoinGecko fails or returns invalid data.
  *   - Redis-backed shared cache (keyed by `currency:rates:<CURRENCY>`).
- *     Falls back to in-process Map when Redis is unavailable, so each replica
- *     does not independently hammer the price feed.
+ *     Falls back to in-process LRU Map when Redis is unavailable, so each
+ *     replica does not independently hammer the price feed.
  *   - All logging via logger.child('CurrencyConversion') — no console.warn.
  *   - Prometheus gauges: price_feed_available{provider} and
  *     price_feed_staleness_seconds{provider}.
  *   - Stale-while-revalidate: serve stale cache when both providers fail,
  *     up to PRICE_STALE_THRESHOLD_MS (default 1 hour).
+ *
+ * Fix #888:
+ *   - In-process fallback cache is now a bounded LRU (CURRENCY_LRU_MAX_SIZE,
+ *     default 50). Once full, the least-recently-used entry is evicted, so
+ *     memory growth is capped regardless of how many distinct currencies are
+ *     seen.
+ *   - Supported fiat currencies are enforced via an allowlist
+ *     (ALLOWED_FIAT_CURRENCIES env var, comma-separated). Requests for
+ *     currencies outside the allowlist are rejected immediately without
+ *     hitting the price feed or the cache.
  */
 
 const https = require("https");
@@ -28,9 +38,63 @@ const CACHE_TTL_MS             = parseInt(process.env.PRICE_CACHE_TTL_MS        
 const PRICE_STALE_THRESHOLD_MS = parseInt(process.env.PRICE_STALE_THRESHOLD_MS  || "3600000", 10);
 const COINGECKO_API_KEY        = process.env.COINGECKO_API_KEY || null;
 
+// Maximum number of distinct currencies to keep in the in-process LRU cache.
+// When the limit is reached the least-recently-used entry is evicted.
+const CURRENCY_LRU_MAX_SIZE = parseInt(process.env.CURRENCY_LRU_MAX_SIZE || "50", 10);
+
 // Redis cache TTL in seconds (slightly longer than in-memory TTL to allow
 // cross-replica stale-while-revalidate).
 const REDIS_CACHE_TTL_S = Math.ceil(PRICE_STALE_THRESHOLD_MS / 1000);
+
+// ── Currency allowlist ────────────────────────────────────────────────────────
+//
+// ALLOWED_FIAT_CURRENCIES can be set as a comma-separated env var to restrict
+// which target currencies the service will accept.  When the env var is absent
+// the service defaults to a curated set of widely-supported fiat currencies.
+//
+// Keeping an explicit allowlist serves two purposes:
+//   1. Prevents cache pollution from arbitrary/typo currency codes.
+//   2. Avoids CoinGecko/Coinbase calls that are guaranteed to fail for
+//      unsupported or non-existent currency identifiers.
+
+const _DEFAULT_ALLOWED_FIAT = new Set([
+  "USD", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "HKD", "NZD",
+  "SEK", "KRW", "SGD", "NOK", "MXN", "INR", "RUB", "ZAR", "BRL", "TRY",
+  "TWD", "DKK", "PLN", "THB", "IDR", "HUF", "CZK", "ILS", "CLP", "PHP",
+  "AED", "COP", "SAR", "MYR", "RON", "PGK", "NGN", "GHS", "KES", "UGX",
+  "TZS", "ETB", "RWF", "XOF", "XAF", "MAD", "EGP", "PKR", "BDT", "VND",
+]);
+
+/**
+ * Build the runtime allowlist from the ALLOWED_FIAT_CURRENCIES env var or
+ * fall back to _DEFAULT_ALLOWED_FIAT.  Returns a Set<string> of uppercase
+ * currency codes.
+ */
+function _buildAllowlist() {
+  const raw = process.env.ALLOWED_FIAT_CURRENCIES;
+  if (!raw || !raw.trim()) return _DEFAULT_ALLOWED_FIAT;
+  const codes = raw
+    .split(",")
+    .map((c) => c.trim().toUpperCase())
+    .filter(Boolean);
+  if (codes.length === 0) return _DEFAULT_ALLOWED_FIAT;
+  return new Set(codes);
+}
+
+// Evaluated once at module load; tests may call _resetAllowlist() to rebuild
+// after changing the env var.
+let ALLOWED_FIAT_CURRENCIES = _buildAllowlist();
+
+function _resetAllowlist() {
+  ALLOWED_FIAT_CURRENCIES = _buildAllowlist();
+}
+
+/**
+ * Returns true when `currency` (already uppercased) is in the allowlist.
+ */
+function _isCurrencyAllowed(currency) {
+  return ALLOWED_FIAT_CURRENCIES.has(currency);
+}
 
 // ── Prometheus metrics ───────────────────────────────────────────────────────
 
@@ -76,10 +140,66 @@ function _recordStaleness(provider, lastSuccessfulFetchMs) {
   }
 }
 
-// ── In-process cache (fallback when Redis unavailable) ───────────────────────
-// Structure: Map<CURRENCY, { rates, fetchedAt (ms), lastSuccessfulFetch (ms) }>
+// ── In-process LRU cache (fallback when Redis unavailable) ───────────────────
+//
+// LruMap is a minimal least-recently-used Map backed by the native Map whose
+// insertion/access order we maintain explicitly:
+//   - On get: delete then re-insert so the key moves to the "most recent" end.
+//   - On set: same re-insert pattern, then evict the oldest entry when over cap.
+//
+// This gives O(1) get/set/evict with no external dependencies.
+//
+// Structure: LruMap<CURRENCY, { rates, fetchedAt (ms), lastSuccessfulFetch (ms) }>
 
-const _localCache = new Map();
+class LruMap {
+  constructor(maxSize) {
+    this._max  = Math.max(1, maxSize);
+    this._map  = new Map();
+  }
+
+  has(key) {
+    return this._map.has(key);
+  }
+
+  get(key) {
+    if (!this._map.has(key)) return undefined;
+    // Move to most-recently-used position.
+    const value = this._map.get(key);
+    this._map.delete(key);
+    this._map.set(key, value);
+    return value;
+  }
+
+  set(key, value) {
+    if (this._map.has(key)) this._map.delete(key);
+    this._map.set(key, value);
+    // Evict the oldest (first) entry when over capacity.
+    if (this._map.size > this._max) {
+      const oldest = this._map.keys().next().value;
+      this._map.delete(oldest);
+      logger.debug("LRU local cache evicted", { evicted: oldest, size: this._map.size });
+    }
+  }
+
+  delete(key) {
+    return this._map.delete(key);
+  }
+
+  clear() {
+    this._map.clear();
+  }
+
+  get size() {
+    return this._map.size;
+  }
+
+  /** Iterate over [key, value] pairs — for getCachedRates() compatibility. */
+  [Symbol.iterator]() {
+    return this._map[Symbol.iterator]();
+  }
+}
+
+const _localCache = new LruMap(CURRENCY_LRU_MAX_SIZE);
 
 // ── In-flight deduplication ──────────────────────────────────────────────────
 const _inFlight = new Map();
@@ -200,6 +320,12 @@ async function _fetchRates(currency) {
 async function getRates(currency) {
   const key = currency.toUpperCase();
 
+  // Reject unsupported currencies immediately — don't hit the price feed or
+  // the cache for codes that will never succeed (fix #888 allowlist).
+  if (!_isCurrencyAllowed(key)) {
+    throw new Error(`Currency "${key}" is not in the supported fiat allowlist`);
+  }
+
   // Return from cache if fresh.
   const cached = await _readCache(key);
   if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
@@ -241,6 +367,13 @@ async function getRates(currency) {
 
 async function convertToLocalCurrency(amount, assetCode = "XLM", targetCurrency = "USD") {
   const currency  = targetCurrency.toUpperCase();
+
+  // Fast-path: reject unsupported currencies without touching the cache or feed.
+  if (!_isCurrencyAllowed(currency)) {
+    logger.warn("Currency not in allowlist", { currency });
+    return { localAmount: null, currency, rate: null, rateTimestamp: null, available: false, stale: false, staleAge: null, unsupportedCurrency: true };
+  }
+
   const rateEntry = await getRates(currency);
 
   if (!rateEntry) {
@@ -304,6 +437,7 @@ function getCachedRates() {
 
 function resetCache() {
   _localCache.clear();
+  _inFlight.clear();
 }
 
 // Back-compat aliases
@@ -353,4 +487,7 @@ module.exports = {
   _fetchRatesFromCoinGecko: (c) => _fetchFromCoinGecko(c),
   _getRates: getRates,
   _getCache: getCachedRates,
+  _resetAllowlist,
+  _getAllowlist: () => ALLOWED_FIAT_CURRENCIES,
+  _getLocalCacheSize: () => _localCache.size,
 };

--- a/tests/currencyConversion.test.js
+++ b/tests/currencyConversion.test.js
@@ -303,9 +303,154 @@ it('currencyConversionService suite', async () => {
     }
   });
 
+  // ── 11. Currency allowlist (fix #888) ────────────────────────────────────
+
+  await test('rejects an unsupported fiat currency (returns available:false)', async () => {
+    svc.resetCache();
+    // NOTREAL is not in the default allowlist.
+    const result = await svc.convertToLocalCurrency(10, 'XLM', 'NOTREAL');
+    assert.strictEqual(result.available, false);
+    assert.strictEqual(result.localAmount, null);
+    assert.strictEqual(result.unsupportedCurrency, true);
+  });
+
+  await test('getRates throws for unsupported currency', async () => {
+    svc.resetCache();
+    let threw = false;
+    try {
+      await svc._getRates('BOGUS');
+    } catch (err) {
+      threw = true;
+      assert.ok(err.message.includes('allowlist'), `Expected allowlist in: "${err.message}"`);
+    }
+    assert.ok(threw, 'Expected getRates to throw for unsupported currency');
+  });
+
+  await test('respects ALLOWED_FIAT_CURRENCIES env var override', async () => {
+    // Override the allowlist to only allow EUR.
+    const prev = process.env.ALLOWED_FIAT_CURRENCIES;
+    process.env.ALLOWED_FIAT_CURRENCIES = 'EUR';
+    svc._resetAllowlist();
+    try {
+      // USD should now be rejected.
+      const resultUsd = await svc.convertToLocalCurrency(10, 'XLM', 'USD');
+      assert.strictEqual(resultUsd.available, false);
+      assert.strictEqual(resultUsd.unsupportedCurrency, true);
+
+      // EUR should be allowed.
+      const restore = mockHttpsGet({ stellar: { eur: 0.22 }, 'usd-coin': { eur: 0.92 } });
+      try {
+        const resultEur = await svc.convertToLocalCurrency(10, 'XLM', 'EUR');
+        assert.strictEqual(resultEur.available, true);
+        assert.strictEqual(resultEur.currency, 'EUR');
+      } finally {
+        restore();
+      }
+    } finally {
+      // Restore env and allowlist.
+      if (prev === undefined) delete process.env.ALLOWED_FIAT_CURRENCIES;
+      else process.env.ALLOWED_FIAT_CURRENCIES = prev;
+      svc._resetAllowlist();
+      svc.resetCache();
+    }
+  });
+
+  await test('allowlist contains major fiat currencies by default', () => {
+    const allowlist = svc._getAllowlist();
+    for (const code of ['USD', 'EUR', 'GBP', 'JPY', 'AUD', 'CAD', 'CHF', 'PGK']) {
+      assert.ok(allowlist.has(code), `Expected default allowlist to include ${code}`);
+    }
+  });
+
+  // ── 12. Bounded LRU (fix #888) ────────────────────────────────────────────
+  // NOTE: These tests need a fresh module with CURRENCY_LRU_MAX_SIZE=2.
+  //       They are defined as top-level it() blocks below the main suite
+  //       to avoid Jest environment teardown issues.
+
   // ── Summary ───────────────────────────────────────────────────────────────
 
   console.log(`\n${passed} passed, ${failed} failed\n`);
   if (failed > 0) process.exit(1);
 })();
 }, 30000);
+
+// ── LRU standalone tests (top-level it() blocks) ─────────────────────────────
+// These require a fresh module load with a custom CURRENCY_LRU_MAX_SIZE so they
+// must live outside the IIFE to ensure proper Jest lifecycle ordering.
+
+it('LRU cache evicts oldest entry when maxSize is exceeded', async () => {
+  let svcSmall;
+  const origMax = process.env.CURRENCY_LRU_MAX_SIZE;
+  const origAllowed = process.env.ALLOWED_FIAT_CURRENCIES;
+  process.env.CURRENCY_LRU_MAX_SIZE = '2';
+  process.env.ALLOWED_FIAT_CURRENCIES = 'USD,EUR,AA1,AA2,AA3';
+
+  // Use jest.isolateModules to get a fresh module that reads the new env vars.
+  jest.isolateModules(() => {
+    svcSmall = require('../backend/src/services/currencyConversionService');
+  });
+
+  try {
+    // Seed three entries: AA1, AA2, AA3 (LRU max = 2).
+    for (const [code, xlm] of [['AA1', 0.1], ['AA2', 0.2], ['AA3', 0.3]]) {
+      const restore = mockHttpsGet({ stellar: { [code.toLowerCase()]: xlm }, 'usd-coin': { [code.toLowerCase()]: 1.0 } });
+      try {
+        await svcSmall.convertToLocalCurrency(1, 'XLM', code);
+      } finally {
+        restore();
+      }
+    }
+
+    // Cache should have at most 2 entries.
+    assert.ok(
+      svcSmall._getLocalCacheSize() <= 2,
+      `Expected LRU size <= 2, got ${svcSmall._getLocalCacheSize()}`
+    );
+    // Oldest entry (AA1) should have been evicted.
+    const cached = svcSmall.getCachedRates();
+    assert.ok(!cached['AA1'], 'AA1 should have been evicted as the oldest entry');
+    assert.ok(cached['AA3'], 'AA3 (most recent) should still be in cache');
+  } finally {
+    if (origMax === undefined) delete process.env.CURRENCY_LRU_MAX_SIZE;
+    else process.env.CURRENCY_LRU_MAX_SIZE = origMax;
+    if (origAllowed === undefined) delete process.env.ALLOWED_FIAT_CURRENCIES;
+    else process.env.ALLOWED_FIAT_CURRENCIES = origAllowed;
+  }
+}, 10000);
+
+it('LRU cache promotes accessed entry (LRU order)', async () => {
+  let svcLru;
+  const origMax = process.env.CURRENCY_LRU_MAX_SIZE;
+  const origAllowed = process.env.ALLOWED_FIAT_CURRENCIES;
+  process.env.CURRENCY_LRU_MAX_SIZE = '2';
+  process.env.ALLOWED_FIAT_CURRENCIES = 'B1,B2,B3';
+
+  jest.isolateModules(() => {
+    svcLru = require('../backend/src/services/currencyConversionService');
+  });
+
+  try {
+    // Seed B1, B2.
+    for (const [code, xlm] of [['B1', 0.1], ['B2', 0.2]]) {
+      const restore = mockHttpsGet({ stellar: { [code.toLowerCase()]: xlm }, 'usd-coin': { [code.toLowerCase()]: 1.0 } });
+      try { await svcLru.convertToLocalCurrency(1, 'XLM', code); } finally { restore(); }
+    }
+
+    // Access B1 to make it the most recently used (cache hit — no network call).
+    await svcLru.convertToLocalCurrency(1, 'XLM', 'B1');
+
+    // Now add B3 — should evict B2 (the LRU), not B1.
+    const restore3 = mockHttpsGet({ stellar: { b3: 0.3 }, 'usd-coin': { b3: 1.0 } });
+    try { await svcLru.convertToLocalCurrency(1, 'XLM', 'B3'); } finally { restore3(); }
+
+    const cached = svcLru.getCachedRates();
+    assert.ok(!cached['B2'], 'B2 (LRU after B1 was accessed) should have been evicted');
+    assert.ok(cached['B1'], 'B1 (recently accessed) should still be in cache');
+    assert.ok(cached['B3'], 'B3 (most recently set) should be in cache');
+  } finally {
+    if (origMax === undefined) delete process.env.CURRENCY_LRU_MAX_SIZE;
+    else process.env.CURRENCY_LRU_MAX_SIZE = origMax;
+    if (origAllowed === undefined) delete process.env.ALLOWED_FIAT_CURRENCIES;
+    else process.env.ALLOWED_FIAT_CURRENCIES = origAllowed;
+  }
+}, 10000);


### PR DESCRIPTION
Closes #888- Replace unbounded in-process Map with LruMap (native Map-based LRU, O(1) get/set/evict, no new dependencies).  Max size controlled via CURRENCY_LRU_MAX_SIZE env var (default 50).  When full, the least-recently-used entry is evicted, so per-replica memory is capped regardless of how many distinct currencies flow through.

- Add supported-fiat-currency allowlist enforced before any cache or network access.  ALLOWED_FIAT_CURRENCIES env var (comma-separated, default ~55 major fiat codes).  getRates() throws immediately for unknown codes; convertToLocalCurrency() returns { available: false, unsupportedCurrency: true } without touching CoinGecko/Coinbase.  This prevents cache pollution from typo or adversarial currency codes.

- resetCache() now also clears _inFlight deduplication map so tests start from a clean slate without leftover in-flight promises.

- Document CURRENCY_LRU_MAX_SIZE and ALLOWED_FIAT_CURRENCIES in backend/.env.example with usage examples.

Tests: 19 unit sub-tests (existing suite extended with allowlist + LRU-eviction + LRU-promotion cases), all passing.

Closes #888