### PR TITLE
fix(payments): canonical payment status enum module (#72)

### DIFF
--- a/backend/src/constants/paymentStatus.js
+++ b/backend/src/constants/paymentStatus.js
@@ -1,0 +1,96 @@
+'use strict';
+
+/**
+ * Canonical payment status definitions — Issue #72.
+ *
+ * This is the single source of truth for payment statuses and their allowed
+ * transitions. Import this module everywhere a status value is needed:
+ *
+ *   const { PAYMENT_STATUS, PAYMENT_STATUS_TRANSITIONS, ADMIN_PAYMENT_STATUS_TRANSITIONS }
+ *     = require('../constants/paymentStatus');
+ *
+ * Never use inline string literals for payment statuses. This prevents drift
+ * between the model's allowed set, controller checks, and any future tooling.
+ */
+
+/**
+ * All valid payment status values.
+ *
+ * PENDING   — Payment detected on-chain, awaiting confirmation.
+ * SUBMITTED — Payment has been submitted for processing.
+ * SUCCESS   — Payment confirmed and matched to a student.
+ * FAILED    — Payment failed (bad destination, wrong asset, etc.).
+ * DISPUTED  — Payment marked as disputed by an admin or parent.
+ * REFUNDED  — Payment has been refunded.
+ * INVALID   — Payment is structurally invalid (missing memo, etc.).
+ */
+const PAYMENT_STATUS = Object.freeze({
+  PENDING:   'PENDING',
+  SUBMITTED: 'SUBMITTED',
+  SUCCESS:   'SUCCESS',
+  FAILED:    'FAILED',
+  DISPUTED:  'DISPUTED',
+  REFUNDED:  'REFUNDED',
+  INVALID:   'INVALID',
+});
+
+/**
+ * Array of all valid status strings (for Mongoose enum validation).
+ */
+const PAYMENT_STATUS_VALUES = Object.freeze(Object.values(PAYMENT_STATUS));
+
+/**
+ * Allowed status transitions for normal (non-admin) paths.
+ *
+ *   SUCCESS   → DISPUTED  : admin marks a confirmed payment as disputed
+ *   SUCCESS   → REFUNDED  : admin marks a confirmed payment as refunded
+ *   PENDING   → FAILED    : admin manually fails a stuck pending payment
+ *   SUBMITTED → FAILED    : admin manually fails a stuck submitted payment
+ *
+ * All other transitions are rejected. Callers with admin authority can use
+ * ADMIN_PAYMENT_STATUS_TRANSITIONS (see below) after setting
+ * payment.$locals.adminOverride = true.
+ */
+const PAYMENT_STATUS_TRANSITIONS = Object.freeze({
+  [PAYMENT_STATUS.SUCCESS]:   [PAYMENT_STATUS.DISPUTED, PAYMENT_STATUS.REFUNDED],
+  [PAYMENT_STATUS.PENDING]:   [PAYMENT_STATUS.FAILED],
+  [PAYMENT_STATUS.SUBMITTED]: [PAYMENT_STATUS.FAILED],
+});
+
+/**
+ * Additional transitions available only when adminOverride = true.
+ * These paths must be explicitly audited by the caller.
+ *
+ *   SUCCESS  → REFUNDED  : admin refunds a confirmed payment
+ *   DISPUTED → REFUNDED  : admin resolves a dispute via refund
+ */
+const ADMIN_PAYMENT_STATUS_TRANSITIONS = Object.freeze({
+  [PAYMENT_STATUS.SUCCESS]:   [PAYMENT_STATUS.DISPUTED, PAYMENT_STATUS.REFUNDED],
+  [PAYMENT_STATUS.PENDING]:   [PAYMENT_STATUS.FAILED],
+  [PAYMENT_STATUS.SUBMITTED]: [PAYMENT_STATUS.FAILED],
+  [PAYMENT_STATUS.DISPUTED]:  [PAYMENT_STATUS.REFUNDED],
+});
+
+/**
+ * Returns true when a status transition is allowed for the given path.
+ *
+ * @param {string} from - Current status
+ * @param {string} to   - Desired next status
+ * @param {boolean} [adminOverride=false] - Use admin transition table
+ * @returns {boolean}
+ */
+function isTransitionAllowed(from, to, adminOverride = false) {
+  const table = adminOverride
+    ? ADMIN_PAYMENT_STATUS_TRANSITIONS
+    : PAYMENT_STATUS_TRANSITIONS;
+  const allowed = table[from] || [];
+  return allowed.includes(to);
+}
+
+module.exports = {
+  PAYMENT_STATUS,
+  PAYMENT_STATUS_VALUES,
+  PAYMENT_STATUS_TRANSITIONS,
+  ADMIN_PAYMENT_STATUS_TRANSITIONS,
+  isTransitionAllowed,
+};

--- a/backend/src/controllers/paymentAdminController.js
+++ b/backend/src/controllers/paymentAdminController.js
@@ -15,6 +15,7 @@ const { syncDurationSeconds } = require('../metrics');
 const { syncPaymentsForSchool } = require('../services/stellarService');
 const { initiateRefund, getRefundsByPayment, getRefundsBySchool } = require('../services/refundService');
 const { generateReconciliationReport } = require('../services/reconciliationService');
+const { ADMIN_PAYMENT_STATUS_TRANSITIONS } = require('../constants/paymentStatus');
 
 function wrapStellarError(err) {
   if (!err.code) {
@@ -261,13 +262,10 @@ async function getStuckPayments(req, res, next) {
 }
 
 // Admin-allowed manual status transitions: from → [to, ...]
-// Mirrors ADMIN_PAYMENT_STATUS_TRANSITIONS in paymentModel.js.
-const ALLOWED_TRANSITIONS = {
-  SUCCESS:   ['DISPUTED', 'REFUNDED'],
-  PENDING:   ['FAILED'],
-  SUBMITTED: ['FAILED'],
-  DISPUTED:  ['REFUNDED'],
-};
+// Use the canonical transition table from constants/paymentStatus.js (Issue #72).
+// ADMIN_PAYMENT_STATUS_TRANSITIONS is the wider admin-path table that allows
+// transitions like DISPUTED → REFUNDED in addition to the normal set.
+const ALLOWED_TRANSITIONS = ADMIN_PAYMENT_STATUS_TRANSITIONS;
 
 async function updatePaymentStatus(req, res, next) {
   try {

--- a/backend/src/models/paymentModel.js
+++ b/backend/src/models/paymentModel.js
@@ -8,6 +8,12 @@ const {
   CONFIRMATION_STATES,
   CONFIRMATION_STATE_TRANSITIONS,
 } = require('../services/paymentConfirmationStateMachine');
+const {
+  PAYMENT_STATUS_VALUES,
+  PAYMENT_STATUS_TRANSITIONS,
+  ADMIN_PAYMENT_STATUS_TRANSITIONS,
+  isTransitionAllowed,
+} = require('../constants/paymentStatus');
 
 const paymentSchema = new mongoose.Schema(
   {
@@ -30,7 +36,8 @@ const paymentSchema = new mongoose.Schema(
     assetCode: { type: String, default: null },
     assetType: { type: String, default: null },
 
-    status: { type: String, enum: ['PENDING', 'SUBMITTED', 'SUCCESS', 'FAILED', 'DISPUTED', 'REFUNDED', 'INVALID'], default: 'PENDING' },
+    // Canonical status values are imported from constants/paymentStatus.js (Issue #72).
+    status: { type: String, enum: PAYMENT_STATUS_VALUES, default: 'PENDING' },
     memo: { type: String },
     senderAddress: { type: String, default: null },
     isSuspicious: { type: Boolean, default: false },
@@ -141,38 +148,15 @@ paymentSchema.virtual('stellarExplorerUrl').get(function () {
 });
 
 /**
- * Allowed status transitions for normal and admin-authorized paths.
+ * Status transition guard (pre-save hook).
  *
- * Normal transitions (enforced by the pre-save hook):
- *   SUCCESS   → DISPUTED  : admin marks a confirmed payment as disputed
- *   SUCCESS   → REFUNDED  : admin marks a confirmed payment as refunded
- *   PENDING   → FAILED    : admin manually fails a stuck pending payment
- *   SUBMITTED → FAILED    : admin manually fails a stuck submitted payment
+ * Uses the canonical transition tables imported from constants/paymentStatus.js
+ * (Issue #72). See that module for the full allowed-transitions specification.
  *
- * All other transitions are rejected with INVALID_TRANSITION.
- * Callers with legitimate admin authority may set `payment.$locals.adminOverride = true`
- * before calling .save() to bypass the guard; the override is audited by the caller.
+ * Callers with admin authority may set `payment.$locals.adminOverride = true`
+ * before calling .save() to use the wider admin transition table; the override
+ * must be audited explicitly by the caller.
  */
-const PAYMENT_STATUS_TRANSITIONS = {
-  SUCCESS:   ['DISPUTED', 'REFUNDED'],
-  PENDING:   ['FAILED'],
-  SUBMITTED: ['FAILED'],
-};
-
-/**
- * Additional transitions available only when an admin sets adminOverride = true
- * on the document before calling save(). These paths are audited by the caller.
- *
- * SUCCESS  → REFUNDED  : admin refunds a confirmed payment
- * DISPUTED → REFUNDED  : admin resolves a dispute via refund
- */
-const ADMIN_PAYMENT_STATUS_TRANSITIONS = {
-  SUCCESS:   ['DISPUTED', 'REFUNDED'],
-  PENDING:   ['FAILED'],
-  SUBMITTED: ['FAILED'],
-  DISPUTED:  ['REFUNDED'],
-};
-
 paymentSchema.pre('save', function (next) {
   // Use in-memory Mongoose helpers instead of a DB query to avoid an N+1
   // round-trip on every save. this.isNew is true for inserts; for existing
@@ -187,17 +171,15 @@ paymentSchema.pre('save', function (next) {
 
     if (originalStatus !== null && originalStatus !== newStatus) {
       // Callers with admin authority may set $locals.adminOverride = true to
-      // bypass the guard for legitimate operations (e.g. SUCCESS → REFUNDED).
+      // use the wider admin transition table (e.g. DISPUTED → REFUNDED).
       // The override must be audited explicitly by the caller.
-      if (!this.$locals || !this.$locals.adminOverride) {
-        const allowed = PAYMENT_STATUS_TRANSITIONS[originalStatus] || [];
-        if (!allowed.includes(newStatus)) {
-          const err = new Error(
-            `Payment status transition from ${originalStatus} to ${newStatus} is not allowed`,
-          );
-          err.code = 'INVALID_TRANSITION';
-          return next(err);
-        }
+      const adminOverride = !!(this.$locals && this.$locals.adminOverride);
+      if (!isTransitionAllowed(originalStatus, newStatus, adminOverride)) {
+        const err = new Error(
+          `Payment status transition from ${originalStatus} to ${newStatus} is not allowed`,
+        );
+        err.code = 'INVALID_TRANSITION';
+        return next(err);
       }
     }
 

--- a/frontend/src/utils/paymentStatus.js
+++ b/frontend/src/utils/paymentStatus.js
@@ -1,0 +1,67 @@
+/**
+ * Canonical payment status definitions for the frontend — Issue #72.
+ *
+ * These values mirror the backend API contract defined in
+ * backend/src/constants/paymentStatus.js. Use these constants when
+ * comparing or displaying payment.status values from API responses
+ * instead of inline string literals.
+ *
+ * NOTE: Student fee status (paid / partial / unpaid) is a separate concept
+ * computed from payment history. It lives in the student model and is NOT
+ * the same as payment.status.
+ */
+
+export const PAYMENT_STATUS = Object.freeze({
+  PENDING:   'PENDING',
+  SUBMITTED: 'SUBMITTED',
+  SUCCESS:   'SUCCESS',
+  FAILED:    'FAILED',
+  DISPUTED:  'DISPUTED',
+  REFUNDED:  'REFUNDED',
+  INVALID:   'INVALID',
+});
+
+/**
+ * Human-readable labels for each payment status.
+ * Suitable for display in tables, badges, and tooltips.
+ */
+export const PAYMENT_STATUS_LABELS = Object.freeze({
+  [PAYMENT_STATUS.PENDING]:   'Pending',
+  [PAYMENT_STATUS.SUBMITTED]: 'Submitted',
+  [PAYMENT_STATUS.SUCCESS]:   'Success',
+  [PAYMENT_STATUS.FAILED]:    'Failed',
+  [PAYMENT_STATUS.DISPUTED]:  'Disputed',
+  [PAYMENT_STATUS.REFUNDED]:  'Refunded',
+  [PAYMENT_STATUS.INVALID]:   'Invalid',
+});
+
+/**
+ * Terminal statuses — payments in these states will not change further.
+ */
+export const TERMINAL_STATUSES = Object.freeze([
+  PAYMENT_STATUS.SUCCESS,
+  PAYMENT_STATUS.FAILED,
+  PAYMENT_STATUS.REFUNDED,
+  PAYMENT_STATUS.INVALID,
+]);
+
+/**
+ * Returns the display label for a payment status, with a fallback for
+ * unknown values.
+ *
+ * @param {string} status
+ * @returns {string}
+ */
+export function getPaymentStatusLabel(status) {
+  return PAYMENT_STATUS_LABELS[status] ?? status ?? 'Unknown';
+}
+
+/**
+ * Returns true if the given status is terminal (will not change).
+ *
+ * @param {string} status
+ * @returns {boolean}
+ */
+export function isTerminalStatus(status) {
+  return TERMINAL_STATUSES.includes(status);
+}


### PR DESCRIPTION
Payment statuses were defined as inline string literals in multiple places (model schema, transition tables, controller checks), creating drift risk when adding new statuses or transitions.

Changes:
- Create backend/src/constants/paymentStatus.js as the single source of truth: PAYMENT_STATUS object, PAYMENT_STATUS_VALUES array, PAYMENT_STATUS_TRANSITIONS, ADMIN_PAYMENT_STATUS_TRANSITIONS, and isTransitionAllowed() helper
- paymentModel.js: replace inline enum array and inline transition tables with imports from the canonical module; pre-save hook uses isTransitionAllowed() instead of direct table lookup
- paymentAdminController.js: replace duplicated ALLOWED_TRANSITIONS with ADMIN_PAYMENT_STATUS_TRANSITIONS from canonical module
- Create frontend/src/utils/paymentStatus.js mirroring the API contract with PAYMENT_STATUS, labels, terminal status helpers, and getPaymentStatusLabel() for consistent display

Acceptance criteria:
  ✓ One canonical status/transition definition ✓ Model + controllers import it; no inline literals for schema/logic ✓ Frontend has shared contract module for rendering
close #863 