### PR TITLE
fix(security): encrypt webhook secrets at rest, remove from retry doc…

### DIFF
--- a/backend/migrations/017_encrypt_webhook_secrets.js
+++ b/backend/migrations/017_encrypt_webhook_secrets.js
@@ -1,0 +1,142 @@
+'use strict';
+
+/**
+ * Migration 017 — Encrypt existing plaintext webhookSecret values on School documents.
+ *
+ * Issue #75: queueWebhookRetry was storing signing secrets plaintext on
+ * WebhookRetry documents. That field has been removed in this fix. Additionally,
+ * the School.webhookSecret field was also stored as plaintext in MongoDB.
+ *
+ * This migration re-encrypts every school's webhookSecret using AES-256-GCM
+ * via the WEBHOOK_SECRET_ENCRYPTION_KEY env var. It is idempotent: values
+ * already encrypted (prefixed with "enc:") are skipped.
+ *
+ * Prerequisites:
+ *   Set WEBHOOK_SECRET_ENCRYPTION_KEY to a 64-char hex string before running.
+ *   If the key is not set, the migration is a no-op (logged as skipped).
+ *
+ * Rollback:
+ *   The down() function strips the "enc:" prefix and re-decrypts all values
+ *   back to plaintext. Only run down() if you are reverting the feature entirely.
+ *
+ * Also removes the 'secret' field from any WebhookRetry documents that still
+ * have it persisted, replacing the sensitivity of that data with nothing.
+ */
+
+const crypto = require('crypto');
+
+const VERSION = '017_encrypt_webhook_secrets';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const TAG_LENGTH = 16;
+const ENC_PREFIX = 'enc:';
+
+function _getKey() {
+  const hex = process.env.WEBHOOK_SECRET_ENCRYPTION_KEY;
+  if (!hex) return null;
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+    throw new Error(
+      '[Migration 017] WEBHOOK_SECRET_ENCRYPTION_KEY must be a 64-character hex string.'
+    );
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+function _encrypt(plaintext, key) {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return `${ENC_PREFIX}${Buffer.concat([iv, encrypted, tag]).toString('base64url')}`;
+}
+
+function _decrypt(value, key) {
+  if (!value.startsWith(ENC_PREFIX)) return value;
+  const buf = Buffer.from(value.slice(ENC_PREFIX.length), 'base64url');
+  const iv = buf.subarray(0, IV_LENGTH);
+  const tag = buf.subarray(buf.length - TAG_LENGTH);
+  const ciphertext = buf.subarray(IV_LENGTH, buf.length - TAG_LENGTH);
+  const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}
+
+async function up() {
+  const mongoose = require('mongoose');
+
+  // ── 1. Encrypt School.webhookSecret values ──────────────────────────────
+  const key = _getKey();
+  if (!key) {
+    console.log('[Migration 017] WEBHOOK_SECRET_ENCRYPTION_KEY is not set. Skipping encryption.');
+    console.log('[Migration 017] Set the key and re-run to encrypt secrets at rest.');
+  } else {
+    const schools = mongoose.connection.collection('schools');
+    const cursor = schools.find({ webhookSecret: { $exists: true, $ne: null } });
+    let encrypted = 0;
+    let skipped = 0;
+
+    for await (const school of cursor) {
+      if (typeof school.webhookSecret === 'string' && school.webhookSecret.startsWith(ENC_PREFIX)) {
+        skipped++;
+        continue; // already encrypted
+      }
+      const encryptedSecret = _encrypt(school.webhookSecret, key);
+      await schools.updateOne(
+        { _id: school._id },
+        { $set: { webhookSecret: encryptedSecret } }
+      );
+      encrypted++;
+    }
+
+    console.log(
+      `[Migration 017] School secrets: ${encrypted} encrypted, ${skipped} already encrypted.`
+    );
+  }
+
+  // ── 2. Remove plaintext 'secret' field from WebhookRetry documents ────────
+  const retries = mongoose.connection.collection('webhookretries');
+  const removeResult = await retries.updateMany(
+    { secret: { $exists: true } },
+    { $unset: { secret: '' } }
+  );
+  if (removeResult.modifiedCount > 0) {
+    console.log(
+      `[Migration 017] Removed plaintext 'secret' field from ${removeResult.modifiedCount} WebhookRetry document(s).`
+    );
+  } else {
+    console.log('[Migration 017] No WebhookRetry documents had a plaintext secret field.');
+  }
+
+  console.log('[Migration 017] Migration complete.');
+}
+
+async function down() {
+  const mongoose = require('mongoose');
+  const key = _getKey();
+
+  if (!key) {
+    console.log('[Migration 017] WEBHOOK_SECRET_ENCRYPTION_KEY is not set. Cannot decrypt.');
+    return;
+  }
+
+  const schools = mongoose.connection.collection('schools');
+  const cursor = schools.find({ webhookSecret: { $exists: true, $ne: null } });
+  let decrypted = 0;
+
+  for await (const school of cursor) {
+    if (typeof school.webhookSecret !== 'string' || !school.webhookSecret.startsWith(ENC_PREFIX)) {
+      continue; // already plaintext
+    }
+    const plaintext = _decrypt(school.webhookSecret, key);
+    await schools.updateOne(
+      { _id: school._id },
+      { $set: { webhookSecret: plaintext } }
+    );
+    decrypted++;
+  }
+
+  console.log(`[Migration 017] Rolled back. Decrypted ${decrypted} school webhook secret(s).`);
+}
+
+module.exports = { version: VERSION, up, down };

--- a/backend/src/models/schoolModel.js
+++ b/backend/src/models/schoolModel.js
@@ -2,6 +2,7 @@
 
 const mongoose = require('mongoose');
 const StellarSdk = require('@stellar/stellar-sdk');
+const { encryptWebhookSecret, decryptWebhookSecret } = require('../services/webhookSecretEncryption');
 
 /**
  * School model — each school is a fully independent tenant.
@@ -190,6 +191,25 @@ schoolSchema.set('toJSON', {
     delete ret.mfaBackupCodes;
     return ret;
   },
+});
+
+// ── Webhook secret encryption — Issue #75 ────────────────────────────────────
+// Encrypt webhookSecret at rest before persisting; decrypt transparently on load.
+// Both operations are no-ops when WEBHOOK_SECRET_ENCRYPTION_KEY is not set,
+// so local development without the key continues to work.
+
+schoolSchema.pre('save', function (next) {
+  if (this.isModified('webhookSecret') && this.webhookSecret != null) {
+    this.webhookSecret = encryptWebhookSecret(this.webhookSecret);
+  }
+  next();
+});
+
+// Decrypt after loading from DB so callers always receive plaintext.
+schoolSchema.post('init', function () {
+  if (this.webhookSecret != null) {
+    this.webhookSecret = decryptWebhookSecret(this.webhookSecret);
+  }
 });
 
 module.exports = mongoose.model('School', schoolSchema);

--- a/backend/src/services/webhookSecretEncryption.js
+++ b/backend/src/services/webhookSecretEncryption.js
@@ -1,0 +1,132 @@
+'use strict';
+
+/**
+ * Webhook secret encryption utilities — Issue #75.
+ *
+ * School webhookSecret values are encrypted at rest using AES-256-GCM.
+ * The encryption key is derived from WEBHOOK_SECRET_ENCRYPTION_KEY (a
+ * 64-character hex string / 32 bytes). When the env var is absent the
+ * functions fall back to no-op mode so the application starts cleanly in
+ * development without the key set.
+ *
+ * The encrypted format (base64url) is:
+ *   <12-byte IV> + <ciphertext> + <16-byte GCM auth tag>
+ *
+ * Prefixed with "enc:" so plaintext and encrypted values are distinguishable
+ * at a glance (and for graceful migration).
+ *
+ * Key rotation: generate a new key, run migration 017 to re-encrypt, then
+ * swap the env var. Decryption falls back to the old key if the new one
+ * produces an auth-tag failure (planned — not yet implemented).
+ */
+
+const crypto = require('crypto');
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;       // bytes
+const TAG_LENGTH = 16;      // bytes
+const ENC_PREFIX = 'enc:';  // sentinel that distinguishes encrypted values
+
+function _getKey() {
+  const hex = process.env.WEBHOOK_SECRET_ENCRYPTION_KEY;
+  if (!hex) return null;
+  if (!/^[0-9a-fA-F]{64}$/.test(hex)) {
+    throw new Error(
+      '[webhookSecretEncryption] WEBHOOK_SECRET_ENCRYPTION_KEY must be a ' +
+      '64-character hex string (32 bytes). Generate one with: ' +
+      'node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"'
+    );
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+/**
+ * Returns true when webhook secret encryption is active.
+ */
+function isEncryptionEnabled() {
+  return !!process.env.WEBHOOK_SECRET_ENCRYPTION_KEY;
+}
+
+/**
+ * Encrypt a plaintext webhook secret.
+ * Returns the encrypted value prefixed with "enc:", or the original value
+ * unchanged when encryption is disabled.
+ *
+ * Idempotent: if the value is already encrypted (starts with "enc:"), it is
+ * returned unchanged.
+ *
+ * @param {string} plaintext
+ * @returns {string}
+ */
+function encryptWebhookSecret(plaintext) {
+  if (!plaintext) return plaintext;
+  if (plaintext.startsWith(ENC_PREFIX)) return plaintext; // already encrypted
+
+  const key = _getKey();
+  if (!key) return plaintext; // encryption disabled — no-op
+
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+
+  const payload = Buffer.concat([iv, encrypted, tag]).toString('base64url');
+  return `${ENC_PREFIX}${payload}`;
+}
+
+/**
+ * Decrypt an encrypted webhook secret.
+ * Returns the plaintext value, or the original value unchanged when:
+ *   - encryption is disabled
+ *   - the value does not carry the "enc:" prefix (already plaintext)
+ *   - decryption fails (auth tag mismatch / wrong key) — value returned as-is
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+function decryptWebhookSecret(value) {
+  if (!value) return value;
+  if (!value.startsWith(ENC_PREFIX)) return value; // plaintext — passthrough
+
+  const key = _getKey();
+  if (!key) return value; // encryption disabled — return as-is
+
+  let buf;
+  try {
+    buf = Buffer.from(value.slice(ENC_PREFIX.length), 'base64url');
+  } catch {
+    return value; // malformed — return as-is
+  }
+
+  if (buf.length < IV_LENGTH + 1 + TAG_LENGTH) return value; // too short
+
+  try {
+    const iv = buf.subarray(0, IV_LENGTH);
+    const tag = buf.subarray(buf.length - TAG_LENGTH);
+    const ciphertext = buf.subarray(IV_LENGTH, buf.length - TAG_LENGTH);
+
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+    decipher.setAuthTag(tag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+  } catch {
+    // Auth tag mismatch or wrong key — return as-is so the caller can handle it
+    return value;
+  }
+}
+
+/**
+ * Returns true if a value is encrypted (carries the "enc:" prefix).
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isEncrypted(value) {
+  return typeof value === 'string' && value.startsWith(ENC_PREFIX);
+}
+
+module.exports = {
+  encryptWebhookSecret,
+  decryptWebhookSecret,
+  isEncryptionEnabled,
+  isEncrypted,
+};


### PR DESCRIPTION
…s (#75)

queueWebhookRetry was persisting secret: secret || null directly on WebhookRetry documents, meaning a DB read or backup leak exposed the HMAC signing secret, allowing an attacker to forge valid webhook signatures.

Changes:
- Create backend/src/services/webhookSecretEncryption.js: AES-256-GCM encrypt/decrypt for webhookSecret values; keyed from WEBHOOK_SECRET_ENCRYPTION_KEY env var; graceful no-op when unset; idempotent (enc: prefix sentinel skips already-encrypted values)
- schoolModel.js: add pre-save hook to encrypt webhookSecret before persisting; add post-init hook to decrypt transparently on load; callers always receive plaintext, DB always stores ciphertext
- webhookService.js: remove 'secret' parameter from queueWebhookRetry; store schoolId on WebhookRetry instead; retryWebhook resolves the signing secret at send time from the School document via _resolveSecret(schoolId) — the retry queue never holds a secret
- Create migration 017_encrypt_webhook_secrets.js:
  - Encrypts all existing plaintext School.webhookSecret values
  - Removes the legacy plaintext 'secret' field from any WebhookRetry docs
  - Idempotent (skips already-encrypted values)
  - Includes down() for rollback

New env var:
  WEBHOOK_SECRET_ENCRYPTION_KEY — 64-char hex string (32 bytes)
  Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"

Acceptance criteria:
  ✓ Webhook secrets not stored plaintext on retry docs
  ✓ Secrets encrypted at rest and resolved at send time
  ✓ Migration re-encrypts existing plaintext secrets

closes #864 