### PR TITLE
fix: email provider abstraction, retry contract, queue & Redis hardening (#869–#872)

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -31,6 +31,7 @@ const receiptsRoutes = require('./routes/receiptsRoutes');
 const feeAdjustmentRoutes = require('./routes/feeAdjustmentRoutes');
 const adminRoutes = require('./routes/adminRoutes');
 const authRoutes = require('./routes/authRoutes');
+const emailRoutes = require('./routes/emailRoutes');
 const metricsRoute = require('./routes/metricsRoute');
 
 const { registerPaymentSavedSubscribers } = require('./services/paymentSavedSubscribers');
@@ -145,6 +146,7 @@ app.use('/api/receipts', receiptsRoutes);
 app.use('/api/fee-adjustments', feeAdjustmentRoutes);
 app.use('/api/admin', adminRoutes);
 app.use('/api/auth', authRoutes);
+app.use('/api/email', emailRoutes);
 app.get('/api/consistency', requireAdminAuth, runConsistencyCheck);
 app.get('/health', healthCheck);
 app.get('/health/live', healthLive);

--- a/backend/src/config/index.js
+++ b/backend/src/config/index.js
@@ -180,6 +180,12 @@ const SMTP_USER = process.env.SMTP_USER || null;
 const SMTP_PASS = process.env.SMTP_PASS || null;
 const SMTP_FROM = process.env.SMTP_FROM || "noreply@stellaredupay.com";
 
+// Pluggable email provider (Issue #80): smtp | ses | sendgrid | console.
+// When unset the email module auto-selects smtp (if SMTP_* configured) else console.
+const EMAIL_PROVIDER = process.env.EMAIL_PROVIDER || null;
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || null;
+const AWS_REGION = process.env.AWS_REGION || null;
+
 // ── Freeze to prevent accidental mutation at runtime ─────────────────────────
 const config = Object.freeze({
   PORT,
@@ -215,6 +221,9 @@ const config = Object.freeze({
   SMTP_USER,
   SMTP_PASS,
   SMTP_FROM,
+  EMAIL_PROVIDER,
+  SENDGRID_API_KEY,
+  AWS_REGION,
 });
 
 module.exports = config;

--- a/backend/src/config/redisClient.js
+++ b/backend/src/config/redisClient.js
@@ -37,14 +37,26 @@ function _updateStatus(newStatus, reason = null) {
   };
 }
 
-function getRedisConfig() {
+/**
+ * Shared reconnection policy used by every Redis consumer (queue, SSE pub/sub,
+ * distributed locks, rate limiter, refresh-token store). Centralising it here
+ * means all consumers reconnect with the same exponential backoff and treat the
+ * same error codes as transient — Issue #83: "Reconnection policy consistent".
+ *
+ * Pass overrides for connection-specific requirements. BullMQ Worker/QueueEvents
+ * connections, for example, require `maxRetriesPerRequest: null`.
+ *
+ * @param {object} [overrides] Merged over the shared defaults.
+ */
+function getRedisConnectionOptions(overrides = {}) {
   return {
-    host: process.env.REDIS_HOST,
+    host: process.env.REDIS_HOST || 'localhost',
     port: parseInt(process.env.REDIS_PORT, 10) || 6379,
     password: process.env.REDIS_PASSWORD || undefined,
     lazyConnect: true,
     enableOfflineQueue: false,
     maxRetriesPerRequest: 1,
+    connectTimeout: 10000,
     retryStrategy(times) {
       if (times >= REDIS_RECONNECT_MAX_ATTEMPTS) {
         return null;
@@ -59,8 +71,12 @@ function getRedisConfig() {
       const transientCodes = ['ECONNREFUSED', 'ENOTFOUND', 'ETIMEDOUT', 'EHOSTUNREACH'];
       return transientCodes.some((code) => err.message.includes(code));
     },
-    connectTimeout: 10000,
+    ...overrides,
   };
+}
+
+function getRedisConfig() {
+  return getRedisConnectionOptions();
 }
 
 function createRedisClient() {
@@ -160,6 +176,8 @@ function resetRedisClient() {
 module.exports = {
   createRedisClient,
   getRedisClient,
+  getRedisConfig,
+  getRedisConnectionOptions,
   getRedisStatus,
   isRedisReady,
   resetRedisClient,

--- a/backend/src/controllers/emailWebhookController.js
+++ b/backend/src/controllers/emailWebhookController.js
@@ -1,0 +1,110 @@
+'use strict';
+
+/**
+ * Email provider bounce/complaint webhooks and suppression-list admin (Issue #80).
+ *
+ *   POST /api/email/webhooks/:provider  — provider callbacks (SES/SNS, SendGrid).
+ *                                         Shared-secret protected (EMAIL_WEBHOOK_SECRET).
+ *   GET  /api/email/suppressions        — list suppressed addresses (admin).
+ *   POST /api/email/suppressions        — manually suppress an address (admin).
+ *   DELETE /api/email/suppressions/:email — clear a suppression (admin).
+ */
+
+const suppressionList = require('../services/email/suppressionList');
+const logger = require('../utils/logger').child('EmailWebhook');
+
+function checkSecret(req) {
+  const expected = process.env.EMAIL_WEBHOOK_SECRET;
+  if (!expected) return true; // not configured — accept (dev). Set it in prod.
+  const provided = req.headers['x-webhook-token'] || req.query.token;
+  return provided === expected;
+}
+
+/**
+ * Normalise provider-specific payloads into a list of
+ * { email, kind: 'bounce'|'complaint', bounceType?, detail }.
+ */
+function parseEvents(provider, body) {
+  const events = [];
+
+  if (provider === 'ses') {
+    // SES delivers via SNS; the Message field is a JSON string.
+    let msg = body;
+    if (body && typeof body.Message === 'string') {
+      try { msg = JSON.parse(body.Message); } catch { msg = body; }
+    }
+    if (msg?.notificationType === 'Bounce' && msg.bounce) {
+      const hard = msg.bounce.bounceType === 'Permanent';
+      for (const r of msg.bounce.bouncedRecipients || []) {
+        events.push({ email: r.emailAddress, kind: 'bounce', bounceType: hard ? 'hard' : 'soft', detail: r.diagnosticCode });
+      }
+    } else if (msg?.notificationType === 'Complaint' && msg.complaint) {
+      for (const r of msg.complaint.complainedRecipients || []) {
+        events.push({ email: r.emailAddress, kind: 'complaint', detail: msg.complaint.complaintFeedbackType });
+      }
+    }
+  } else if (provider === 'sendgrid') {
+    // SendGrid posts an array of event objects.
+    const arr = Array.isArray(body) ? body : [body];
+    for (const ev of arr) {
+      if (!ev || !ev.email) continue;
+      if (ev.event === 'bounce' || ev.event === 'dropped') {
+        const hard = ev.type === 'bounce' || ev.event === 'bounce';
+        events.push({ email: ev.email, kind: 'bounce', bounceType: hard ? 'hard' : 'soft', detail: ev.reason });
+      } else if (ev.event === 'spamreport') {
+        events.push({ email: ev.email, kind: 'complaint', detail: 'spamreport' });
+      }
+    }
+  }
+
+  return events;
+}
+
+async function handleWebhook(req, res) {
+  const { provider } = req.params;
+
+  if (!['ses', 'sendgrid'].includes(provider)) {
+    return res.status(400).json({ error: 'Unsupported provider', code: 'UNSUPPORTED_PROVIDER' });
+  }
+  if (!checkSecret(req)) {
+    return res.status(401).json({ error: 'Invalid webhook token', code: 'UNAUTHORIZED' });
+  }
+
+  try {
+    const events = parseEvents(provider, req.body);
+    for (const ev of events) {
+      if (ev.kind === 'bounce') {
+        await suppressionList.recordBounce(ev.email, { bounceType: ev.bounceType, source: provider, detail: ev.detail });
+      } else if (ev.kind === 'complaint') {
+        await suppressionList.recordComplaint(ev.email, { source: provider, detail: ev.detail });
+      }
+    }
+    logger.info('Processed email webhook', { provider, events: events.length });
+    return res.status(200).json({ processed: events.length });
+  } catch (err) {
+    logger.error('Failed to process email webhook', { provider, error: err.message });
+    return res.status(500).json({ error: 'Webhook processing failed', code: 'WEBHOOK_ERROR' });
+  }
+}
+
+async function listSuppressions(req, res) {
+  const { limit, skip } = req.query;
+  const result = await suppressionList.list({ limit, skip });
+  return res.status(200).json(result);
+}
+
+async function addSuppression(req, res) {
+  const { email, reason = 'manual', bounceType, detail } = req.body || {};
+  if (!email) {
+    return res.status(400).json({ error: 'email is required', code: 'VALIDATION_ERROR' });
+  }
+  const record = await suppressionList.suppress(email, { reason, bounceType, source: 'admin', detail });
+  return res.status(201).json(record);
+}
+
+async function removeSuppression(req, res) {
+  const removed = await suppressionList.remove(req.params.email);
+  return res.status(200).json({ removed });
+}
+
+module.exports = { handleWebhook, listSuppressions, addSuppression, removeSuppression, parseEvents };

--- a/backend/src/metrics/index.js
+++ b/backend/src/metrics/index.js
@@ -73,6 +73,40 @@ new client.Gauge({
   },
 });
 
+// queue_failed{queue} — number of jobs currently in the failed state per
+// BullMQ queue, plus the dead-letter backlog. Operators alert on any sustained
+// growth here: a rising failed count means retries are exhausting, and any
+// dead-letter accumulation means jobs need manual inspection (Issue #82).
+new client.Gauge({
+  name: 'queue_failed',
+  help: 'Number of failed/dead-lettered jobs per BullMQ queue',
+  labelNames: ['queue'],
+  registers: [registry],
+  async collect() {
+    try {
+      const { getQueueStats, getDLQStats } = require('../queue/transactionRetryQueue');
+      const [retryResult, dlqResult] = await Promise.allSettled([
+        getQueueStats(),
+        getDLQStats(),
+      ]);
+
+      this.reset();
+
+      if (retryResult.status === 'fulfilled' && retryResult.value?.metrics) {
+        this.set({ queue: 'transaction-retry' }, retryResult.value.metrics.failed || 0);
+      }
+
+      if (dlqResult.status === 'fulfilled' && dlqResult.value?.enabled) {
+        const m = dlqResult.value.metrics;
+        // Dead-lettered jobs land as waiting in the DLQ (no DLQ worker drains them).
+        this.set({ queue: 'transaction-dead-letter' }, (m.waiting || 0) + (m.failed || 0));
+      }
+    } catch (_) {
+      // Redis may not be configured — scrape still succeeds
+    }
+  },
+});
+
 // sse_connected_clients / sse_active_schools — current SSE fan-out registry
 // size on this replica, read live from the SSE service on each scrape.
 new client.Gauge({

--- a/backend/src/models/emailSuppressionModel.js
+++ b/backend/src/models/emailSuppressionModel.js
@@ -1,0 +1,53 @@
+'use strict';
+
+/**
+ * Email suppression list (Issue #80).
+ *
+ * Records addresses that must NOT be emailed again because of a hard bounce,
+ * spam complaint, manual block, or reminder unsubscribe. The email module
+ * consults this list before every send so dropped/abusive addresses are never
+ * retried, and it feeds the reminder opt-out flow (Issue #9).
+ *
+ * Soft bounces are recorded for visibility but do NOT suppress — only `hard`
+ * bounces, `complaint`, `manual`, and `unsubscribe` reasons block delivery.
+ */
+
+const mongoose = require('mongoose');
+
+const SUPPRESSION_REASONS = ['bounce', 'complaint', 'manual', 'unsubscribe'];
+// Reasons that actually block delivery. A soft bounce is reason 'bounce' with
+// bounceType 'soft' — recorded but not blocking.
+const BLOCKING = new Set(['complaint', 'manual', 'unsubscribe']);
+
+const emailSuppressionSchema = new mongoose.Schema(
+  {
+    email: {
+      type: String,
+      required: true,
+      unique: true, // unique implies a single-field index
+      trim: true,
+      lowercase: true,
+    },
+    reason: { type: String, enum: SUPPRESSION_REASONS, required: true },
+    // Only meaningful when reason === 'bounce': 'hard' suppresses, 'soft' does not.
+    bounceType: { type: String, enum: ['hard', 'soft', null], default: null },
+    // Provider/source that reported the event (e.g. 'ses', 'sendgrid', 'admin').
+    source: { type: String, default: null },
+    // Free-form detail for operators (provider diagnostic code, message, etc.).
+    detail: { type: String, default: null },
+    suppressedAt: { type: Date, default: Date.now },
+  },
+  { timestamps: true }
+);
+
+/**
+ * Whether a stored suppression record blocks delivery.
+ */
+emailSuppressionSchema.methods.isBlocking = function isBlocking() {
+  if (BLOCKING.has(this.reason)) return true;
+  return this.reason === 'bounce' && this.bounceType === 'hard';
+};
+
+emailSuppressionSchema.statics.SUPPRESSION_REASONS = SUPPRESSION_REASONS;
+
+module.exports = mongoose.model('EmailSuppression', emailSuppressionSchema);

--- a/backend/src/queue/transactionRetryQueue.js
+++ b/backend/src/queue/transactionRetryQueue.js
@@ -35,7 +35,19 @@ const config = {
   },
   worker: {
     concurrency: parseInt(process.env.QUEUE_CONCURRENCY, 10) || 5,
+    // How long a job's lock is held before it is considered stalled. Must exceed
+    // the worst-case processing time (Stellar verification) or healthy jobs get
+    // re-queued mid-flight. Defaults to 2× the Stellar timeout plus headroom.
+    lockDuration: parseInt(process.env.QUEUE_LOCK_DURATION_MS, 10) || 30000,
+    // How often the worker scans for stalled jobs (crashed/locked-up workers).
+    stalledInterval: parseInt(process.env.QUEUE_STALLED_INTERVAL_MS, 10) || 30000,
+    // How many times a stalled job is recovered before it is failed for good
+    // (and routed to the dead-letter queue). Prevents an infinite stall loop.
+    maxStalledCount: parseInt(process.env.QUEUE_MAX_STALLED_COUNT, 10) || 2,
   },
+  // Jitter applied to the exponential backoff so a thundering herd of jobs that
+  // failed together (e.g. a Horizon outage) don't all retry at the same instant.
+  jitterRatio: parseFloat(process.env.RETRY_JITTER_RATIO) || 0.2,
   stellar: {
     timeout: parseInt(process.env.STELLAR_NETWORK_TIMEOUT_MS, 10) || 10000,
   },
@@ -162,16 +174,21 @@ function createQueueEvents() {
 }
 
 /**
- * Calculate exponential backoff delay
+ * Calculate exponential backoff delay with optional jitter.
  * @param {number} attempt - Current attempt number (1-indexed)
+ * @param {boolean} [withJitter=true] - Apply +/- jitterRatio randomisation
  * @returns {number} - Delay in milliseconds
  */
-function calculateBackoffDelay(attempt) {
-  const delay = Math.min(
+function calculateBackoffDelay(attempt, withJitter = true) {
+  const base = Math.min(
     config.retry.initialDelay * Math.pow(config.retry.backoffMultiplier, attempt - 1),
     config.retry.maxDelay
   );
-  return delay;
+  if (!withJitter || config.jitterRatio <= 0) return Math.round(base);
+  // Full +/- jitter: spread retries across [base*(1-r), base*(1+r)].
+  const spread = base * config.jitterRatio;
+  const jittered = base - spread + Math.random() * (2 * spread);
+  return Math.max(0, Math.round(Math.min(jittered, config.retry.maxDelay)));
 }
 
 /**
@@ -312,8 +329,7 @@ async function processTransactionRetryJob(job) {
     };
     
   } catch (error) {
-    const isPermanentError = ['TX_FAILED', 'MISSING_MEMO', 'INVALID_DESTINATION', 
-                              'UNSUPPORTED_ASSET', 'DUPLICATE_TX'].includes(error.code);
+    const isPermanentError = require('../services/retryContract').isPermanent(error);
     const hasReachedMaxAttempts = job.attemptsMade >= config.retry.maxAttempts - 1;
     
     if (isPermanentError || hasReachedMaxAttempts) {
@@ -368,6 +384,15 @@ function createRetryWorker() {
       {
         connection: initializeRedisConnection(),
         concurrency: config.worker.concurrency,
+        // Stalled-job recovery: jobs whose worker died mid-flight are reclaimed.
+        lockDuration: config.worker.lockDuration,
+        stalledInterval: config.worker.stalledInterval,
+        maxStalledCount: config.worker.maxStalledCount,
+        settings: {
+          // Jobs are added with backoff.type 'custom'; BullMQ resolves the delay
+          // through this strategy, giving us exponential backoff WITH jitter.
+          backoffStrategy: (attemptsMade) => calculateBackoffDelay(attemptsMade + 1),
+        },
       }
     );
     

--- a/backend/src/routes/emailRoutes.js
+++ b/backend/src/routes/emailRoutes.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const { requireAdminAuth } = require('../middleware/auth');
+const {
+  handleWebhook,
+  listSuppressions,
+  addSuppression,
+  removeSuppression,
+} = require('../controllers/emailWebhookController');
+
+// Public provider webhooks (bounce/complaint). Protected by EMAIL_WEBHOOK_SECRET
+// (shared-secret check inside the controller), not by admin auth.
+router.post('/webhooks/:provider', handleWebhook);
+
+// Suppression-list administration (admin only).
+router.use('/suppressions', requireAdminAuth);
+router.get('/suppressions', listSuppressions);
+router.post('/suppressions', addSuppression);
+router.delete('/suppressions/:email', removeSuppression);
+
+module.exports = router;

--- a/backend/src/services/bullMQRetryService.js
+++ b/backend/src/services/bullMQRetryService.js
@@ -18,65 +18,26 @@ const {
 
 const PendingVerification = require('../models/pendingVerificationModel');
 
+// Shared retry contract (Issue #81) — both backends classify failures identically.
+const retryContract = require('./retryContract');
+
 // Singleton queue instance
 let queueInstance = null;
 
 /**
- * Error classification for retry decisions
+ * Error classification for retry decisions. Kept as an exported shape for
+ * backwards compatibility; the canonical lists live in retryContract.
  */
 const ERROR_CLASSIFICATION = {
-  TRANSIENT: [
-    'STELLAR_NETWORK_ERROR',
-    'ECONNREFUSED',
-    'ETIMEDOUT',
-    'ENOTFOUND',
-    'NETWORK_ERROR',
-    'SOCKET_TIMEOUT',
-    'REQUEST_TIMEOUT',
-    'HORIZON_UNAVAILABLE',
-  ],
-  PERMANENT: [
-    'TX_FAILED',
-    'MISSING_MEMO',
-    'INVALID_DESTINATION',
-    'UNSUPPORTED_ASSET',
-    'DUPLICATE_TX',
-    'INVALID_TRANSACTION_HASH',
-    'TRANSACTION_NOT_FOUND',
-  ],
+  TRANSIENT: retryContract.TRANSIENT_ERROR_CODES,
+  PERMANENT: retryContract.PERMANENT_ERROR_CODES,
 };
 
 /**
- * Classify error type for retry decision
+ * Classify error type for retry decision (delegates to the shared contract).
  */
 function classifyError(error) {
-  const errorCode = error.code || '';
-  const errorMessage = error.message || '';
-  
-  if (ERROR_CLASSIFICATION.PERMANENT.includes(errorCode)) {
-    return 'permanent';
-  }
-  
-  if (ERROR_CLASSIFICATION.TRANSIENT.includes(errorCode)) {
-    return 'transient';
-  }
-  
-  // Check error message for transient indicators
-  const transientPatterns = [
-    /network/i,
-    /timeout/i,
-    /connection/i,
-    /unavailable/i,
-    /temporary/i,
-  ];
-  
-  for (const pattern of transientPatterns) {
-    if (pattern.test(errorMessage)) {
-      return 'transient';
-    }
-  }
-  
-  return 'unknown';
+  return retryContract.classifyError(error);
 }
 
 /**

--- a/backend/src/services/distributedLock.js
+++ b/backend/src/services/distributedLock.js
@@ -27,17 +27,15 @@
 
 const crypto = require('crypto');
 const logger = require('../utils/logger').child('DistributedLock');
+const { getRedisConnectionOptions } = require('../config/redisClient');
 
 const redisEnabled = Boolean(process.env.REDIS_HOST);
 
-const redisConfig = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: parseInt(process.env.REDIS_PORT, 10) || 6379,
-  password: process.env.REDIS_PASSWORD || undefined,
-  lazyConnect: true,
-  maxRetriesPerRequest: null,
-  enableOfflineQueue: false,
-};
+// Share the central reconnection policy (Issue #83) so the lock client backs off
+// and treats transient errors identically to every other Redis consumer.
+// maxRetriesPerRequest: null lets a command wait through a reconnect rather than
+// erroring immediately, so a brief blip doesn't spuriously deny every lock.
+const redisConfig = getRedisConnectionOptions({ maxRetriesPerRequest: null });
 
 let client = null;
 

--- a/backend/src/services/email/emailProvider.js
+++ b/backend/src/services/email/emailProvider.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Email provider factory (Issue #80).
+ *
+ * Selects a pluggable provider implementing the interface:
+ *   { name, send(message) -> { messageId }, verify() -> { ok, error? } }
+ *
+ * Selection order:
+ *   1. EMAIL_PROVIDER env (smtp | ses | sendgrid | console)
+ *   2. fall back to 'smtp' when SMTP_HOST/USER/PASS are configured
+ *   3. otherwise 'console' (logs instead of sending — safe default for dev)
+ */
+
+const config = require('../../config');
+const logger = require('../../utils/logger').child('EmailProvider');
+
+const PROVIDERS = {
+  console: require('./providers/consoleProvider'),
+  smtp: require('./providers/smtpProvider'),
+  ses: require('./providers/sesProvider'),
+  sendgrid: require('./providers/sendgridProvider'),
+};
+
+let _selected = null;
+
+function resolveProviderName() {
+  const explicit = (process.env.EMAIL_PROVIDER || config.EMAIL_PROVIDER || '').toLowerCase();
+  if (explicit) {
+    if (!PROVIDERS[explicit]) {
+      logger.warn(`Unknown EMAIL_PROVIDER "${explicit}" — falling back to console`);
+      return 'console';
+    }
+    return explicit;
+  }
+  if (config.SMTP_HOST && config.SMTP_USER && config.SMTP_PASS) return 'smtp';
+  return 'console';
+}
+
+function getProvider() {
+  if (_selected) return _selected;
+  const name = resolveProviderName();
+  _selected = PROVIDERS[name];
+  logger.info(`Email provider selected: ${name}`);
+  return _selected;
+}
+
+/** Reset cached selection (tests / config reloads). */
+function _reset() {
+  _selected = null;
+  for (const p of Object.values(PROVIDERS)) {
+    if (typeof p._reset === 'function') p._reset();
+  }
+}
+
+module.exports = { getProvider, resolveProviderName, _reset, PROVIDERS };

--- a/backend/src/services/email/index.js
+++ b/backend/src/services/email/index.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * Unified email send path (Issue #80).
+ *
+ * All transactional email (receipts, reminders) flows through sendEmail(), which:
+ *   1. Honours the suppression list — never sends to a bounced/complained/
+ *      unsubscribed address.
+ *   2. Sends through the configured pluggable provider (smtp | ses | sendgrid |
+ *      console) — see emailProvider.js.
+ *   3. Retries transient failures with exponential backoff + jitter so an email
+ *      that fails for a blip is not silently lost.
+ *
+ * Bounce/complaint handling is asynchronous (provider webhooks → suppressionList),
+ * see controllers/emailWebhookController.js.
+ */
+
+const config = require('../../config');
+const logger = require('../../utils/logger').child('EmailService');
+const { getProvider } = require('./emailProvider');
+const suppressionList = require('./suppressionList');
+
+const MAX_RETRIES = parseInt(process.env.EMAIL_MAX_RETRIES, 10) || 3;
+const RETRY_BASE_MS = parseInt(process.env.EMAIL_RETRY_BASE_MS, 10) || 500;
+const RETRY_MAX_MS = parseInt(process.env.EMAIL_RETRY_MAX_MS, 10) || 30000;
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function backoff(attempt) {
+  const base = Math.min(RETRY_BASE_MS * Math.pow(2, attempt - 1), RETRY_MAX_MS);
+  // +/- 20% jitter to avoid synchronised retries when many sends fail at once.
+  return Math.round(base * (0.8 + Math.random() * 0.4));
+}
+
+/**
+ * Send a transactional email with suppression checks and retry.
+ *
+ * @param {object} message
+ * @param {string} message.to
+ * @param {string} message.subject
+ * @param {string} [message.text]
+ * @param {string} [message.html]
+ * @param {string} [message.from]
+ * @param {string} [message.category]   - logical type, e.g. 'receipt'|'reminder'
+ * @returns {Promise<{sent:boolean, skipped?:boolean, suppressed?:boolean,
+ *   messageId?:string, attempts?:number, provider?:string, error?:string}>}
+ */
+async function sendEmail(message) {
+  const { to, subject, category } = message;
+
+  if (!to) {
+    logger.info('Email skipped — no recipient', { category, subject });
+    return { sent: false, skipped: true, reason: 'no_recipient' };
+  }
+
+  // 1. Suppression check — never email a bounced/complained/unsubscribed address.
+  if (await suppressionList.isSuppressed(to)) {
+    logger.info('Email skipped — recipient suppressed', { to, category });
+    return { sent: false, skipped: true, suppressed: true };
+  }
+
+  const provider = getProvider();
+
+  // 2. Send with retry on transient failure.
+  let lastError = null;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const { messageId } = await provider.send(message);
+      logger.info('Email sent', { to, category, provider: provider.name, messageId, attempts: attempt });
+      return { sent: true, messageId, attempts: attempt, provider: provider.name };
+    } catch (err) {
+      lastError = err;
+      const willRetry = attempt < MAX_RETRIES;
+      logger.warn('Email send attempt failed', {
+        to,
+        category,
+        provider: provider.name,
+        attempt,
+        willRetry,
+        error: err.message,
+      });
+      if (willRetry) await sleep(backoff(attempt));
+    }
+  }
+
+  logger.error('Email send failed after retries', {
+    to,
+    category,
+    provider: provider.name,
+    attempts: MAX_RETRIES,
+    error: lastError?.message,
+  });
+  return { sent: false, attempts: MAX_RETRIES, provider: provider.name, error: lastError?.message };
+}
+
+/**
+ * Verify the active provider is reachable/configured (used by /health and the
+ * reminder startup check).
+ */
+async function verify() {
+  const provider = getProvider();
+  if (typeof provider.verify !== 'function') return { ok: true };
+  return provider.verify();
+}
+
+module.exports = {
+  sendEmail,
+  verify,
+  suppressionList,
+  MAX_RETRIES,
+};

--- a/backend/src/services/email/providers/consoleProvider.js
+++ b/backend/src/services/email/providers/consoleProvider.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Console/no-op email provider.
+ *
+ * Default provider for development and any environment without email
+ * infrastructure: it logs the message that *would* be sent instead of dropping
+ * it silently, so reminder/receipt emails remain visible in logs.
+ */
+
+const logger = require('../../../utils/logger').child('EmailProvider:console');
+
+module.exports = {
+  name: 'console',
+
+  async send(message) {
+    logger.info('Email (console provider — not actually sent)', {
+      to: message.to,
+      subject: message.subject,
+      category: message.category,
+    });
+    return { messageId: `console-${process.pid}-${message.to}-${message.subject}` };
+  },
+
+  async verify() {
+    return { ok: true };
+  },
+};

--- a/backend/src/services/email/providers/sendgridProvider.js
+++ b/backend/src/services/email/providers/sendgridProvider.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * SendGrid email provider.
+ *
+ * The SendGrid SDK is an optional peer dependency, required lazily so it is only
+ * needed when EMAIL_PROVIDER=sendgrid. Bounces/complaints are delivered via
+ * SendGrid Event Webhooks and handled by the email webhook controller.
+ */
+
+const config = require('../../../config');
+
+let _mail = null;
+
+function getMail() {
+  if (_mail) return _mail;
+  let sgMail;
+  try {
+    sgMail = require('@sendgrid/mail');
+  } catch (_) {
+    throw new Error(
+      'EMAIL_PROVIDER=sendgrid requires the "@sendgrid/mail" package to be installed'
+    );
+  }
+  const apiKey = config.SENDGRID_API_KEY || process.env.SENDGRID_API_KEY;
+  if (!apiKey) {
+    throw new Error('EMAIL_PROVIDER=sendgrid requires SENDGRID_API_KEY to be configured');
+  }
+  sgMail.setApiKey(apiKey);
+  _mail = sgMail;
+  return _mail;
+}
+
+module.exports = {
+  name: 'sendgrid',
+
+  async send(message) {
+    const mail = getMail();
+    const [res] = await mail.send({
+      to: message.to,
+      from: message.from || config.SMTP_FROM,
+      subject: message.subject,
+      text: message.text,
+      html: message.html,
+    });
+    return { messageId: res?.headers?.['x-message-id'] || res?.headers?.['x-message-id'.toUpperCase()] };
+  },
+
+  async verify() {
+    try {
+      getMail();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err.message };
+    }
+  },
+
+  _reset() {
+    _mail = null;
+  },
+};

--- a/backend/src/services/email/providers/sesProvider.js
+++ b/backend/src/services/email/providers/sesProvider.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * AWS SES email provider.
+ *
+ * The AWS SDK is an optional peer dependency — it is required lazily so the
+ * application runs without it unless EMAIL_PROVIDER=ses is actually selected.
+ * Bounces and complaints are delivered asynchronously by SES via SNS and handled
+ * by the email webhook controller, which feeds the suppression list.
+ */
+
+const config = require('../../../config');
+
+let _client = null;
+let _SendEmailCommand = null;
+
+function getClient() {
+  if (_client) return _client;
+  let SESClient;
+  try {
+    ({ SESClient, SendEmailCommand: _SendEmailCommand } = require('@aws-sdk/client-ses'));
+  } catch (_) {
+    throw new Error(
+      'EMAIL_PROVIDER=ses requires the "@aws-sdk/client-ses" package to be installed'
+    );
+  }
+  _client = new SESClient({ region: config.AWS_REGION || process.env.AWS_REGION });
+  return _client;
+}
+
+module.exports = {
+  name: 'ses',
+
+  async send(message) {
+    const client = getClient();
+    const command = new _SendEmailCommand({
+      Source: message.from || config.SMTP_FROM,
+      Destination: { ToAddresses: [message.to] },
+      Message: {
+        Subject: { Data: message.subject, Charset: 'UTF-8' },
+        Body: {
+          Text: { Data: message.text || '', Charset: 'UTF-8' },
+          ...(message.html && { Html: { Data: message.html, Charset: 'UTF-8' } }),
+        },
+      },
+    });
+    const res = await client.send(command);
+    return { messageId: res.MessageId };
+  },
+
+  async verify() {
+    try {
+      getClient();
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err.message };
+    }
+  },
+
+  _reset() {
+    _client = null;
+    _SendEmailCommand = null;
+  },
+};

--- a/backend/src/services/email/providers/smtpProvider.js
+++ b/backend/src/services/email/providers/smtpProvider.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * SMTP email provider (nodemailer). Used when EMAIL_PROVIDER=smtp and SMTP_*
+ * settings are configured.
+ */
+
+const nodemailer = require('nodemailer');
+const config = require('../../../config');
+const logger = require('../../../utils/logger').child('EmailProvider:smtp');
+
+let _transporter = null;
+
+function getTransporter() {
+  if (_transporter) return _transporter;
+  if (!config.SMTP_HOST || !config.SMTP_USER || !config.SMTP_PASS) {
+    throw new Error('SMTP provider selected but SMTP_HOST/SMTP_USER/SMTP_PASS are not configured');
+  }
+  _transporter = nodemailer.createTransport({
+    host: config.SMTP_HOST,
+    port: config.SMTP_PORT,
+    secure: config.SMTP_SECURE,
+    auth: { user: config.SMTP_USER, pass: config.SMTP_PASS },
+  });
+  return _transporter;
+}
+
+module.exports = {
+  name: 'smtp',
+
+  async send(message) {
+    const info = await getTransporter().sendMail({
+      from: message.from || config.SMTP_FROM,
+      to: message.to,
+      subject: message.subject,
+      text: message.text,
+      html: message.html,
+    });
+    return { messageId: info.messageId };
+  },
+
+  async verify() {
+    try {
+      await getTransporter().verify();
+      return { ok: true };
+    } catch (err) {
+      logger.error('SMTP verification failed', { error: err.message });
+      return { ok: false, error: err.message };
+    }
+  },
+
+  // Exposed for tests to reset the cached transporter.
+  _reset() {
+    _transporter = null;
+  },
+};

--- a/backend/src/services/email/suppressionList.js
+++ b/backend/src/services/email/suppressionList.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * Email suppression list operations (Issue #80).
+ *
+ * Honoured by sendEmail() before every send, and fed by the provider bounce/
+ * complaint webhooks. A hard bounce or complaint also flips the matching
+ * student's reminderOptOut so the reminder pipeline stops targeting the address
+ * (Issue #9 opt-out integration).
+ */
+
+const EmailSuppression = require('../../models/emailSuppressionModel');
+const logger = require('../../utils/logger').child('EmailSuppression');
+
+function normalize(email) {
+  return (email || '').trim().toLowerCase();
+}
+
+/**
+ * Is this address currently blocked from delivery?
+ * @param {string} email
+ * @returns {Promise<boolean>}
+ */
+async function isSuppressed(email) {
+  const addr = normalize(email);
+  if (!addr) return false;
+  const record = await EmailSuppression.findOne({ email: addr }).lean();
+  if (!record) return false;
+  // Soft bounces are recorded but do not block.
+  if (record.reason === 'bounce' && record.bounceType === 'soft') return false;
+  return true;
+}
+
+/**
+ * Add or update a suppression record. Blocking reasons also opt the student out
+ * of reminders so we stop generating sends to a dead/abusive address.
+ *
+ * @param {string} email
+ * @param {{reason: string, bounceType?: string, source?: string, detail?: string}} opts
+ */
+async function suppress(email, { reason, bounceType = null, source = null, detail = null } = {}) {
+  const addr = normalize(email);
+  if (!addr) return null;
+
+  const record = await EmailSuppression.findOneAndUpdate(
+    { email: addr },
+    { $set: { reason, bounceType, source, detail, suppressedAt: new Date() } },
+    { upsert: true, new: true }
+  );
+
+  const blocking = reason !== 'bounce' || bounceType === 'hard';
+  if (blocking) {
+    await _optOutStudents(addr, reason);
+    logger.warn('Address suppressed', { email: addr, reason, bounceType, source });
+  } else {
+    logger.info('Soft bounce recorded (not blocking)', { email: addr, source });
+  }
+  return record;
+}
+
+async function recordBounce(email, { bounceType = 'hard', source = null, detail = null } = {}) {
+  return suppress(email, { reason: 'bounce', bounceType, source, detail });
+}
+
+async function recordComplaint(email, { source = null, detail = null } = {}) {
+  return suppress(email, { reason: 'complaint', source, detail });
+}
+
+/**
+ * Remove a suppression (e.g. operator clears a stale bounce, or a parent
+ * resubscribes). Does not automatically re-enable reminders.
+ */
+async function remove(email) {
+  const addr = normalize(email);
+  if (!addr) return false;
+  const res = await EmailSuppression.deleteOne({ email: addr });
+  return res.deletedCount > 0;
+}
+
+/** Paginated listing for the admin/operator view. */
+async function list({ limit = 50, skip = 0 } = {}) {
+  const cappedLimit = Math.min(Math.max(parseInt(limit, 10) || 50, 1), 200);
+  const cappedSkip = Math.max(parseInt(skip, 10) || 0, 0);
+  const [items, total] = await Promise.all([
+    EmailSuppression.find({}).sort({ suppressedAt: -1 }).skip(cappedSkip).limit(cappedLimit).lean(),
+    EmailSuppression.countDocuments({}),
+  ]);
+  return { items, total, limit: cappedLimit, skip: cappedSkip };
+}
+
+/**
+ * Opt out any student whose contact/parent email matches a now-suppressed
+ * address. Best-effort: failures are logged, never thrown back to the caller.
+ */
+async function _optOutStudents(addr, reason) {
+  try {
+    const Student = require('../../models/studentModel');
+    // Cross-school infrastructure op: a suppressed address may belong to any
+    // tenant, so we bypass tenant scoping (the address itself is the scope).
+    const res = await Student.updateMany(
+      { $or: [{ parentEmail: addr }, { contactEmail: addr }], reminderOptOut: { $ne: true } },
+      { $set: { reminderOptOut: true } },
+      { _bypassTenantScope: true }
+    );
+    const modified = res?.modifiedCount ?? res?.nModified ?? 0;
+    if (modified > 0) {
+      logger.info('Opted out students after suppression', { email: addr, reason, modified });
+    }
+  } catch (err) {
+    logger.error('Failed to opt out students after suppression', { email: addr, error: err.message });
+  }
+}
+
+module.exports = {
+  isSuppressed,
+  suppress,
+  recordBounce,
+  recordComplaint,
+  remove,
+  list,
+  normalize,
+};

--- a/backend/src/services/emailService.js
+++ b/backend/src/services/emailService.js
@@ -1,67 +1,53 @@
 'use strict';
 
 /**
- * Email service for sending transactional emails.
- * Issue #669: Sends payment receipt emails when payments transition to SUCCESS.
+ * Payment receipt emails.
+ * Issue #669: sends a receipt when a payment transitions to SUCCESS.
+ * Issue #80:  now routed through the unified email module (services/email),
+ *             which adds the pluggable provider, retry, and suppression handling.
+ *             The receipt body is rendered from externalized templates
+ *             (templates/receiptEmail.{txt,html}).
  */
 
 const logger = require('../utils/logger');
+const { sendEmail } = require('./email');
+const { renderEmailTemplate } = require('../utils/templateRenderer');
 
 /**
  * Send payment receipt email to parent/student contact email.
- * Called when a payment transitions to SUCCESS status.
- * 
+ *
  * @param {Object} options
  * @param {string} options.to - Recipient email address
- * @param {string} options.studentName - Student name for personalization
- * @param {number} options.amount - Payment amount
- * @param {string} options.txHash - Stellar transaction hash
- * @param {Date} options.confirmedAt - Payment confirmation timestamp
- * @param {number} options.remainingBalance - Remaining fee balance after payment
+ * @param {string} options.studentName
+ * @param {number} options.amount
+ * @param {string} options.txHash
+ * @param {Date}   options.confirmedAt
+ * @param {number} options.remainingBalance
  * @returns {Promise<Object>} Email send result
  */
 async function sendPaymentReceipt(options) {
   const { to, studentName, amount, txHash, confirmedAt, remainingBalance } = options;
 
   if (!to) {
-    logger.info({
-      msg: 'Payment receipt email skipped: no contact email',
-      studentName,
-      amount,
-    });
-    return { skipped: true };
+    logger.info({ msg: 'Payment receipt email skipped: no contact email', studentName, amount });
+    return { sent: false, skipped: true };
   }
 
-  try {
-    // TODO: Integrate with actual email provider (SendGrid, AWS SES, etc.)
-    // For now, log the email that would be sent
-    logger.info({
-      msg: 'Payment receipt email queued',
-      to,
-      studentName,
-      amount,
-      txHash,
-      confirmedAt,
-      remainingBalance,
-    });
+  const { text, html } = renderEmailTemplate('receiptEmail', {
+    studentName,
+    amount,
+    txHash,
+    confirmedAt: confirmedAt ? new Date(confirmedAt).toISOString() : '',
+    remainingBalance: remainingBalance > 0 ? remainingBalance : '',
+  });
 
-    // Return mock result for testing
-    return {
-      messageId: `mock-${Date.now()}`,
-      to,
-      subject: `Payment Receipt for ${studentName}`,
-    };
-  } catch (err) {
-    logger.error({
-      msg: 'Failed to send payment receipt email',
-      to,
-      studentName,
-      error: err.message,
-    });
-    throw err;
-  }
+  return sendEmail({
+    to,
+    subject: `Payment Receipt for ${studentName}`,
+    text,
+    html,
+    category: 'receipt',
+  });
 }
 
-module.exports = {
-  sendPaymentReceipt,
-};
+module.exports = { sendPaymentReceipt };

--- a/backend/src/services/notificationService.js
+++ b/backend/src/services/notificationService.js
@@ -1,86 +1,35 @@
 'use strict';
 
 /**
- * Notification Service
+ * Notification Service — fee reminder emails.
  *
- * Sends fee reminder emails to parents via SMTP (nodemailer).
- * Falls back to console logging when SMTP is not configured — useful
- * for development and environments without email infrastructure.
+ * Issue #80: sending is now delegated to the unified email module
+ * (services/email), giving reminders a pluggable provider (SMTP/SES/SendGrid),
+ * automatic retry, and suppression-list handling. This service is responsible
+ * only for building the reminder content from external templates and the signed
+ * unsubscribe link.
  *
- * Email bodies are loaded from:
+ * Templates:
  *   backend/src/templates/reminderEmail.txt  (plain-text)
  *   backend/src/templates/reminderEmail.html (HTML)
  *
  * Supported placeholders: {{studentName}}, {{studentId}}, {{className}},
- * {{schoolName}}, {{feeAmount}}, {{outstanding}}, {{reminderNote}}
- * The {{#if reminderNote}}…{{/if}} block is stripped when reminderNote is empty.
+ * {{schoolName}}, {{feeAmount}}, {{outstanding}}, {{reminderNote}},
+ * {{unsubscribeUrl}}
  */
 
-const fs = require('fs');
-const path = require('path');
-const nodemailer = require('nodemailer');
 const config = require('../config');
 const logger = require('../utils/logger').child('NotificationService');
 const { generateUnsubscribeToken } = require('../utils/unsubscribeToken');
-
-const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
-
-function loadTemplate(filename) {
-  return fs.readFileSync(path.join(TEMPLATES_DIR, filename), 'utf8');
-}
-
-function renderTemplate(template, vars) {
-  // Replace {{#if key}}…{{/if}} blocks — include content only when key is truthy
-  let out = template.replace(/\{\{#if (\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g, (_, key, inner) =>
-    vars[key] ? inner : ''
-  );
-  // Replace {{key}} placeholders
-  return out.replace(/\{\{(\w+)\}\}/g, (_, key) => (vars[key] != null ? vars[key] : ''));
-}
-
-let _transporter = null;
+const { renderEmailTemplate } = require('../utils/templateRenderer');
+const email = require('./email');
 
 /**
- * Lazily initialise the nodemailer transporter.
- * Returns null (and logs a warning) when SMTP is not configured.
- */
-function getTransporter() {
-  if (_transporter) return _transporter;
-
-  if (!config.SMTP_HOST || !config.SMTP_USER || !config.SMTP_PASS) {
-    logger.warn('SMTP not configured — reminder emails will be logged only. Set SMTP_HOST, SMTP_USER, SMTP_PASS to enable sending.');
-    return null;
-  }
-
-  _transporter = nodemailer.createTransport({
-    host:   config.SMTP_HOST,
-    port:   config.SMTP_PORT,
-    secure: config.SMTP_SECURE,
-    auth: {
-      user: config.SMTP_USER,
-      pass: config.SMTP_PASS,
-    },
-  });
-
-  return _transporter;
-}
-
-/**
- * Verify SMTP connectivity using nodemailer's built-in verify().
+ * Verify the active email provider is reachable/configured.
  * Returns { ok: true } on success, { ok: false, error } on failure.
  */
 async function verifySmtp() {
-  const transporter = getTransporter();
-  if (!transporter) {
-    return { ok: false, error: 'SMTP not configured' };
-  }
-  try {
-    await transporter.verify();
-    return { ok: true };
-  } catch (err) {
-    logger.error('SMTP verification failed', { error: err.message });
-    return { ok: false, error: err.message };
-  }
+  return email.verify();
 }
 
 /**
@@ -94,9 +43,7 @@ function buildReminderEmail({ studentName, studentId, className, feeAmount, rema
     : '';
 
   const vars = { studentName, studentId, className, feeAmount, outstanding, schoolName, reminderNote, unsubscribeUrl: unsubscribeUrl || '' };
-
-  const text = renderTemplate(loadTemplate('reminderEmail.txt'), vars);
-  const html = renderTemplate(loadTemplate('reminderEmail.html'), vars);
+  const { text, html } = renderEmailTemplate('reminderEmail', vars);
 
   return { subject, text, html };
 }
@@ -114,20 +61,27 @@ function buildReminderEmail({ studentName, studentId, className, feeAmount, rema
  * @param {number|null} opts.remainingBalance
  * @param {string} opts.schoolName
  * @param {number} opts.reminderCount
- * @returns {Promise<{sent: boolean, messageId?: string, preview?: string}>}
+ * @returns {Promise<{sent: boolean, messageId?: string, preview?: string, suppressed?: boolean}>}
  */
 async function sendFeeReminder(opts) {
-  // Generate a signed unsubscribe token for this student/school pair
   const token = generateUnsubscribeToken(opts.studentId, opts.schoolId || 'unknown', config.JWT_SECRET);
   const baseUrl = config.APP_URL || process.env.APP_URL || 'http://localhost:5000';
   const unsubscribeUrl = `${baseUrl}/api/reminders/unsubscribe?token=${encodeURIComponent(token)}`;
 
   const { subject, text, html } = buildReminderEmail({ ...opts, unsubscribeUrl });
-  const transporter = getTransporter();
 
-  if (!transporter) {
-    // Dev/no-SMTP fallback — log the reminder so it's not silently dropped
-    logger.info('REMINDER (no SMTP)', {
+  const result = await email.sendEmail({
+    to: opts.to,
+    subject,
+    text,
+    html,
+    category: 'reminder',
+  });
+
+  // The console (dev/no-provider) backend logs instead of delivering — preserve
+  // the original "not sent" semantics so reminder tracking isn't advanced in dev.
+  if (result.provider === 'console') {
+    logger.info('REMINDER (console provider)', {
       to: opts.to,
       subject,
       studentId: opts.studentId,
@@ -136,22 +90,25 @@ async function sendFeeReminder(opts) {
     return { sent: false, preview: text };
   }
 
-  const info = await transporter.sendMail({
-    from:    config.SMTP_FROM,
-    to:      opts.to,
-    subject,
-    text,
-    html,
-  });
+  if (result.sent) {
+    logger.info('Reminder email sent', {
+      messageId: result.messageId,
+      to: opts.to,
+      studentId: opts.studentId,
+      reminderCount: opts.reminderCount,
+    });
+    return { sent: true, messageId: result.messageId };
+  }
 
-  logger.info('Reminder email sent', {
-    messageId:    info.messageId,
-    to:           opts.to,
-    studentId:    opts.studentId,
-    reminderCount: opts.reminderCount,
-  });
+  // Suppressed recipient — a deliberate skip, not a provider failure.
+  if (result.suppressed) {
+    logger.info('Reminder skipped — recipient suppressed', { to: opts.to, studentId: opts.studentId });
+    return { sent: false, suppressed: true };
+  }
 
-  return { sent: true, messageId: info.messageId };
+  // Genuine delivery failure after retries — throw so the caller's circuit
+  // breaker counts it (preserves the original sendMail-throws behaviour).
+  throw new Error(result.error || 'Email delivery failed after retries');
 }
 
 module.exports = { sendFeeReminder, verifySmtp };

--- a/backend/src/services/retryContract.js
+++ b/backend/src/services/retryContract.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Shared retry contract (Issue #81).
+ *
+ * The two retry backends — the Redis/BullMQ backend (bullMQRetryService) and the
+ * MongoDB fallback (retryService) — must classify failures identically so a
+ * transaction that is retryable in dev is retryable in prod and vice versa.
+ *
+ * This module is the single source of truth for that classification. Both
+ * backends import it; the shared contract test (tests/retryBackendContract.test.js)
+ * asserts they agree.
+ *
+ * Guarantee differences that CANNOT be unified (durability, ordering, rate-limit
+ * scope) are documented in docs/retry-backends.md, not here.
+ */
+
+// Errors that will never succeed on retry — fail straight to the dead-letter
+// queue rather than wasting attempts.
+const PERMANENT_ERROR_CODES = [
+  'TX_FAILED',
+  'MISSING_MEMO',
+  'INVALID_DESTINATION',
+  'UNSUPPORTED_ASSET',
+  'DUPLICATE_TX',
+  'INVALID_TRANSACTION_HASH',
+  'TRANSACTION_NOT_FOUND',
+];
+
+// Errors that are worth retrying with backoff (network/transient).
+const TRANSIENT_ERROR_CODES = [
+  'STELLAR_NETWORK_ERROR',
+  'ECONNREFUSED',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'NETWORK_ERROR',
+  'SOCKET_TIMEOUT',
+  'REQUEST_TIMEOUT',
+  'HORIZON_UNAVAILABLE',
+];
+
+const TRANSIENT_MESSAGE_PATTERNS = [
+  /network/i,
+  /timeout/i,
+  /connection/i,
+  /unavailable/i,
+  /temporary/i,
+];
+
+/**
+ * Classify an error for the retry decision.
+ * @param {{code?: string, message?: string}} error
+ * @returns {'permanent'|'transient'|'unknown'}
+ */
+function classifyError(error) {
+  if (!error) return 'unknown';
+  const code = error.code || '';
+  const message = error.message || '';
+
+  if (PERMANENT_ERROR_CODES.includes(code)) return 'permanent';
+  if (TRANSIENT_ERROR_CODES.includes(code)) return 'transient';
+  if (TRANSIENT_MESSAGE_PATTERNS.some((p) => p.test(message))) return 'transient';
+  return 'unknown';
+}
+
+/** Permanent errors must NOT be retried. */
+function isPermanent(error) {
+  return classifyError(error) === 'permanent';
+}
+
+module.exports = {
+  PERMANENT_ERROR_CODES,
+  TRANSIENT_ERROR_CODES,
+  classifyError,
+  isPermanent,
+};

--- a/backend/src/services/retryService.js
+++ b/backend/src/services/retryService.js
@@ -16,6 +16,7 @@ const { verifyTransaction, recordPayment } = require("./stellarService");
 const { server } = require("../config/stellarConfig");
 const config = require("../config/index");
 const { withStellarRetry } = require("../utils/withStellarRetry");
+const retryContract = require("./retryContract");
 const logger = require("../utils/logger").child("RetryService");
 
 const RETRY_INTERVAL_MS = config.RETRY_INTERVAL_MS;
@@ -235,13 +236,9 @@ async function processPendingVerifications() {
         });
       } catch (err) {
         const attempts = item.attempts + 1;
-        const isPermanentError = [
-          "TX_FAILED",
-          "MISSING_MEMO",
-          "INVALID_DESTINATION",
-          "UNSUPPORTED_ASSET",
-          "DUPLICATE_TX",
-        ].includes(err.code);
+        // Shared retry contract (Issue #81) — same permanent classification as
+        // the BullMQ backend.
+        const isPermanentError = retryContract.isPermanent(err);
         const isStellarError =
           !err.code || err.code === "STELLAR_NETWORK_ERROR";
 

--- a/backend/src/services/retryServiceSelector.js
+++ b/backend/src/services/retryServiceSelector.js
@@ -19,6 +19,21 @@ function useBullMQ() {
   return Boolean(process.env.REDIS_HOST);
 }
 
+/**
+ * Best-effort replica count from common orchestration env vars. Returns 1 when
+ * unknown (single replica is the safe assumption for the warning below).
+ * Set REPLICA_COUNT explicitly in multi-replica deployments for accuracy.
+ */
+function getReplicaCount() {
+  const raw =
+    process.env.REPLICA_COUNT ||
+    process.env.WEB_CONCURRENCY ||
+    process.env.INSTANCE_COUNT ||
+    process.env.NUMBER_OF_REPLICAS;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
 function start() {
   if (useBullMQ()) {
     _selected = 'bullmq';
@@ -28,6 +43,21 @@ function start() {
   } else {
     _selected = 'mongodb';
     logger.info('REDIS_HOST not set — retry backend: MongoDB (retryService)');
+
+    // Issue #81: the MongoDB backend's rate-limit counters and locks are
+    // in-process. Running >1 replica against it means each replica retries the
+    // same backlog independently — double-processing risk and no shared
+    // rate-limit budget. Warn loudly; Redis/BullMQ is required for multi-replica.
+    const replicas = getReplicaCount();
+    if (replicas > 1) {
+      logger.error(
+        `[CRITICAL] In-process MongoDB retry backend is running with ${replicas} replicas. ` +
+        'Rate-limit counters and retry coordination are per-process — replicas will ' +
+        'independently re-drive the same failed transactions (double-processing risk). ' +
+        'Set REDIS_HOST to use the BullMQ backend for any multi-replica deployment.'
+      );
+    }
+
     const { startRetryWorker } = require('./retryService');
     startRetryWorker();
   }
@@ -53,4 +83,4 @@ function getSelectedBackend() {
   return _selected;
 }
 
-module.exports = { start, stop, isRunning, getSelectedBackend, useBullMQ };
+module.exports = { start, stop, isRunning, getSelectedBackend, useBullMQ, getReplicaCount };

--- a/backend/src/services/sseService.js
+++ b/backend/src/services/sseService.js
@@ -22,6 +22,7 @@
 
 const Redis = require('ioredis');
 const logger = require('../utils/logger').child('SSEService');
+const { getRedisConnectionOptions } = require('../config/redisClient');
 
 // Map of schoolId -> Set of SSE response objects (process-local)
 const clients = new Map();
@@ -37,14 +38,10 @@ const MAX_CONNECTIONS_PER_SCHOOL =
 // cannot issue regular commands such as PUBLISH.
 const redisEnabled = Boolean(process.env.REDIS_HOST);
 
-const redisConfig = {
-  host: process.env.REDIS_HOST || 'localhost',
-  port: parseInt(process.env.REDIS_PORT, 10) || 6379,
-  password: process.env.REDIS_PASSWORD || undefined,
-  lazyConnect: true,
-  maxRetriesPerRequest: null,
-  enableOfflineQueue: false,
-};
+// Shared reconnection policy (Issue #83). pub/sub connections need
+// maxRetriesPerRequest: null so a blocking SUBSCRIBE survives a reconnect; on a
+// total outage emit() degrades to local fan-out (see emit() below).
+const redisConfig = getRedisConnectionOptions({ maxRetriesPerRequest: null });
 
 let publisher = null;
 let subscriber = null;

--- a/backend/src/templates/receiptEmail.html
+++ b/backend/src/templates/receiptEmail.html
@@ -1,0 +1,10 @@
+<p>Dear Parent/Guardian,</p>
+<p>We have received your school fee payment for <strong>{{studentName}}</strong>. Thank you.</p>
+<table style="border-collapse:collapse;margin:16px 0;">
+  <tr><td style="padding:4px 12px 4px 0;color:#555;">Amount Paid</td><td><strong>{{amount}}</strong></td></tr>
+  <tr><td style="padding:4px 12px 4px 0;color:#555;">Transaction Hash</td><td><code>{{txHash}}</code></td></tr>
+  <tr><td style="padding:4px 12px 4px 0;color:#555;">Confirmed At</td><td>{{confirmedAt}}</td></tr>
+  {{#if remainingBalance}}<tr><td style="padding:4px 12px 4px 0;color:#555;">Remaining Balance</td><td>{{remainingBalance}}</td></tr>{{/if}}
+</table>
+<p>This receipt confirms the payment was recorded on the Stellar network. Keep it for your records.</p>
+<p>Thank you,<br/><strong>StellarEduPay</strong></p>

--- a/backend/src/templates/receiptEmail.txt
+++ b/backend/src/templates/receiptEmail.txt
@@ -1,0 +1,14 @@
+Dear Parent/Guardian,
+
+We have received your school fee payment for {{studentName}}. Thank you.
+
+  Amount Paid       : {{amount}}
+  Transaction Hash  : {{txHash}}
+  Confirmed At      : {{confirmedAt}}
+{{#if remainingBalance}}  Remaining Balance : {{remainingBalance}}
+{{/if}}
+This receipt confirms the payment was recorded on the Stellar network. Keep it
+for your records.
+
+Thank you,
+StellarEduPay

--- a/backend/src/utils/templateRenderer.js
+++ b/backend/src/utils/templateRenderer.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * Minimal external-template loader and renderer shared by the email services
+ * (Issue #80 — "Templates externalized and tested").
+ *
+ * Templates live under backend/src/templates/. Supported syntax:
+ *   {{key}}                       — substituted with vars[key] ('' when nullish)
+ *   {{#if key}}…{{/if}}           — block included only when vars[key] is truthy
+ *
+ * Loaded template files are cached in-process; pass `fresh: true` to bypass the
+ * cache (used in tests).
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
+const _cache = new Map();
+
+function loadTemplate(filename, { fresh = false } = {}) {
+  if (!fresh && _cache.has(filename)) return _cache.get(filename);
+  const contents = fs.readFileSync(path.join(TEMPLATES_DIR, filename), 'utf8');
+  _cache.set(filename, contents);
+  return contents;
+}
+
+function renderTemplate(template, vars = {}) {
+  const withConditionals = template.replace(
+    /\{\{#if (\w+)\}\}([\s\S]*?)\{\{\/if\}\}/g,
+    (_, key, inner) => (vars[key] ? inner : '')
+  );
+  return withConditionals.replace(/\{\{(\w+)\}\}/g, (_, key) =>
+    vars[key] != null ? String(vars[key]) : ''
+  );
+}
+
+/**
+ * Load `name.txt` and `name.html` and render both with the same vars.
+ * @returns {{text: string, html: string}}
+ */
+function renderEmailTemplate(name, vars, opts = {}) {
+  return {
+    text: renderTemplate(loadTemplate(`${name}.txt`, opts), vars),
+    html: renderTemplate(loadTemplate(`${name}.html`, opts), vars),
+  };
+}
+
+module.exports = { loadTemplate, renderTemplate, renderEmailTemplate, TEMPLATES_DIR };

--- a/backend/tests/emailService.test.js
+++ b/backend/tests/emailService.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+/**
+ * Tests for the unified email module (Issue #80):
+ *   - external template rendering (receipt + reminder)
+ *   - suppression list is honoured before sending
+ *   - transient failures are retried, then surfaced after max attempts
+ *   - provider factory selection
+ *   - bounce/complaint webhook parsing (SES + SendGrid)
+ */
+
+// config/index.js requires MONGO_URI; we never connect, just need it present.
+process.env.MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/test';
+
+// Keep retry backoff effectively instant for the retry test.
+process.env.EMAIL_RETRY_BASE_MS = '1';
+process.env.EMAIL_RETRY_MAX_MS = '2';
+process.env.EMAIL_MAX_RETRIES = '3';
+
+const { renderEmailTemplate } = require('../src/utils/templateRenderer');
+
+describe('templateRenderer / externalized templates', () => {
+  test('renders receipt template with substitutions and conditional block', () => {
+    const { text, html } = renderEmailTemplate('receiptEmail', {
+      studentName: 'Ada Lovelace',
+      amount: 150,
+      txHash: 'abc123',
+      confirmedAt: '2026-06-30T00:00:00.000Z',
+      remainingBalance: 50,
+    });
+    expect(text).toContain('Ada Lovelace');
+    expect(text).toContain('150');
+    expect(text).toContain('abc123');
+    expect(text).toContain('Remaining Balance');
+    expect(html).toContain('<strong>150</strong>');
+  });
+
+  test('omits {{#if}} block when value is falsy', () => {
+    const { text } = renderEmailTemplate('receiptEmail', {
+      studentName: 'Grace',
+      amount: 100,
+      txHash: 'x',
+      confirmedAt: 'now',
+      remainingBalance: '', // paid in full
+    });
+    expect(text).not.toContain('Remaining Balance');
+  });
+
+  test('renders reminder template with unsubscribe link', () => {
+    const { text, html } = renderEmailTemplate('reminderEmail', {
+      studentName: 'Bob',
+      studentId: 'S1',
+      className: '5A',
+      feeAmount: 200,
+      outstanding: 200,
+      schoolName: 'Test School',
+      reminderNote: '',
+      unsubscribeUrl: 'https://x/unsub?token=abc',
+    });
+    expect(text).toContain('Bob');
+    expect(html).toContain('unsub?token=abc');
+  });
+});
+
+describe('sendEmail', () => {
+  const mockSend = jest.fn();
+  const mockIsSuppressed = jest.fn();
+
+  jest.mock('../src/services/email/emailProvider', () => ({
+    getProvider: () => ({
+      name: 'mock',
+      send: (...a) => mockSend(...a),
+      verify: async () => ({ ok: true }),
+    }),
+  }));
+  jest.mock('../src/services/email/suppressionList', () => ({
+    isSuppressed: (...a) => mockIsSuppressed(...a),
+  }));
+
+  let sendEmail;
+  beforeAll(() => {
+    sendEmail = require('../src/services/email').sendEmail;
+  });
+
+  beforeEach(() => {
+    mockSend.mockReset();
+    mockIsSuppressed.mockReset().mockResolvedValue(false);
+  });
+
+  test('skips and reports when no recipient', async () => {
+    const res = await sendEmail({ subject: 'x' });
+    expect(res).toEqual(expect.objectContaining({ sent: false, skipped: true }));
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('honours suppression list — never sends to suppressed address', async () => {
+    mockIsSuppressed.mockResolvedValue(true);
+    const res = await sendEmail({ to: 'bounced@example.com', subject: 'x', text: 'y' });
+    expect(res).toEqual(expect.objectContaining({ sent: false, skipped: true, suppressed: true }));
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  test('sends on first try', async () => {
+    mockSend.mockResolvedValue({ messageId: 'm1' });
+    const res = await sendEmail({ to: 'a@example.com', subject: 's', text: 't' });
+    expect(res).toEqual(expect.objectContaining({ sent: true, messageId: 'm1', attempts: 1 }));
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries transient failure then succeeds', async () => {
+    mockSend
+      .mockRejectedValueOnce(new Error('ETIMEDOUT'))
+      .mockResolvedValueOnce({ messageId: 'm2' });
+    const res = await sendEmail({ to: 'a@example.com', subject: 's', text: 't' });
+    expect(res).toEqual(expect.objectContaining({ sent: true, messageId: 'm2', attempts: 2 }));
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  test('returns failure after exhausting retries', async () => {
+    mockSend.mockRejectedValue(new Error('boom'));
+    const res = await sendEmail({ to: 'a@example.com', subject: 's', text: 't' });
+    expect(res.sent).toBe(false);
+    expect(res.attempts).toBe(3);
+    expect(res.error).toBe('boom');
+    expect(mockSend).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('emailProvider factory', () => {
+  // sendEmail's describe mocks the provider module file-wide; use the real impl.
+  const { resolveProviderName } = jest.requireActual('../src/services/email/emailProvider');
+  const orig = { ...process.env };
+  afterEach(() => {
+    process.env.EMAIL_PROVIDER = orig.EMAIL_PROVIDER;
+  });
+
+  test('honours explicit EMAIL_PROVIDER', () => {
+    process.env.EMAIL_PROVIDER = 'sendgrid';
+    expect(resolveProviderName()).toBe('sendgrid');
+  });
+
+  test('falls back to console for unknown provider', () => {
+    process.env.EMAIL_PROVIDER = 'pigeon';
+    expect(resolveProviderName()).toBe('console');
+  });
+});
+
+describe('webhook event parsing', () => {
+  const { parseEvents } = require('../src/controllers/emailWebhookController');
+
+  test('parses SES permanent bounce as hard', () => {
+    const body = {
+      Message: JSON.stringify({
+        notificationType: 'Bounce',
+        bounce: { bounceType: 'Permanent', bouncedRecipients: [{ emailAddress: 'x@y.com', diagnosticCode: '550' }] },
+      }),
+    };
+    const events = parseEvents('ses', body);
+    expect(events).toEqual([
+      expect.objectContaining({ email: 'x@y.com', kind: 'bounce', bounceType: 'hard' }),
+    ]);
+  });
+
+  test('parses SES complaint', () => {
+    const body = {
+      Message: JSON.stringify({
+        notificationType: 'Complaint',
+        complaint: { complainedRecipients: [{ emailAddress: 'c@y.com' }], complaintFeedbackType: 'abuse' },
+      }),
+    };
+    const events = parseEvents('ses', body);
+    expect(events[0]).toEqual(expect.objectContaining({ email: 'c@y.com', kind: 'complaint' }));
+  });
+
+  test('parses SendGrid bounce + spamreport array', () => {
+    const events = parseEvents('sendgrid', [
+      { email: 'b@y.com', event: 'bounce', type: 'bounce', reason: 'mailbox unavailable' },
+      { email: 's@y.com', event: 'spamreport' },
+    ]);
+    expect(events).toEqual([
+      expect.objectContaining({ email: 'b@y.com', kind: 'bounce', bounceType: 'hard' }),
+      expect.objectContaining({ email: 's@y.com', kind: 'complaint' }),
+    ]);
+  });
+});

--- a/backend/tests/redisReconnectionPolicy.test.js
+++ b/backend/tests/redisReconnectionPolicy.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+/**
+ * Redis reconnection-policy tests (Issue #83).
+ *
+ * Every Redis consumer (queue, SSE pub/sub, distributed lock, rate limiter,
+ * refresh-token store) shares one reconnection policy via
+ * getRedisConnectionOptions(). These tests pin that policy: exponential backoff
+ * that gives up after a bounded number of attempts, transient-only
+ * reconnectOnError, and that per-consumer overrides compose correctly.
+ */
+
+const { getRedisConnectionOptions } = require('../src/config/redisClient');
+
+describe('shared Redis connection options', () => {
+  test('exposes a consistent base policy', () => {
+    const opts = getRedisConnectionOptions();
+    expect(typeof opts.retryStrategy).toBe('function');
+    expect(typeof opts.reconnectOnError).toBe('function');
+    expect(opts.enableOfflineQueue).toBe(false);
+    expect(opts.connectTimeout).toBeGreaterThan(0);
+  });
+
+  test('retryStrategy backs off and eventually gives up', () => {
+    const { retryStrategy } = getRedisConnectionOptions();
+    const first = retryStrategy(1);
+    const second = retryStrategy(2);
+    expect(second).toBeGreaterThanOrEqual(first);
+    // After the bounded attempts it returns null (stop reconnecting).
+    expect(retryStrategy(1000)).toBeNull();
+  });
+
+  test('reconnectOnError reconnects only on transient errors', () => {
+    const { reconnectOnError } = getRedisConnectionOptions();
+    expect(reconnectOnError(new Error('connect ECONNREFUSED 127.0.0.1:6379'))).toBe(true);
+    expect(reconnectOnError(new Error('ETIMEDOUT'))).toBe(true);
+    expect(reconnectOnError(new Error('WRONGPASS invalid password'))).toBe(false);
+    expect(reconnectOnError(null)).toBe(false);
+  });
+
+  test('overrides compose over the base policy (pub/sub needs null max retries)', () => {
+    const opts = getRedisConnectionOptions({ maxRetriesPerRequest: null });
+    expect(opts.maxRetriesPerRequest).toBeNull();
+    // Base policy is still present after override.
+    expect(typeof opts.retryStrategy).toBe('function');
+    expect(opts.enableOfflineQueue).toBe(false);
+  });
+});
+
+describe('retry backend replica detection', () => {
+  const selector = require('../src/services/retryServiceSelector');
+  const orig = { ...process.env };
+  afterEach(() => {
+    process.env.REPLICA_COUNT = orig.REPLICA_COUNT;
+    process.env.WEB_CONCURRENCY = orig.WEB_CONCURRENCY;
+  });
+
+  test('defaults to 1 when no replica env var set', () => {
+    delete process.env.REPLICA_COUNT;
+    delete process.env.WEB_CONCURRENCY;
+    delete process.env.INSTANCE_COUNT;
+    delete process.env.NUMBER_OF_REPLICAS;
+    expect(selector.getReplicaCount()).toBe(1);
+  });
+
+  test('reads REPLICA_COUNT', () => {
+    process.env.REPLICA_COUNT = '4';
+    expect(selector.getReplicaCount()).toBe(4);
+  });
+
+  test('falls back to WEB_CONCURRENCY', () => {
+    delete process.env.REPLICA_COUNT;
+    process.env.WEB_CONCURRENCY = '3';
+    expect(selector.getReplicaCount()).toBe(3);
+  });
+});

--- a/backend/tests/retryBackendContract.test.js
+++ b/backend/tests/retryBackendContract.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+/**
+ * Shared retry-backend contract test (Issue #81).
+ *
+ * Both retry backends — BullMQ (Redis) and the MongoDB fallback — must classify
+ * failures identically against the single shared contract (retryContract.js).
+ * This suite runs the SAME assertions against the classification each backend
+ * actually uses, so the two cannot silently diverge.
+ *
+ * The classification is the part of the contract that is backend-independent and
+ * unit-testable without live Redis/Mongo. Durability/ordering/rate-limit
+ * differences are documented (and intentionally NOT unified) in
+ * docs/retry-backends.md.
+ */
+
+const retryContract = require('../src/services/retryContract');
+
+// The classifier as exposed by each backend.
+const bullmqClassify = require('../src/services/bullMQRetryService').classifyError;
+
+// The MongoDB backend uses retryContract.isPermanent() directly; expose an
+// equivalent classifier so the same cases run against it.
+const mongoIsPermanent = retryContract.isPermanent;
+
+const CASES = [
+  { name: 'on-chain failure', error: { code: 'TX_FAILED' }, permanent: true, classification: 'permanent' },
+  { name: 'missing memo', error: { code: 'MISSING_MEMO' }, permanent: true, classification: 'permanent' },
+  { name: 'duplicate tx', error: { code: 'DUPLICATE_TX' }, permanent: true, classification: 'permanent' },
+  { name: 'network error code', error: { code: 'ETIMEDOUT' }, permanent: false, classification: 'transient' },
+  { name: 'stellar network error', error: { code: 'STELLAR_NETWORK_ERROR' }, permanent: false, classification: 'transient' },
+  { name: 'transient by message', error: { message: 'temporary network blip' }, permanent: false, classification: 'transient' },
+  { name: 'unknown error', error: { code: 'WAT' }, permanent: false, classification: 'unknown' },
+];
+
+describe('retry contract — shared classification', () => {
+  test.each(CASES)('classifies "$name" as $classification', ({ error, classification }) => {
+    expect(retryContract.classifyError(error)).toBe(classification);
+  });
+});
+
+// The "contract" run against BOTH backends: same input → same permanent decision.
+const BACKENDS = [
+  { backend: 'bullmq', isPermanent: (e) => bullmqClassify(e) === 'permanent' },
+  { backend: 'mongodb', isPermanent: (e) => mongoIsPermanent(e) },
+];
+
+describe.each(BACKENDS)('retry backend contract: $backend', ({ isPermanent }) => {
+  test.each(CASES)('permanent decision for "$name" matches contract', ({ error, permanent }) => {
+    expect(isPermanent(error)).toBe(permanent);
+  });
+});
+
+describe('both backends agree on every case', () => {
+  test.each(CASES)('"$name" — bullmq and mongodb agree', ({ error }) => {
+    const bullmqPermanent = bullmqClassify(error) === 'permanent';
+    const mongoPermanent = mongoIsPermanent(error);
+    expect(bullmqPermanent).toBe(mongoPermanent);
+  });
+});

--- a/backend/tests/retryQueueWorkerConfig.test.js
+++ b/backend/tests/retryQueueWorkerConfig.test.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * BullMQ worker configuration + backoff tests (Issue #82).
+ *
+ * Verifies that worker options (concurrency, stalled-job handling, lock
+ * duration) are explicitly configured and that the exponential backoff applies
+ * jitter within the expected bounds and respects the max-delay cap.
+ */
+
+const { config, calculateBackoffDelay } = require('../src/queue/transactionRetryQueue');
+
+describe('worker options are explicitly configured', () => {
+  test('concurrency is set', () => {
+    expect(config.worker.concurrency).toBeGreaterThan(0);
+  });
+
+  test('stalled-job recovery is configured', () => {
+    expect(config.worker.lockDuration).toBeGreaterThan(0);
+    expect(config.worker.stalledInterval).toBeGreaterThan(0);
+    expect(config.worker.maxStalledCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test('dead-letter queue is enabled by default', () => {
+    expect(config.dlq.enabled).toBe(true);
+  });
+
+  test('retry attempts and max delay are bounded', () => {
+    expect(config.retry.maxAttempts).toBeGreaterThan(0);
+    expect(config.retry.maxDelay).toBeGreaterThan(config.retry.initialDelay);
+  });
+});
+
+describe('calculateBackoffDelay', () => {
+  test('first attempt without jitter equals the initial delay', () => {
+    expect(calculateBackoffDelay(1, false)).toBe(config.retry.initialDelay);
+  });
+
+  test('grows exponentially without jitter', () => {
+    const a1 = calculateBackoffDelay(1, false);
+    const a2 = calculateBackoffDelay(2, false);
+    const a3 = calculateBackoffDelay(3, false);
+    expect(a2).toBe(a1 * config.retry.backoffMultiplier);
+    expect(a3).toBe(a1 * config.retry.backoffMultiplier ** 2);
+  });
+
+  test('never exceeds the max delay cap', () => {
+    for (let attempt = 1; attempt <= 50; attempt++) {
+      expect(calculateBackoffDelay(attempt, false)).toBeLessThanOrEqual(config.retry.maxDelay);
+      expect(calculateBackoffDelay(attempt, true)).toBeLessThanOrEqual(config.retry.maxDelay);
+    }
+  });
+
+  test('jitter keeps delays within +/- jitterRatio of the base', () => {
+    const base = calculateBackoffDelay(3, false);
+    const r = config.jitterRatio;
+    for (let i = 0; i < 200; i++) {
+      const d = calculateBackoffDelay(3, true);
+      expect(d).toBeGreaterThanOrEqual(Math.floor(base * (1 - r)) - 1);
+      expect(d).toBeLessThanOrEqual(Math.ceil(base * (1 + r)) + 1);
+    }
+  });
+
+  test('jitter actually varies the delay', () => {
+    const samples = new Set();
+    for (let i = 0; i < 20; i++) samples.add(calculateBackoffDelay(3, true));
+    expect(samples.size).toBeGreaterThan(1);
+  });
+});

--- a/docs/email-delivery.md
+++ b/docs/email-delivery.md
@@ -1,0 +1,89 @@
+# Email Delivery
+
+> Audit reference: Issue #80 (#869) — pluggable provider, retry, bounce/complaint
+> handling, externalized templates.
+
+All transactional email (payment receipts, fee reminders) flows through a single
+module — `backend/src/services/email` — which provides a pluggable provider, a
+retry path, and a suppression list. Individual services
+(`emailService.js`, `notificationService.js`) only build content; they never talk
+to a provider directly.
+
+```
+emailService.sendPaymentReceipt ─┐
+                                 ├─> services/email.sendEmail() ─> provider.send()
+notificationService.sendFeeReminder ─┘        │
+                                              ├─ suppression check (skip if blocked)
+                                              └─ retry w/ exponential backoff + jitter
+```
+
+## Providers
+
+Selected via `EMAIL_PROVIDER` (`smtp` | `ses` | `sendgrid` | `console`). When
+unset, the module auto-selects `smtp` if `SMTP_HOST/SMTP_USER/SMTP_PASS` are
+configured, otherwise `console` (logs instead of sending — safe dev default).
+
+Each provider implements `{ name, send(message), verify() }`
+(`backend/src/services/email/providers/`). The AWS SES and SendGrid SDKs are
+**optional** peer dependencies, required lazily — install only the one you use:
+
+| Provider   | Required config                          | SDK package            |
+|------------|------------------------------------------|------------------------|
+| `console`  | —                                        | —                      |
+| `smtp`     | `SMTP_HOST`, `SMTP_USER`, `SMTP_PASS`, `SMTP_PORT`, `SMTP_SECURE`, `SMTP_FROM` | `nodemailer` (bundled) |
+| `ses`      | `AWS_REGION` (+ standard AWS credentials) | `@aws-sdk/client-ses`  |
+| `sendgrid` | `SENDGRID_API_KEY`                       | `@sendgrid/mail`       |
+
+## Retry
+
+`sendEmail()` retries transient send failures with exponential backoff + jitter.
+
+| Env var               | Default | Meaning                         |
+|-----------------------|---------|---------------------------------|
+| `EMAIL_MAX_RETRIES`   | `3`     | Total attempts per send         |
+| `EMAIL_RETRY_BASE_MS` | `500`   | Base backoff delay              |
+| `EMAIL_RETRY_MAX_MS`  | `30000` | Backoff cap                     |
+
+A genuine failure after all retries is surfaced to the caller. For reminders, a
+failure throws so the reminder circuit breaker can trip; a *suppressed* recipient
+is a deliberate skip, not a failure.
+
+## Bounce & complaint suppression
+
+The suppression list (`emailSuppressionModel`, `services/email/suppressionList.js`)
+records addresses that must not be emailed again. `sendEmail()` consults it before
+every send. A hard bounce or complaint also flips the matching student's
+`reminderOptOut` (Issue #9 opt-out integration). Soft bounces are recorded for
+visibility but do **not** block delivery.
+
+### Provider webhooks
+
+Providers report bounces/complaints asynchronously. Point them at:
+
+```
+POST /api/email/webhooks/ses        (SES → SNS notifications)
+POST /api/email/webhooks/sendgrid   (SendGrid Event Webhook)
+```
+
+Protect them with a shared secret: set `EMAIL_WEBHOOK_SECRET` and configure the
+provider to send it as `x-webhook-token` (or `?token=`). Without the secret set,
+webhooks are accepted unauthenticated (dev only — always set it in production).
+
+### Operator endpoints (admin auth)
+
+```
+GET    /api/email/suppressions          list suppressed addresses
+POST   /api/email/suppressions          manually suppress { email, reason, bounceType, detail }
+DELETE /api/email/suppressions/:email   clear a suppression
+```
+
+## Templates
+
+Bodies are externalized under `backend/src/templates/` and rendered by
+`utils/templateRenderer.js` (`{{key}}` substitution and `{{#if key}}…{{/if}}`
+blocks):
+
+- `receiptEmail.txt` / `receiptEmail.html`
+- `reminderEmail.txt` / `reminderEmail.html`
+
+Rendering and the send path are covered by `backend/tests/emailService.test.js`.

--- a/docs/redis-dependency.md
+++ b/docs/redis-dependency.md
@@ -1,0 +1,91 @@
+# Redis Dependency & Graceful Degradation
+
+> Audit reference: Issue #83 (#872) — Redis is a single point of failure for the
+> queue, SSE pub/sub, rate limiting, refresh tokens, and distributed locks.
+
+When `REDIS_HOST` is set, Redis backs several subsystems at once, so a single
+Redis outage has a wide blast radius. This document is the dependency surface,
+the per-consumer degradation contract, the reconnection policy, and the HA
+recommendation.
+
+## Dependency surface
+
+| Consumer            | Module                              | Used for                                  |
+|---------------------|-------------------------------------|-------------------------------------------|
+| Retry queue (BullMQ)| `queue/transactionRetryQueue.js`    | Durable failed-transaction retries        |
+| SSE pub/sub         | `services/sseService.js`            | Cross-replica real-time event fan-out     |
+| Rate limiting       | `middleware/rateLimiter.js`         | Shared rate-limit counters across replicas|
+| Refresh-token store | auth/session layer                  | Refresh-token validity / revocation       |
+| Distributed locks   | `services/distributedLock.js`       | Single-processing of a school's sync      |
+
+## Degradation modes
+
+Each consumer has a defined behaviour when Redis is unavailable:
+
+| Consumer          | Degradation mode                                                                 |
+|-------------------|---------------------------------------------------------------------------------|
+| Distributed locks | **Fail closed** — `acquire()` returns `null` on Redis error, so the cycle is skipped rather than risking two workers proceeding. The unique index on `Payment {schoolId, txHash}` remains the authoritative dedup guard. |
+| SSE pub/sub       | **Falls back to local fan-out** — a failed `PUBLISH` still delivers to clients connected to the current replica; cross-replica delivery is lost until Redis recovers. With `REDIS_HOST` unset it runs single-process by design. |
+| Retry queue       | Initialization failure is surfaced loudly in logs and via `/health` (`retryQueue.status: failed`); the HTTP server still boots. Without `REDIS_HOST` the MongoDB backend is used (single-replica only — see [retry-backends.md](./retry-backends.md)). |
+| Rate limiting     | Counters become in-process per replica (not shared); limits still apply locally. A loud startup warning is emitted for the MongoDB/in-process path. |
+| Refresh tokens    | Validation degrades; treat as fail-closed for session issuance.                 |
+
+The guiding principle: **anything guarding correctness (locks, dedup) fails
+closed; anything best-effort (SSE) degrades to local.**
+
+## Health reporting
+
+`GET /health` reports Redis status under `checks.retryQueue`:
+
+```json
+"retryQueue": {
+  "status": "ok",
+  "backend": "bullmq",
+  "redisConfigured": true,
+  "redisStatus": "ready",
+  "redisHost": "...",
+  "lastUpdatedAt": "..."
+}
+```
+
+`redisStatus` is one of `ready | connecting | reconnecting | unavailable |
+closed | ended | disabled`. When Redis is configured but not `ready`, overall
+health is reported as `degraded` (HTTP 200) — DB is still up and cached data can
+be served.
+
+## Reconnection policy
+
+All consumers share one policy via `getRedisConnectionOptions()` in
+`config/redisClient.js`, so backoff and transient-error handling are identical
+everywhere (previously each client set its own ad-hoc options):
+
+| Env var                          | Default | Meaning                              |
+|----------------------------------|---------|--------------------------------------|
+| `REDIS_RECONNECT_MAX_ATTEMPTS`   | `8`     | Reconnect attempts before giving up  |
+| `REDIS_RECONNECT_BASE_DELAY_MS`  | `500`   | Base backoff between attempts        |
+| `REDIS_RECONNECT_MAX_DELAY_MS`   | `30000` | Backoff cap                          |
+| `REDIS_LOG_THROTTLE_MS`          | `60000` | Throttle for repeated Redis warnings |
+
+- `retryStrategy` backs off exponentially and returns `null` after the max
+  attempts (stop reconnecting).
+- `reconnectOnError` reconnects only on transient codes (`ECONNREFUSED`,
+  `ENOTFOUND`, `ETIMEDOUT`, `EHOSTUNREACH`).
+- Consumers needing blocking commands (BullMQ Worker/QueueEvents, pub/sub
+  subscriber, lock client) override `maxRetriesPerRequest: null` while inheriting
+  the rest of the shared policy.
+
+Pinned by `backend/tests/redisReconnectionPolicy.test.js`.
+
+## High availability
+
+For production, run Redis in an HA topology so a single node failure does not
+take down all of the above simultaneously:
+
+- **Redis Sentinel** — automatic failover for a primary/replica set. ioredis
+  accepts `{ sentinels, name }`; thread these through `getRedisConnectionOptions`.
+- **Redis Cluster** — sharded + replicated for horizontal scale.
+
+Operationally: deploy Redis with persistence (AOF), monitor `redisStatus` via
+`/health`, and alert on `degraded`. Pair HA Redis with `REPLICA_COUNT` set
+correctly so the BullMQ backend is selected (never the in-process MongoDB
+fallback) in multi-replica deployments.

--- a/docs/retry-backends.md
+++ b/docs/retry-backends.md
@@ -1,0 +1,89 @@
+# Transaction Retry Backends
+
+> Audit reference: Issue #81 (#870) — single retry contract + guarantee matrix;
+> Issue #82 (#871) — BullMQ worker configuration, dead-letter strategy, metrics.
+
+Failed Stellar transaction verifications are retried by one of two backends,
+selected at startup by `retryServiceSelector`:
+
+- **BullMQ** (Redis-backed) — used when `REDIS_HOST` is set.
+- **MongoDB** (`retryService`) — fallback when `REDIS_HOST` is unset.
+
+Only one runs at a time. **Redis/BullMQ is required for any multi-replica
+deployment** (see the guarantee matrix). On startup with the MongoDB backend and
+`REPLICA_COUNT > 1` (also read from `WEB_CONCURRENCY` / `INSTANCE_COUNT` /
+`NUMBER_OF_REPLICAS`), the selector logs a loud `[CRITICAL]` warning.
+
+## Shared contract
+
+Both backends classify failures through one shared module —
+`backend/src/services/retryContract.js` — so a transaction that is retryable in
+dev (Mongo) is retryable in prod (Redis) and vice versa.
+
+- `PERMANENT_ERROR_CODES` → never retried; routed to the dead-letter backlog.
+- `TRANSIENT_ERROR_CODES` + transient message patterns → retried with backoff.
+- Everything else → `unknown` (retried until max attempts, then dead-lettered).
+
+`backend/tests/retryBackendContract.test.js` runs the **same** classification
+cases against both backends and asserts they agree on every case.
+
+## Guarantee matrix
+
+| Property            | BullMQ (Redis)                                  | MongoDB (`retryService`)                          |
+|---------------------|-------------------------------------------------|---------------------------------------------------|
+| Durability          | Jobs persisted in Redis; survive restarts       | Records persisted in MongoDB; survive restarts    |
+| Multi-replica safe  | **Yes** — Redis coordinates a single consumer   | **No** — each replica polls independently         |
+| Rate-limit scope    | Shared across replicas (Redis)                  | **In-process only** — per replica, resets on restart |
+| Concurrency control | Explicit worker `concurrency` (`QUEUE_CONCURRENCY`) | Single in-process timer loop, batch of 50       |
+| Ordering            | Not guaranteed (delayed/backoff jobs reorder)   | Roughly `nextRetryAt` order within a batch        |
+| Backoff             | Exponential + jitter                            | Exponential (1m·2ⁿ, capped 60m), no jitter        |
+| Dead-letter         | Dedicated `transaction-dead-letter-queue`       | `status: 'dead_letter'` on the PendingVerification |
+| Stalled-job recovery| Yes (BullMQ lock + `maxStalledCount`)           | N/A (synchronous batch)                           |
+
+The single-replica MongoDB path is correct and convenient for development; it is
+**not** safe to run more than one replica against it.
+
+## BullMQ worker configuration (Issue #82)
+
+All options are explicit in `backend/src/queue/transactionRetryQueue.js` and
+env-overridable:
+
+| Env var                       | Default   | Meaning                                              |
+|-------------------------------|-----------|-----------------------------------------------------|
+| `QUEUE_CONCURRENCY`           | `5`       | Concurrent jobs per worker                           |
+| `MAX_RETRY_ATTEMPTS`          | `10`      | Attempts before a job is dead-lettered               |
+| `INITIAL_RETRY_DELAY_MS`      | `60000`   | Base backoff delay                                   |
+| `MAX_RETRY_DELAY_MS`          | `3600000` | Backoff cap                                          |
+| `RETRY_BACKOFF_MULTIPLIER`    | `2`       | Exponential multiplier                               |
+| `RETRY_JITTER_RATIO`          | `0.2`     | ± jitter applied to each backoff delay               |
+| `QUEUE_LOCK_DURATION_MS`      | `30000`   | Job lock TTL; must exceed worst-case processing time |
+| `QUEUE_STALLED_INTERVAL_MS`   | `30000`   | How often stalled jobs are scanned                   |
+| `QUEUE_MAX_STALLED_COUNT`     | `2`       | Stalled recoveries before failing for good           |
+| `DLQ_ENABLED`                 | `true`    | Enable the dead-letter queue                         |
+| `DLQ_MAX_AGE_MS`              | `604800000` (7d) | Dead-letter retention                         |
+
+**Jitter** spreads retries so a batch of jobs that failed together (e.g. a
+Horizon outage) don't all retry on the same tick — a thundering-herd guard. Jobs
+are enqueued with `backoff.type: 'custom'`; the worker resolves the delay via a
+registered `backoffStrategy` that applies exponential backoff **with** jitter.
+
+**Retention:** completed jobs are trimmed (age 1h / last 1000); failed jobs are
+kept for analysis; dead-lettered jobs are retained for `DLQ_MAX_AGE_MS`.
+
+### Dead-letter queue
+
+Permanently-failed and max-attempt-exhausted jobs are moved to
+`transaction-dead-letter-queue`, inspectable by admins via `/api/retry-queue`
+(see `retryQueueRoutes`). The MongoDB backend exposes the equivalent backlog
+(`status: dead_letter`) with list/inspect/re-drive helpers in `retryService`.
+
+### Metrics
+
+Exported on `/metrics` (Prometheus):
+
+- `queue_depth{queue}` — actionable jobs (waiting + active + delayed).
+- `queue_failed{queue}` — failed + dead-lettered jobs per queue.
+- `pending_verification_backlog{status}` — MongoDB-backend backlog depth.
+
+Alert on sustained growth of `queue_failed` or any `transaction-dead-letter`
+accumulation.


### PR DESCRIPTION
## Summary

Hardens the email and retry/Redis reliability surface across four related audit issues (Issues #80–#83 of the 2026-06-24 codebase audit).

Closes #869
Closes #870
Closes #871
Closes #872

---

### #869 — Email provider abstraction, retries, bounce handling, externalized templates
- New `services/email` module: **pluggable provider** factory (`smtp` / `ses` / `sendgrid` / `console`), each implementing `{ name, send, verify }`. AWS SES & SendGrid SDKs are lazy optional dependencies.
- `sendEmail()` checks the **suppression list** first, then sends with **exponential backoff + jitter** retries.
- **Suppression list** (`emailSuppressionModel` + `suppressionList.js`): a hard bounce/complaint blocks delivery **and** flips the student's `reminderOptOut` (feeds the #9 opt-out flow). Soft bounces are recorded but non-blocking.
- **Provider bounce/complaint webhooks** (`POST /api/email/webhooks/:provider` for SES/SendGrid, shared-secret protected) + admin suppression CRUD (`/api/email/suppressions`).
- **Externalized receipt templates** (`receiptEmail.{txt,html}`) + shared `templateRenderer` util. `emailService` / `notificationService` refactored to route through the module (reminder circuit-breaker semantics preserved).

**Acceptance:** ✅ Pluggable provider with retry/queue · ✅ bounce/complaint suppression honored · ✅ templates externalized and tested.

### #870 — Single retry contract across both backends
- `retryContract.js` is now the **single source of truth** for failure classification; both the BullMQ and MongoDB backends use it.
- **Shared contract test** runs identical cases against both backends and asserts they agree.
- **Loud `[CRITICAL]` startup warning** when the in-process MongoDB backend runs with `>1` replica.
- **Guarantee matrix** (durability, ordering, rate-limit scope) documented in `docs/retry-backends.md`.

**Acceptance:** ✅ One shared contract test against both backends · ✅ documented guarantee matrix · ✅ startup warns loudly for in-process backend with >1 replica.

### #871 — BullMQ worker concurrency, failure handling, dead-letter strategy
- Explicit worker options: `concurrency`, `lockDuration`, `stalledInterval`, `maxStalledCount`.
- Exponential backoff now applies **jitter** via a registered `backoffStrategy` (also resolves the previously-unhandled `custom` backoff type).
- `queue_failed{queue}` Prometheus metric exported (failed + dead-lettered jobs).
- Worker options, DLQ, and metrics documented.

**Acceptance:** ✅ worker options explicitly configured and documented · ✅ permanently-failed jobs land in an inspectable dead-letter queue · ✅ queue depth/failure metrics exported.

### #872 — Redis single-point-of-failure hardening
- Centralized `getRedisConnectionOptions()` shared by the queue, SSE pub/sub, and distributed lock — consistent backoff & transient-error handling everywhere.
- `docs/redis-dependency.md`: dependency surface, **per-consumer degradation modes** (locks fail-closed, SSE falls back to local), reconnection policy, and HA (Sentinel/Cluster) recommendation. `/health` already reports Redis status.

**Acceptance:** ✅ each Redis consumer has a defined degradation mode · ✅ `/health` reports Redis status · ✅ reconnection policy consistent and tested; HA documented.

---

## Tests
57 new tests across 4 suites, all passing:
- `emailService.test.js` — template rendering, suppression honored, retry/backoff, provider selection, webhook parsing
- `retryBackendContract.test.js` — shared classification run against both backends
- `retryQueueWorkerConfig.test.js` — worker options + backoff jitter bounds
- `redisReconnectionPolicy.test.js` — shared reconnection policy + replica detection

The only failing tests in the repo (`transactionPollingDistributedLock.test.js`) are **pre-existing on `main`** (`assetCode is not defined`) and unrelated to this change.

## Config added (all optional, backwards compatible)
`EMAIL_PROVIDER`, `SENDGRID_API_KEY`, `AWS_REGION`, `EMAIL_WEBHOOK_SECRET`, `EMAIL_MAX_RETRIES`, `EMAIL_RETRY_BASE_MS`, `EMAIL_RETRY_MAX_MS`, `RETRY_JITTER_RATIO`, `QUEUE_LOCK_DURATION_MS`, `QUEUE_STALLED_INTERVAL_MS`, `QUEUE_MAX_STALLED_COUNT`, `REPLICA_COUNT`.
