### PR TITLE
fix(webhooks): full jitter backoff, configurable schedule, replay end…

### DIFF
--- a/backend/src/controllers/webhookAdminController.js
+++ b/backend/src/controllers/webhookAdminController.js
@@ -32,6 +32,7 @@ async function listDLQ(req, res, next) {
  * POST /api/admin/webhooks/dlq/:id/retry
  * Re-queues a single exhausted delivery for immediate retry.
  * Resets attempt count so it gets a full retry budget again.
+ * Only accepts deliveries in 'failed' state.
  */
 async function retryDLQEntry(req, res, next) {
   try {
@@ -49,6 +50,8 @@ async function retryDLQEntry(req, res, next) {
           attemptCount: 0,
           nextRetryAt: new Date(),
           lastError: null,
+          leasedAt: null,
+          leasedBy: null,
         },
       }
     );
@@ -60,4 +63,61 @@ async function retryDLQEntry(req, res, next) {
   }
 }
 
-module.exports = { listDLQ, retryDLQEntry };
+/**
+ * POST /api/admin/webhooks/:id/replay — Issue #73
+ *
+ * Manual replay endpoint for any webhook delivery regardless of status.
+ * Unlike /dlq/:id/retry (which only accepts 'failed' entries), this endpoint
+ * accepts deliveries in any state and immediately re-queues them for delivery.
+ *
+ * Use cases:
+ *   - Replay a 'failed' delivery after a receiver outage is resolved.
+ *   - Force immediate re-delivery of a 'pending' delivery (e.g. stuck clock).
+ *   - Re-deliver a 'succeeded' delivery when the receiver lost the event.
+ *
+ * By default, attemptCount is reset to 0 so the delivery gets a fresh
+ * retry budget. Pass ?resetAttempts=false to preserve the current count
+ * (useful when re-delivering a succeeded event without burning a retry slot).
+ */
+async function replayWebhook(req, res, next) {
+  try {
+    const entry = await WebhookRetry.findById(req.params.id);
+    if (!entry) return res.status(404).json({ error: 'Webhook delivery not found' });
+
+    const resetAttempts = req.query.resetAttempts !== 'false'; // default: true
+
+    const update = {
+      $set: {
+        status: 'pending',
+        nextRetryAt: new Date(), // immediate
+        lastError: null,
+        leasedAt: null,
+        leasedBy: null,
+      },
+    };
+
+    if (resetAttempts) {
+      update.$set.attemptCount = 0;
+    }
+
+    await WebhookRetry.updateOne({ _id: entry._id }, update);
+
+    logger.info('Webhook replay triggered by admin', {
+      deliveryId: entry.deliveryId,
+      url: entry.url,
+      previousStatus: entry.status,
+      resetAttempts,
+    });
+
+    res.json({
+      success: true,
+      deliveryId: entry.deliveryId,
+      previousStatus: entry.status,
+      resetAttempts,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+module.exports = { listDLQ, retryDLQEntry, replayWebhook };

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -3,7 +3,7 @@
 const express = require('express');
 const router = express.Router();
 const { setLogLevel } = require('../controllers/adminController');
-const { listDLQ, retryDLQEntry } = require('../controllers/webhookAdminController');
+const { listDLQ, retryDLQEntry, replayWebhook } = require('../controllers/webhookAdminController');
 const {
   getBacklog,
   listDeadLetterVerifications,
@@ -19,6 +19,8 @@ router.post('/log-level', requireAdminAuth, auditContext, setLogLevel);
 // Webhook dead-letter queue admin endpoints
 router.get('/webhooks/dlq', requireAdminAuth, listDLQ);
 router.post('/webhooks/dlq/:id/retry', requireAdminAuth, auditContext, retryDLQEntry);
+// Manual replay — accepts any delivery status (Issue #73)
+router.post('/webhooks/:id/replay', requireAdminAuth, auditContext, replayWebhook);
 
 // Stellar verification retry backlog / dead-letter admin endpoints
 router.get('/pending-verifications/backlog', requireAdminAuth, getBacklog);


### PR DESCRIPTION
…point (#73)

Fixed delay schedule [1m,5m,15m] had no jitter and only 3 attempts (~21 min total), causing synchronized retry storms and permanent failure after brief outages longer than 21 minutes.

Changes:
- getBackoffDelay(): apply full-jitter (random in [0, baseDelay]) to spread retry waves; average latency stays at ½×baseDelay but no two workers retry at the same instant
- Extended default schedule to 8 steps: 1m,5m,15m,30m,1h,2h,4h,8h (covers outages up to ~12 hours before exhaustion)
- DEFAULT_MAX_ATTEMPTS raised to 8 (configurable via WEBHOOK_MAX_ATTEMPTS)
- Configurable delay schedule via WEBHOOK_RETRY_DELAYS_MS (comma-separated ms)
- Add POST /api/admin/webhooks/:id/replay endpoint: manually re-queues any delivery regardless of status (failed/succeeded/pending); resets attempt count by default (?resetAttempts=false to preserve)
- Existing /dlq/:id/retry preserved for backward compatibility

New env vars:
  WEBHOOK_MAX_ATTEMPTS        — max retry attempts (default: 8)
  WEBHOOK_RETRY_DELAYS_MS     — comma-separated delay schedule in ms
  WEBHOOK_LEASE_TIMEOUT_MS    — stuck-lease recovery threshold

Acceptance criteria:
  ✓ Backoff includes jitter; no synchronized retry waves ✓ Receiver outages longer than 21 min survivable (up to ~12h default) ✓ Admin can replay failed deliveries via POST /api/admin/webhooks/:id/replay

closes #862 