### PR TITLE
fix(stellar): cursor paging, failed-tx/issuer filtering, stroop-safe amounts (#839 #840 #841 #842)

### DIFF
--- a/backend/src/config/stellarConfig.js
+++ b/backend/src/config/stellarConfig.js
@@ -67,15 +67,42 @@ if (!configuredAsset) {
 const ACCEPTED_ASSETS = { [configuredAsset.code]: configuredAsset };
 
 /**
- * Check whether an asset (by code and type) is accepted by the system.
- * @param {string} assetCode  e.g. 'XLM', 'USDC'
- * @param {string} assetType  Stellar asset type string ('native', 'credit_alphanum4', …)
- * @returns {{ accepted: boolean, asset: object|null }}
+ * Check whether an asset (by code, type, and — for credit assets — issuer) is
+ * accepted by the system.
+ *
+ * Issuer validation (#841) is a security boundary, not a nicety: a non-native
+ * asset is only as trustworthy as its issuer. The asset code "USDC" is just a
+ * 4-character label that ANY account can mint. Without pinning the issuer, a
+ * worthless token coded "USDC" from an attacker's account would be credited at
+ * face value — direct financial fraud. So for credit assets we require the
+ * on-chain `asset_issuer` to exactly match the issuer pinned for the active
+ * network in config (Circle's canonical USDC issuer). Native XLM has no issuer
+ * and must not carry one.
+ *
+ * @param {string} assetCode    e.g. 'XLM', 'USDC'
+ * @param {string} assetType    Stellar asset type ('native', 'credit_alphanum4', …)
+ * @param {string|null} [assetIssuer]  on-chain issuer account (G...) for credit assets
+ * @returns {{ accepted: boolean, asset: object|null, reason?: string }}
  */
-function isAcceptedAsset(assetCode, assetType) {
+function isAcceptedAsset(assetCode, assetType, assetIssuer = null) {
   const asset = ACCEPTED_ASSETS[assetCode];
-  if (!asset) return { accepted: false, asset: null };
-  if (asset.type !== assetType) return { accepted: false, asset: null };
+  if (!asset) return { accepted: false, asset: null, reason: 'unsupported_code' };
+  if (asset.type !== assetType) return { accepted: false, asset: null, reason: 'type_mismatch' };
+
+  // Native asset (XLM): no issuer exists on-chain. Reject any spurious issuer.
+  if (asset.type === 'native') {
+    if (assetIssuer) return { accepted: false, asset: null, reason: 'unexpected_issuer' };
+    return { accepted: true, asset };
+  }
+
+  // Credit asset (e.g. USDC): the pinned issuer must be configured AND must
+  // exactly match the on-chain asset_issuer.
+  if (!asset.issuer) {
+    return { accepted: false, asset: null, reason: 'issuer_not_configured' };
+  }
+  if (assetIssuer !== asset.issuer) {
+    return { accepted: false, asset: null, reason: 'issuer_mismatch' };
+  }
   return { accepted: true, asset };
 }
 

--- a/backend/src/models/schoolModel.js
+++ b/backend/src/models/schoolModel.js
@@ -29,6 +29,15 @@ const schoolSchema = new mongoose.Schema(
     },
     network:        { type: String, enum: ['testnet', 'mainnet'], default: 'testnet' },
     isActive:       { type: Boolean, default: true, index: true },
+    /**
+     * Horizon paging cursor for the transaction poller (#839).
+     * Holds the `paging_token` of the most recently examined transaction for
+     * this school's wallet. The poller resumes ascending paging from this value
+     * each cycle, so it never re-scans history from genesis and never skips a
+     * transaction (gap-free, resumable). Null/unset = start from the oldest
+     * transaction on first run.
+     */
+    syncCursor:     { type: String, default: null },
     adminEmail:     { type: String, default: null },
     address:        { type: String, default: null },
     /**

--- a/backend/src/services/parsers/amountExtractor.js
+++ b/backend/src/services/parsers/amountExtractor.js
@@ -8,27 +8,22 @@
  */
 
 const { isAcceptedAsset } = require('../../config/stellarConfig');
+const { normalizeToNumber } = require('../../utils/stellarAmount');
 const logger = require('../../utils/logger').child('AmountExtractor');
 
 /**
- * Normalize Stellar amount to consistent decimal precision
+ * Normalize a raw Stellar amount to a number with exact 7-decimal precision.
+ * Delegates to the centralized stroop converter (#842) so all monetary
+ * normalization goes through one float-safe code path.
  * @param {string} rawAmount - Raw amount from Stellar API
  * @returns {number} Normalized amount with 7 decimal precision
  */
 function normalizeAmount(rawAmount) {
   if (!rawAmount) return 0;
-  
   try {
-    const parsed = parseFloat(rawAmount);
-    if (isNaN(parsed)) {
-      logger.warn('Invalid amount format', { rawAmount });
-      return 0;
-    }
-    
-    // Stellar uses 7 decimal places for precision
-    return parseFloat(parsed.toFixed(7));
+    return normalizeToNumber(rawAmount);
   } catch (error) {
-    logger.error('Error normalizing amount', { rawAmount, error: error.message });
+    logger.warn('Invalid amount format', { rawAmount, error: error.message });
     return 0;
   }
 }
@@ -208,10 +203,11 @@ function detectAsset(op) {
     const assetCode = assetType === 'native' ? 'XLM' : op.asset_code;
     const assetIssuer = assetType === 'native' ? null : op.asset_issuer;
 
-    // Check if asset is accepted by the system
-    const { accepted, asset } = isAcceptedAsset(assetCode, assetType);
+    // Check if asset is accepted by the system. Pass the issuer so credit
+    // assets (USDC) are validated against the pinned canonical issuer (#841).
+    const { accepted, asset } = isAcceptedAsset(assetCode, assetType, assetIssuer);
     if (!accepted) {
-      logger.debug('Unsupported asset', { assetCode, assetType, assetIssuer });
+      logger.debug('Unsupported or untrusted asset', { assetCode, assetType, assetIssuer });
       return null;
     }
 
@@ -239,7 +235,7 @@ function detectSourceAsset(op) {
     const sourceAssetCode = sourceAssetType === 'native' ? 'XLM' : op.source_asset_code;
     const sourceAssetIssuer = sourceAssetType === 'native' ? null : op.source_asset_issuer;
 
-    const { accepted, asset } = isAcceptedAsset(sourceAssetCode, sourceAssetType);
+    const { accepted, asset } = isAcceptedAsset(sourceAssetCode, sourceAssetType, sourceAssetIssuer);
     if (!accepted) {
       return null;
     }

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -11,17 +11,27 @@ const Payment = require("../models/paymentModel");
 const Student = require("../models/studentModel");
 const PaymentIntent = require("../models/paymentIntentModel");
 const { validatePaymentAmount } = require("../utils/paymentLimits");
+const { toStroops, stroopsToNumber, compareAmounts } = require("../utils/stellarAmount");
 const { withStellarRetry } = require("../utils/withStellarRetry");
 const { savePayment } = require("./transactionService");
 const { deriveCorrelationId } = require("../utils/correlationId");
-const { CONFIRMATION_STATES } = require("./paymentConfirmationStateMachine");
+const {
+  CONFIRMATION_STATES,
+  computeTargetState,
+  resolveNextState,
+  deriveLegacyConfirmationStatus,
+  isConfirmedOrAbove,
+} = require("./paymentConfirmationStateMachine");
 const logger = require("../utils/logger").child("StellarService");
 
 function detectAsset(payOp) {
   const assetType = payOp.asset_type;
   const assetCode = assetType === "native" ? "XLM" : payOp.asset_code;
   const assetIssuer = assetType === "native" ? null : payOp.asset_issuer;
-  const { accepted } = isAcceptedAsset(assetCode, assetType);
+  // Pass the issuer so credit assets (USDC) are validated against the pinned
+  // canonical issuer for the active network (#841). A fake "USDC" from any
+  // other issuer is rejected here.
+  const { accepted } = isAcceptedAsset(assetCode, assetType, assetIssuer);
   if (!accepted) return null;
   return { assetCode, assetType, assetIssuer };
 }
@@ -56,7 +66,11 @@ function normalizeAmount(rawAmount) {
  *   - MEMO_ID, MEMO_HASH, MEMO_RETURN: Unsupported types (UNSUPPORTED_MEMO_TYPE)
  */
 async function extractValidPayment(tx, walletAddress) {
-  if (!tx.successful) return null;
+  // #840 — A transaction can be included in a ledger yet have
+  // `successful === false` (e.g. a failed operation). Such transactions must
+  // NEVER be credited. Require an explicit success flag rather than merely
+  // truthy, so a failed-but-included tx (or one missing the flag) is rejected.
+  if (tx.successful !== true) return null;
 
   // Unwrap fee-bump transaction to get the inner transaction
   const innerTx = tx.inner_transaction || tx;
@@ -85,6 +99,9 @@ async function extractValidPayment(tx, walletAddress) {
   const ops = await withStellarRetry(() => innerTx.operations(), {
     label: "extractValidPayment.operations",
   });
+  // #840 — only a successful `payment` operation landing on the school wallet
+  // is creditable. detectAsset then enforces the asset/issuer (#841): a
+  // wrong-asset or fake-issuer operation yields null and is rejected here.
   const payOp = ops.records.find(
     (op) => op.type === "payment" && op.to === walletAddress,
   );
@@ -97,15 +114,21 @@ async function extractValidPayment(tx, walletAddress) {
 }
 
 function validatePaymentAgainstFee(paymentAmount, expectedFee) {
-  if (paymentAmount < expectedFee) {
+  // Compare in exact integer stroop space (#842). Float comparison of the paid
+  // amount vs the fee can mis-judge an exact-match payment as short/over by a
+  // rounding epsilon; stroop comparison is exact.
+  const paidStroops = toStroops(paymentAmount);
+  const feeStroops = toStroops(expectedFee);
+
+  if (paidStroops < feeStroops) {
     return {
       status: "underpaid",
       excessAmount: 0,
       message: `Payment of ${paymentAmount} is less than the required fee of ${expectedFee}`,
     };
   }
-  if (paymentAmount > expectedFee) {
-    const excess = parseFloat((paymentAmount - expectedFee).toFixed(7));
+  if (paidStroops > feeStroops) {
+    const excess = stroopsToNumber(paidStroops - feeStroops);
     return {
       status: "overpaid",
       excessAmount: excess,
@@ -676,14 +699,17 @@ async function syncPaymentsForSchool(school) {
 
       // Partial payments are accepted in the sync path — cumulative total determines status.
       // A single payment below the fee is recorded as 'partial' (credit toward remainingBalance).
+      // Compare in exact stroop space (#842) so an exact cumulative match is never
+      // mis-classified as partial/overpaid by a float rounding epsilon.
+      const cumulativeVsFee = compareAmounts(cumulativeTotal, student.feeAmount);
       let cumulativeStatus;
-      if (cumulativeTotal < student.feeAmount) cumulativeStatus = "partial";
-      else if (cumulativeTotal > student.feeAmount) cumulativeStatus = "overpaid";
+      if (cumulativeVsFee < 0) cumulativeStatus = "partial";
+      else if (cumulativeVsFee > 0) cumulativeStatus = "overpaid";
       else cumulativeStatus = "valid";
 
       const excessAmount =
         cumulativeStatus === "overpaid"
-          ? parseFloat((cumulativeTotal - student.feeAmount).toFixed(7))
+          ? stroopsToNumber(toStroops(cumulativeTotal) - toStroops(student.feeAmount))
           : 0;
 
       try {

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -8,6 +8,7 @@ const { server } = require('../config/stellarConfig');
 const { extractValidPayment, validatePaymentAgainstFee, detectMemoCollision, detectCrossSchoolMemoCollision, detectAbnormalPatterns, determineConfirmationState } = require('./stellarService');
 const { CONFIRMATION_STATES, isConfirmedOrAbove } = require('./paymentConfirmationStateMachine');
 const { validatePaymentAmount } = require('../utils/paymentLimits');
+const { compareAmounts, toStroops, stroopsToNumber, normalizeToNumber } = require('../utils/stellarAmount');
 const { generateReferenceCode } = require('../utils/generateReferenceCode');
 const { emit: sseEmit } = require('./sseService');
 const lock = require('./distributedLock');
@@ -25,6 +26,10 @@ const SYNC_INTERVAL_MS = config.SYNC_INTERVAL_MS;
 // TTL of the per-school distributed sync lock (crash-safety net).
 const SYNC_LOCK_TTL_MS = config.SYNC_LOCK_TTL_MS;
 const TRANSACTIONS_PER_POLL = 20;
+// Safety cap on how many pages a single poll cycle will drain for one school.
+// Bounds per-cycle work while letting a fresh school's history backfill across
+// cycles (default: up to 50 pages × 20 = 1000 tx/cycle). Configurable.
+const MAX_PAGES_PER_POLL = parseInt(process.env.SYNC_MAX_PAGES_PER_POLL || '50', 10);
 
 // Exponential backoff state — reset on first successful poll after errors.
 // POLL_MAX_BACKOFF_MS defaults to 5 minutes; configurable via env var.
@@ -56,7 +61,8 @@ async function processTransaction(tx, school) {
   }
 
   const { payOp, memo, asset } = valid;
-  const paymentAmount = parseFloat(payOp.amount);
+  // Exact stroop-based normalization (#842) — never parseFloat a monetary value.
+  const paymentAmount = normalizeToNumber(payOp.amount);
 
   // Validate payment amount is within configured limits
   const limitValidation = validatePaymentAmount(paymentAmount);
@@ -112,16 +118,19 @@ async function processTransaction(tx, school) {
     { $group: { _id: null, total: { $sum: '$amount' } } },
   ]);
   const previousTotal = previousPayments.length ? previousPayments[0].total : 0;
-  const cumulativeTotal = parseFloat((previousTotal + paymentAmount).toFixed(7));
-  const remaining = parseFloat((student.feeAmount - cumulativeTotal).toFixed(7));
+  // Sum/diff in exact stroop space (#842) so an exact cumulative match is never
+  // mis-flagged as underpaid/overpaid by a float rounding epsilon.
+  const cumulativeTotal = stroopsToNumber(toStroops(previousTotal) + toStroops(paymentAmount));
+  const remaining = stroopsToNumber(toStroops(student.feeAmount) - toStroops(cumulativeTotal));
 
+  const cumulativeVsFee = compareAmounts(cumulativeTotal, student.feeAmount);
   let cumulativeStatus;
-  if (cumulativeTotal < student.feeAmount) cumulativeStatus = 'underpaid';
-  else if (cumulativeTotal > student.feeAmount) cumulativeStatus = 'overpaid';
+  if (cumulativeVsFee < 0) cumulativeStatus = 'underpaid';
+  else if (cumulativeVsFee > 0) cumulativeStatus = 'overpaid';
   else cumulativeStatus = 'valid';
 
   const excessAmount = cumulativeStatus === 'overpaid'
-    ? parseFloat((cumulativeTotal - student.feeAmount).toFixed(7))
+    ? stroopsToNumber(toStroops(cumulativeTotal) - toStroops(student.feeAmount))
     : 0;
 
   const feeValidation = validatePaymentAgainstFee(paymentAmount, student.feeAmount);
@@ -213,6 +222,26 @@ async function processTransaction(tx, school) {
 /**
  * Poll transactions for a single school.
  *
+ * Cursor management (#839): the poller persists a per-school Horizon
+ * `paging_token` cursor (`school.syncCursor`) and resumes ASCENDING paging from
+ * it every cycle. This is the key to being both gap-free and efficient:
+ *   - Ascending order from the saved cursor means we always move forward and
+ *     never skip a transaction (no missed payments).
+ *   - Persisting the cursor means we never replay history from genesis on each
+ *     cycle (no unbounded re-scans / excess Horizon load). A fresh school with
+ *     no cursor starts from the oldest transaction and backfills across cycles,
+ *     bounded by MAX_PAGES_PER_POLL per cycle.
+ * The cursor is advanced over EVERY examined transaction (processed or skipped)
+ * and persisted after each page, so a crash mid-cycle resumes correctly without
+ * gaps or rescans.
+ *
+ * Horizon 429 / errors: any Horizon failure (including HTTP 429 rate limiting)
+ * throws out of the page fetch and is reported as `horizonError`, which drives
+ * the cycle-level exponential backoff in pollAllSchools. Because the cursor is
+ * only advanced for transactions we actually examined and persisted, a 429
+ * mid-cycle never skips transactions — the next cycle resumes from the last
+ * persisted token.
+ *
  * Wrapped in a per-school distributed lock (Redis SET NX PX) so that, across
  * horizontally-scaled replicas or an overlapping slow poll, only one worker
  * syncs a given school at a time. If the lock is already held the cycle is
@@ -230,24 +259,47 @@ async function pollSchoolTransactions(school) {
     return { schoolId: school.schoolId, processed: 0, skipped: 0, lockSkipped: true };
   }
 
+  let cursor = school.syncCursor || null;
+  const startCursor = cursor;
+  let processedCount = 0;
+  let skippedCount = 0;
+
   try {
-    const transactions = await server
-      .transactions()
-      .forAccount(school.stellarAddress)
-      .order('desc')
-      .limit(TRANSACTIONS_PER_POLL)
-      .call();
+    for (let pages = 0; pages < MAX_PAGES_PER_POLL; pages++) {
+      let builder = server
+        .transactions()
+        .forAccount(school.stellarAddress)
+        .order('asc')
+        .limit(TRANSACTIONS_PER_POLL);
+      // Resume from the persisted cursor; omit on first-ever run so Horizon
+      // returns from the oldest transaction.
+      if (cursor) builder = builder.cursor(cursor);
 
-    let processedCount = 0;
-    let skippedCount = 0;
+      const page = await builder.call();
+      const records = (page && page.records) || [];
+      if (records.length === 0) break;
 
-    for (const tx of transactions.records) {
-      const result = await processTransaction(tx, school);
-      if (result.processed) {
-        processedCount++;
-      } else {
-        skippedCount++;
+      for (const tx of records) {
+        const result = await processTransaction(tx, school);
+        if (result.processed) {
+          processedCount++;
+        } else {
+          skippedCount++;
+        }
+        // Advance past every examined tx — we never need to re-read it. Reorg /
+        // confirmation promotion is handled separately by finalizeConfirmedPayments.
+        if (tx.paging_token) cursor = tx.paging_token;
       }
+
+      // Persist the cursor after each page so a crash resumes without gaps/rescans.
+      if (cursor && cursor !== startCursor) {
+        await School.updateOne(
+          { schoolId: school.schoolId },
+          { $set: { syncCursor: cursor } },
+        );
+      }
+
+      if (records.length < TRANSACTIONS_PER_POLL) break; // drained this cycle
     }
 
     if (processedCount > 0) {
@@ -255,16 +307,20 @@ async function pollSchoolTransactions(school) {
         schoolId: school.schoolId,
         processed: processedCount,
         skipped: skippedCount,
+        cursor,
       });
     }
 
-    return { schoolId: school.schoolId, processed: processedCount, skipped: skippedCount };
+    return { schoolId: school.schoolId, processed: processedCount, skipped: skippedCount, cursor };
   } catch (error) {
+    const status = error.response?.status || error.status || error.statusCode;
     logger.error('Error polling school transactions', {
       schoolId: school.schoolId,
       error: error.message,
+      status,
+      rateLimited: status === 429,
     });
-    return { schoolId: school.schoolId, error: error.message, horizonError: true };
+    return { schoolId: school.schoolId, error: error.message, horizonError: true, status };
   } finally {
     await lock.release(lockKey, token);
   }

--- a/backend/src/utils/stellarAmount.js
+++ b/backend/src/utils/stellarAmount.js
@@ -1,0 +1,124 @@
+'use strict';
+
+/**
+ * Stellar amount utilities — exact, float-safe monetary math (#842).
+ *
+ * Stellar represents every amount as a signed 64-bit integer count of
+ * "stroops", where 1 unit (XLM or USDC — both use 7 decimal places) = 10,000,000
+ * stroops. Horizon hands amounts back as decimal strings (e.g. "100.0000000").
+ *
+ * Doing arithmetic or comparisons on these as JS floats (parseFloat / toFixed)
+ * risks off-by-epsilon errors: a payment that exactly equals the required fee
+ * can be judged short or over by a rounding artifact. This module is the single
+ * canonical place that converts to/from integer stroops (as BigInt) and compares
+ * amounts in stroop space, so monetary decisions are always exact.
+ */
+
+const DECIMALS = 7;
+const STROOPS_PER_UNIT = 10000000n; // 1e7
+
+/**
+ * Convert a decimal amount (string from Horizon or a JS number) to an exact
+ * integer number of stroops as a BigInt. Fractional digits beyond 7 are rounded
+ * half-up, matching Stellar's own precision rules.
+ *
+ * @param {string|number|bigint} amount
+ * @returns {bigint} stroops
+ */
+function toStroops(amount) {
+  if (typeof amount === 'bigint') return amount;
+  if (amount === null || amount === undefined || amount === '') {
+    throw new TypeError(`Cannot convert ${amount} to stroops`);
+  }
+
+  // Use a fixed-point string so we never depend on float arithmetic. For a JS
+  // number, toFixed gives a decimal string already rounded to 7 places.
+  let str = typeof amount === 'number' ? amount.toFixed(DECIMALS) : String(amount).trim();
+
+  const negative = str.startsWith('-');
+  if (negative) str = str.slice(1);
+
+  if (!/^\d*(\.\d*)?$/.test(str) || str === '' || str === '.') {
+    throw new TypeError(`Invalid amount for stroop conversion: ${amount}`);
+  }
+
+  const [intPart = '0', fracRaw = ''] = str.split('.');
+  const frac = (fracRaw + '0'.repeat(DECIMALS)).slice(0, DECIMALS);
+
+  let stroops = BigInt(intPart || '0') * STROOPS_PER_UNIT + BigInt(frac || '0');
+
+  // Round half-up if there are more than 7 fractional digits.
+  if (fracRaw.length > DECIMALS && Number(fracRaw[DECIMALS]) >= 5) {
+    stroops += 1n;
+  }
+
+  return negative ? -stroops : stroops;
+}
+
+/**
+ * Convert integer stroops back to a 7-decimal-place decimal string.
+ * @param {bigint|number|string} stroops
+ * @returns {string}
+ */
+function fromStroops(stroops) {
+  const b = BigInt(stroops);
+  const negative = b < 0n;
+  const abs = negative ? -b : b;
+  const intPart = abs / STROOPS_PER_UNIT;
+  const frac = (abs % STROOPS_PER_UNIT).toString().padStart(DECIMALS, '0');
+  return `${negative ? '-' : ''}${intPart}.${frac}`;
+}
+
+/**
+ * Convert integer stroops to a JS number (7-decimal precision). Safe for the
+ * full Stellar range when used for display/storage; comparisons should prefer
+ * compareAmounts so they stay in exact stroop space.
+ * @param {bigint|number|string} stroops
+ * @returns {number}
+ */
+function stroopsToNumber(stroops) {
+  return parseFloat(fromStroops(stroops));
+}
+
+/**
+ * Compare two decimal amounts exactly in stroop space.
+ * @returns {number} -1 if a < b, 0 if equal, 1 if a > b
+ */
+function compareAmounts(a, b) {
+  const sa = toStroops(a);
+  const sb = toStroops(b);
+  if (sa < sb) return -1;
+  if (sa > sb) return 1;
+  return 0;
+}
+
+/** True iff the two amounts are exactly equal to the stroop. */
+function amountsEqual(a, b) {
+  return compareAmounts(a, b) === 0;
+}
+
+/**
+ * Normalize a raw Horizon amount to a JS number using exact stroop conversion.
+ * Drop-in replacement for the old parseFloat/toFixed-based normalizer.
+ * @param {string|number} rawAmount
+ * @returns {number}
+ */
+function normalizeToNumber(rawAmount) {
+  if (rawAmount === null || rawAmount === undefined || rawAmount === '') return 0;
+  try {
+    return stroopsToNumber(toStroops(rawAmount));
+  } catch (_) {
+    return 0;
+  }
+}
+
+module.exports = {
+  DECIMALS,
+  STROOPS_PER_UNIT,
+  toStroops,
+  fromStroops,
+  stroopsToNumber,
+  compareAmounts,
+  amountsEqual,
+  normalizeToNumber,
+};

--- a/tests/extractValidPaymentReorgAsset.test.js
+++ b/tests/extractValidPaymentReorgAsset.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+/**
+ * #840 — Reorg / failed-transaction handling distinct from successful ledger
+ *        inclusion, plus #841 wrong-asset rejection in the credit path.
+ *
+ * A Stellar transaction can be included in a ledger yet have
+ * `successful === false`. Such a transaction must never be credited. Likewise a
+ * payment carrying a USDC-coded asset from the wrong issuer must be rejected.
+ * These tests drive extractValidPayment against fixtures for: a failed-but-
+ * included tx, a wrong-issuer USDC tx, a wrong-destination tx, and the happy
+ * path — asserting only a successful payment to the wallet with the pinned
+ * asset is accepted.
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.JWT_SECRET = 'test-jwt-secret-for-extract-valid-payment-suite-1234567890';
+
+const WALLET = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+const USDC_GOOD = 'GBUSDCGOODISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const USDC_BAD = 'GBUSDCBADISSUERBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+// Mock stellarConfig so we control the pinned USDC issuer and accepted asset
+// without loading the real SDK/network layer.
+jest.mock('../backend/src/config/stellarConfig', () => ({
+  server: {},
+  CONFIRMATION_THRESHOLD: 2,
+  FINALIZATION_THRESHOLD: 10,
+  ACCEPTED_ASSETS: {
+    USDC: { code: 'USDC', type: 'credit_alphanum4', issuer: 'GBUSDCGOODISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' },
+  },
+  // Real-shaped issuer validation: USDC only from the pinned good issuer.
+  isAcceptedAsset: (code, type, issuer) => {
+    if (code !== 'USDC' || type !== 'credit_alphanum4') return { accepted: false, asset: null };
+    if (issuer !== 'GBUSDCGOODISSUERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA') {
+      return { accepted: false, asset: null, reason: 'issuer_mismatch' };
+    }
+    return { accepted: true, asset: { code, type } };
+  },
+}));
+
+// @stellar/stellar-sdk's Operation is only used by normalizeAmount; stub it.
+jest.mock('@stellar/stellar-sdk', () => ({
+  Operation: { _fromXDRAmount: (s) => (parseInt(s, 10) / 1e7).toFixed(7) },
+}), { virtual: true });
+
+jest.mock('../backend/src/models/paymentModel', () => ({ findOne: jest.fn() }));
+jest.mock('../backend/src/models/studentModel', () => ({ findOne: jest.fn() }));
+jest.mock('../backend/src/models/paymentIntentModel', () => ({ findOne: jest.fn() }));
+jest.mock('../backend/src/services/transactionService', () => ({ savePayment: jest.fn() }));
+jest.mock('../backend/src/utils/withStellarRetry', () => ({
+  withStellarRetry: (fn) => fn(),
+  classifyHorizonError: (e) => e,
+}));
+
+const { extractValidPayment } = require('../backend/src/services/stellarService');
+
+function makeTx({ successful = true, memoType = 'text', memo = 'STU001', ops = [] }) {
+  return {
+    hash: 'TXHASH',
+    successful,
+    memo_type: memoType,
+    memo,
+    operations: async () => ({ records: ops }),
+  };
+}
+
+const goodOp = {
+  type: 'payment',
+  to: WALLET,
+  from: 'GSENDER',
+  amount: '100.0000000',
+  asset_type: 'credit_alphanum4',
+  asset_code: 'USDC',
+  asset_issuer: USDC_GOOD,
+};
+
+describe('extractValidPayment — failed-tx & asset validation (#840/#841)', () => {
+  test('rejects a failed-but-included transaction (successful=false)', async () => {
+    const tx = makeTx({ successful: false, ops: [goodOp] });
+    expect(await extractValidPayment(tx, WALLET)).toBeNull();
+  });
+
+  test('rejects a transaction missing the success flag', async () => {
+    const tx = makeTx({ ops: [goodOp] });
+    delete tx.successful; // successful === undefined
+    expect(await extractValidPayment(tx, WALLET)).toBeNull();
+  });
+
+  test('rejects USDC from a non-canonical issuer (fake token)', async () => {
+    const tx = makeTx({ ops: [{ ...goodOp, asset_issuer: USDC_BAD }] });
+    expect(await extractValidPayment(tx, WALLET)).toBeNull();
+  });
+
+  test('rejects a payment to the wrong destination', async () => {
+    const tx = makeTx({ ops: [{ ...goodOp, to: 'GSOMEONEELSE' }] });
+    expect(await extractValidPayment(tx, WALLET)).toBeNull();
+  });
+
+  test('rejects a non-payment operation (e.g. create_account)', async () => {
+    const tx = makeTx({ ops: [{ type: 'create_account', to: WALLET, asset_type: 'native' }] });
+    expect(await extractValidPayment(tx, WALLET)).toBeNull();
+  });
+
+  test('accepts a successful payment to the wallet with the pinned asset', async () => {
+    const tx = makeTx({ ops: [goodOp] });
+    const valid = await extractValidPayment(tx, WALLET);
+    expect(valid).not.toBeNull();
+    expect(valid.memo).toBe('STU001');
+    expect(valid.asset.assetCode).toBe('USDC');
+    expect(valid.asset.assetIssuer).toBe(USDC_GOOD);
+  });
+});

--- a/tests/stellarAmountStroops.test.js
+++ b/tests/stellarAmountStroops.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+/**
+ * #842 — Amount/precision handling for Stellar (7-decimal stroops).
+ *
+ * Stellar amounts are exact integers in stroops (1 unit = 1e7 stroops). These
+ * tests assert the centralized stroop utility is exact and, critically, that an
+ * amount exactly equal to a fee is NEVER judged short/over by a float epsilon
+ * (the headline acceptance criterion), including over a large property sweep.
+ */
+
+const {
+  toStroops,
+  fromStroops,
+  stroopsToNumber,
+  compareAmounts,
+  amountsEqual,
+  normalizeToNumber,
+  STROOPS_PER_UNIT,
+} = require('../backend/src/utils/stellarAmount');
+
+describe('stellarAmount — toStroops / fromStroops', () => {
+  test('whole numbers', () => {
+    expect(toStroops('200')).toBe(2000000000n);
+    expect(toStroops(200)).toBe(2000000000n);
+  });
+
+  test('Horizon-style 7-decimal strings', () => {
+    expect(toStroops('100.0000000')).toBe(1000000000n);
+    expect(toStroops('0.0000001')).toBe(1n); // 1 stroop, the minimum
+  });
+
+  test('rounds half-up beyond 7 decimals', () => {
+    expect(toStroops('100.123456789')).toBe(1001234568n); // ...567|89 -> rounds up
+    expect(toStroops('0.00000004')).toBe(0n);             // below half-stroop -> down
+    expect(toStroops('0.00000005')).toBe(1n);             // exactly half -> up
+  });
+
+  test('round-trips exactly — even where float toFixed is lossy', () => {
+    for (const v of ['0.0000001', '1.2345678', '100.0000000', '922337203685.4775807', '0.0000000']) {
+      expect(fromStroops(toStroops(v))).toBe(v);
+    }
+    // The max int64 amount is NOT exactly representable as a JS float — this
+    // precision loss is precisely why monetary math must use integer stroops (#842).
+    expect(Number('922337203685.4775807').toFixed(7)).not.toBe('922337203685.4775807');
+    expect(fromStroops(toStroops('922337203685.4775807'))).toBe('922337203685.4775807');
+  });
+
+  test('throws on garbage input', () => {
+    expect(() => toStroops('abc')).toThrow();
+    expect(() => toStroops(null)).toThrow();
+    expect(() => toStroops(undefined)).toThrow();
+  });
+});
+
+describe('stellarAmount — float traps are exact in stroop space', () => {
+  test('0.1 + 0.2 (float) equals 0.3 in stroops', () => {
+    // 0.1 + 0.2 === 0.30000000000000004 as a float; in stroops both are 3,000,000.
+    expect(amountsEqual(0.1 + 0.2, '0.3')).toBe(true);
+    expect(compareAmounts(0.1 + 0.2, 0.3)).toBe(0);
+  });
+
+  test('an exactly-equal payment vs fee compares equal', () => {
+    expect(compareAmounts('250.0000000', 250)).toBe(0);
+    expect(compareAmounts(250, '250')).toBe(0);
+  });
+
+  test('normalizeToNumber matches a clean parse but is float-safe', () => {
+    expect(normalizeToNumber('100.1234568')).toBe(100.1234568);
+    expect(normalizeToNumber('')).toBe(0);
+    expect(normalizeToNumber(null)).toBe(0);
+  });
+});
+
+describe('stellarAmount — property sweep over many amounts (#842)', () => {
+  test('toStroops↔fromStroops round-trip + exact-equality never mis-flags', () => {
+    let checked = 0;
+    for (let i = 0; i < 5000; i++) {
+      const stroops = BigInt(Math.floor(Math.random() * Number(STROOPS_PER_UNIT) * 100000));
+      const decimal = fromStroops(stroops);
+
+      // Round-trip is exact.
+      expect(toStroops(decimal)).toBe(stroops);
+
+      // A payment built from the same stroop count is ALWAYS judged equal —
+      // never short or over by a rounding epsilon.
+      const feeNumber = stroopsToNumber(stroops);
+      expect(compareAmounts(decimal, feeNumber)).toBe(0);
+      expect(amountsEqual(decimal, feeNumber)).toBe(true);
+
+      // One stroop more is strictly greater; one stroop less strictly smaller.
+      expect(compareAmounts(fromStroops(stroops + 1n), decimal)).toBe(1);
+      if (stroops > 0n) {
+        expect(compareAmounts(fromStroops(stroops - 1n), decimal)).toBe(-1);
+      }
+      checked++;
+    }
+    expect(checked).toBe(5000);
+  });
+});

--- a/tests/transactionPollingCursor.test.js
+++ b/tests/transactionPollingCursor.test.js
@@ -1,0 +1,192 @@
+'use strict';
+
+/**
+ * #839 — Horizon cursor management & pagination correctness for the poller.
+ *
+ * Asserts the poller:
+ *   - resumes ASCENDING paging from the persisted per-school cursor,
+ *   - persists the advancing cursor (last examined paging_token) each cycle,
+ *   - never re-scans from genesis once a cursor exists (no full rescans),
+ *   - processes every record in a page in order (gap-free), and
+ *   - on a Horizon 429 surfaces a horizonError WITHOUT advancing the cursor,
+ *     so the next cycle resumes safely (and the cycle backs off).
+ */
+
+process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+process.env.POLL_INTERVAL_MS = '30000';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+jest.mock('mongoose', () => ({
+  connect: jest.fn().mockResolvedValue(true),
+  Schema: class { constructor() { this.index = jest.fn(); } },
+  model: jest.fn().mockReturnValue({}),
+  connection: { startSession: jest.fn() },
+}));
+
+// Configurable Horizon server mock that records each call's order + cursor and
+// returns queued pages. (`mock`-prefixed so jest.mock may reference them.)
+const mockCallLog = [];
+let mockPageQueue = [];
+let mockFailNext = null; // error to throw on next call, or null
+
+jest.mock('../backend/src/config/stellarConfig', () => ({
+  server: {
+    transactions: () => ({
+      forAccount: () => {
+        const state = {};
+        const builder = {
+          order: (o) => { state.order = o; return builder; },
+          limit: (n) => { state.limit = n; return builder; },
+          cursor: (c) => { state.cursor = c; return builder; },
+          call: async () => {
+            mockCallLog.push({ order: state.order, cursor: state.cursor, limit: state.limit });
+            if (mockFailNext) { const e = mockFailNext; mockFailNext = null; throw e; }
+            return mockPageQueue.shift() || { records: [] };
+          },
+        };
+        return builder;
+      },
+    }),
+  },
+}));
+
+jest.mock('../backend/src/models/schoolModel', () => ({
+  find: jest.fn(),
+  updateOne: jest.fn().mockResolvedValue({ acknowledged: true }),
+}));
+jest.mock('../backend/src/models/paymentModel', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  aggregate: jest.fn().mockResolvedValue([]),
+  create: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/models/studentModel', () => ({
+  findOne: jest.fn().mockResolvedValue(null),
+  findOneAndUpdate: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../backend/src/services/stellarService', () => ({
+  extractValidPayment: jest.fn().mockResolvedValue(null), // skip path — exercises cursor only
+  validatePaymentAgainstFee: jest.fn().mockReturnValue({ status: 'valid' }),
+  detectMemoCollision: jest.fn().mockResolvedValue({ suspicious: false }),
+  detectCrossSchoolMemoCollision: jest.fn().mockResolvedValue({ suspicious: false }),
+  detectAbnormalPatterns: jest.fn().mockResolvedValue({ suspicious: false }),
+  checkConfirmationStatus: jest.fn().mockResolvedValue(true),
+  determineConfirmationState: jest.fn().mockResolvedValue({
+    state: 'confirmed', changed: true, confirmationStatus: 'confirmed', latestLedgerSequence: 1,
+  }),
+}));
+jest.mock('../backend/src/services/sseService', () => ({ emit: jest.fn() }));
+jest.mock('../backend/src/services/distributedLock', () => ({
+  acquire: jest.fn().mockResolvedValue('lock-token'),
+  release: jest.fn().mockResolvedValue(true),
+}));
+jest.mock('../backend/src/utils/paymentLimits', () => ({
+  validatePaymentAmount: jest.fn().mockReturnValue({ valid: true }),
+}));
+jest.mock('../backend/src/utils/generateReferenceCode', () => ({
+  generateReferenceCode: jest.fn().mockResolvedValue('REF001'),
+}));
+jest.mock('../backend/src/utils/logger', () => ({
+  child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+
+const School = require('../backend/src/models/schoolModel');
+const lock = require('../backend/src/services/distributedLock');
+const {
+  pollSchoolTransactions,
+  pollAllSchools,
+  _getBackoffState,
+  _resetBackoffState,
+} = require('../backend/src/services/transactionPollingService');
+
+const ADDRESS = 'GTEST_WALLET_ADDRESS';
+const rec = (token) => ({ hash: `tx_${token}`, paging_token: token, created_at: '2026-01-01T00:00:00Z' });
+
+beforeEach(() => {
+  _resetBackoffState();
+  jest.clearAllMocks();
+  mockCallLog.length = 0;
+  mockPageQueue = [];
+  mockFailNext = null;
+  lock.acquire.mockResolvedValue('lock-token');
+});
+
+describe('poller cursor management (#839)', () => {
+  test('first run (no cursor) pages ascending from the oldest and persists the last token', async () => {
+    mockPageQueue = [{ records: [rec('1'), rec('2'), rec('3')] }];
+    const school = { schoolId: 'SCH001', stellarAddress: ADDRESS };
+
+    const result = await pollSchoolTransactions(school);
+
+    // Ascending order, no cursor passed on the first-ever call.
+    expect(mockCallLog[0].order).toBe('asc');
+    expect(mockCallLog[0].cursor).toBeUndefined();
+    // Every record examined (gap-free); cursor advanced to the last token.
+    expect(result.skipped).toBe(3);
+    expect(result.cursor).toBe('3');
+    expect(School.updateOne).toHaveBeenCalledWith(
+      { schoolId: 'SCH001' },
+      { $set: { syncCursor: '3' } },
+    );
+  });
+
+  test('resumes from the persisted cursor — no full-history rescan', async () => {
+    mockPageQueue = [{ records: [rec('11'), rec('12')] }];
+    const school = { schoolId: 'SCH001', stellarAddress: ADDRESS, syncCursor: '10' };
+
+    await pollSchoolTransactions(school);
+
+    expect(mockCallLog[0].cursor).toBe('10'); // resumed, not from genesis
+    expect(mockCallLog[0].order).toBe('asc');
+    expect(School.updateOne).toHaveBeenCalledWith(
+      { schoolId: 'SCH001' },
+      { $set: { syncCursor: '12' } },
+    );
+  });
+
+  test('drains multiple pages within a cycle until a short page is returned', async () => {
+    // A full page (== limit) forces another fetch; the short page ends the cycle.
+    const full = Array.from({ length: 20 }, (_, i) => rec(`p1_${i}`));
+    mockPageQueue = [{ records: full }, { records: [rec('p2_0')] }];
+    const school = { schoolId: 'SCH001', stellarAddress: ADDRESS };
+
+    const result = await pollSchoolTransactions(school);
+
+    expect(mockCallLog.length).toBe(2);
+    expect(mockCallLog[1].cursor).toBe('p1_19'); // second fetch resumes after the full page
+    expect(result.cursor).toBe('p2_0');
+  });
+
+  test('a 429 surfaces horizonError and does NOT advance the cursor', async () => {
+    mockFailNext = Object.assign(new Error('Too Many Requests'), { status: 429 });
+    const school = { schoolId: 'SCH001', stellarAddress: ADDRESS, syncCursor: '5' };
+
+    const result = await pollSchoolTransactions(school);
+
+    expect(result.horizonError).toBe(true);
+    expect(result.status).toBe(429);
+    expect(School.updateOne).not.toHaveBeenCalled(); // cursor untouched → safe resume
+    expect(lock.release).toHaveBeenCalled();         // lock always released
+  });
+
+  test('a 429 in a cycle triggers exponential backoff', async () => {
+    School.find.mockResolvedValue([{ schoolId: 'SCH001', stellarAddress: ADDRESS }]);
+    mockFailNext = Object.assign(new Error('Too Many Requests'), { status: 429 });
+
+    await pollAllSchools();
+
+    const { consecutiveErrors, currentIntervalMs } = _getBackoffState();
+    expect(consecutiveErrors).toBe(1);
+    expect(currentIntervalMs).toBe(30000 * 2);
+  });
+
+  test('lock contention skips the school without touching the cursor', async () => {
+    lock.acquire.mockResolvedValueOnce(null);
+    const school = { schoolId: 'SCH001', stellarAddress: ADDRESS, syncCursor: '5' };
+
+    const result = await pollSchoolTransactions(school);
+
+    expect(result.lockSkipped).toBe(true);
+    expect(mockCallLog.length).toBe(0);
+    expect(School.updateOne).not.toHaveBeenCalled();
+  });
+});

--- a/tests/usdcIssuerValidation.test.js
+++ b/tests/usdcIssuerValidation.test.js
@@ -1,0 +1,87 @@
+'use strict';
+
+/**
+ * #841 — USDC asset issuer / trustline validation.
+ *
+ * The asset code "USDC" is just a label any account can mint. Crediting it
+ * without pinning the issuer would let an attacker "pay" fees with a worthless
+ * look-alike token. These tests load the REAL stellarConfig (with USDC as the
+ * accepted asset) and assert isAcceptedAsset only accepts USDC from the pinned
+ * canonical issuer for the active network, rejects every other issuer, and that
+ * the pinned issuer differs correctly between testnet and mainnet.
+ */
+
+const TESTNET_USDC = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+const MAINNET_USDC = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+const ATTACKER_ISSUER = 'GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ';
+
+function loadConfig({ network, acceptedAsset = 'USDC', usdcIssuer } = {}) {
+  jest.resetModules();
+  process.env.MONGO_URI = 'mongodb://localhost:27017/test';
+  process.env.JWT_SECRET = 'test-jwt-secret-for-usdc-issuer-suite-1234567890';
+  process.env.STELLAR_NETWORK = network || 'testnet';
+  process.env.ACCEPTED_ASSET = acceptedAsset;
+  if (usdcIssuer === undefined) delete process.env.USDC_ISSUER;
+  else process.env.USDC_ISSUER = usdcIssuer;
+  return require('../backend/src/config/stellarConfig');
+}
+
+afterEach(() => {
+  jest.resetModules();
+  delete process.env.STELLAR_NETWORK;
+  delete process.env.ACCEPTED_ASSET;
+  delete process.env.USDC_ISSUER;
+});
+
+describe('isAcceptedAsset — USDC issuer pinning (#841)', () => {
+  test('accepts USDC ONLY from the pinned testnet issuer', () => {
+    const { isAcceptedAsset } = loadConfig({ network: 'testnet' });
+
+    const ok = isAcceptedAsset('USDC', 'credit_alphanum4', TESTNET_USDC);
+    expect(ok.accepted).toBe(true);
+  });
+
+  test('rejects a USDC-coded asset from a non-canonical issuer (fraud vector)', () => {
+    const { isAcceptedAsset } = loadConfig({ network: 'testnet' });
+
+    const attacker = isAcceptedAsset('USDC', 'credit_alphanum4', ATTACKER_ISSUER);
+    expect(attacker.accepted).toBe(false);
+    expect(attacker.reason).toBe('issuer_mismatch');
+
+    // Even the mainnet issuer is wrong on testnet.
+    expect(isAcceptedAsset('USDC', 'credit_alphanum4', MAINNET_USDC).accepted).toBe(false);
+  });
+
+  test('rejects USDC with a missing/empty issuer', () => {
+    const { isAcceptedAsset } = loadConfig({ network: 'testnet' });
+    expect(isAcceptedAsset('USDC', 'credit_alphanum4', null).accepted).toBe(false);
+    expect(isAcceptedAsset('USDC', 'credit_alphanum4').accepted).toBe(false);
+    expect(isAcceptedAsset('USDC', 'credit_alphanum4', '').accepted).toBe(false);
+  });
+
+  test('config differs correctly for testnet vs mainnet', () => {
+    const testnet = loadConfig({ network: 'testnet' });
+    expect(testnet.isAcceptedAsset('USDC', 'credit_alphanum4', TESTNET_USDC).accepted).toBe(true);
+    expect(testnet.isAcceptedAsset('USDC', 'credit_alphanum4', MAINNET_USDC).accepted).toBe(false);
+
+    const mainnet = loadConfig({ network: 'mainnet' });
+    expect(mainnet.isAcceptedAsset('USDC', 'credit_alphanum4', MAINNET_USDC).accepted).toBe(true);
+    expect(mainnet.isAcceptedAsset('USDC', 'credit_alphanum4', TESTNET_USDC).accepted).toBe(false);
+  });
+
+  test('honors an explicit USDC_ISSUER override', () => {
+    const { isAcceptedAsset } = loadConfig({ network: 'mainnet', usdcIssuer: ATTACKER_ISSUER });
+    // With the override pinned, only that issuer is accepted.
+    expect(isAcceptedAsset('USDC', 'credit_alphanum4', ATTACKER_ISSUER).accepted).toBe(true);
+    expect(isAcceptedAsset('USDC', 'credit_alphanum4', MAINNET_USDC).accepted).toBe(false);
+  });
+});
+
+describe('isAcceptedAsset — native XLM has no issuer', () => {
+  test('accepts native XLM with no issuer, rejects a spurious one', () => {
+    const { isAcceptedAsset } = loadConfig({ network: 'testnet', acceptedAsset: 'XLM' });
+    expect(isAcceptedAsset('XLM', 'native', null).accepted).toBe(true);
+    expect(isAcceptedAsset('XLM', 'native').accepted).toBe(true);
+    expect(isAcceptedAsset('XLM', 'native', ATTACKER_ISSUER).accepted).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the Stellar payment ingestion path across four audit issues (data integrity + one security-critical). All changes are additive/behavior-preserving on the happy path and covered by new tests.

Closes #839
Closes #840
Closes #841
Closes #842

## #841 — USDC asset issuer validation (security, critical)
`isAcceptedAsset(code, type, issuer)` now pins the issuer. Credit assets (USDC) must match the canonical issuer for the active network; native XLM must carry no issuer. A worthless token coded `USDC` from any other issuer is **rejected** instead of credited at face value. The on-chain `asset_issuer` is threaded through `detectAsset` in both `stellarService` and the `amountExtractor` parser.

- ✅ USDC validated against the pinned issuer
- ✅ Non-canonical issuers rejected
- ✅ Config differs correctly for testnet vs mainnet

## #840 — Failed-tx / wrong-asset filtering
`extractValidPayment` now requires `tx.successful === true` (rejects failed-but-included transactions) and only credits a `payment` operation to the school wallet carrying a valid pinned asset.

- ✅ Only successful payment operations are credited
- ✅ USDC issuer verified against config
- ✅ Failed / wrong-asset fixtures asserted as rejected

## #842 — Stroop / float-safety
New `backend/src/utils/stellarAmount.js` performs exact integer-stroop (BigInt) conversion and comparison. `validatePaymentAgainstFee` and the cumulative under/over/valid checks now compare in **stroop space**, so an exact payment can never be mis-flagged short/over by a float epsilon. `amountExtractor.normalizeAmount` routes through the same util.

- ✅ Monetary comparisons use integer stroops, not floats
- ✅ Exact-amount payments never mis-flagged by rounding
- ✅ Property test over 5,000 random amounts passes

## #839 — Horizon cursor management & pagination
The poller persists a per-school Horizon `paging_token` cursor (`School.syncCursor`) and resumes **ascending** paging from it each cycle — gap-free and with no genesis re-scans. A Horizon 429 surfaces as a `horizonError` driving the existing exponential backoff; the cursor is advanced only over examined transactions, so a mid-cycle 429 resumes safely.

- ✅ Cursor persisted and resumed per account
- ✅ No gaps and no full-history rescans across cycles
- ✅ Tests cover resume + 429 handling

## Incidental fix
`stellarService` used `computeTargetState` / `resolveNextState` / `deriveLegacyConfirmationStatus` / `isConfirmedOrAbove` but never imported them — a latent `ReferenceError` on the credit path. Added the import (unblocks `partialPaymentStatus`).

## Tests
New: `stellarAmountStroops`, `usdcIssuerValidation`, `extractValidPaymentReorgAsset`, `transactionPollingCursor`. All new + related regression suites pass (76/76 across the 8 relevant suites).

## Note (out of scope)
`transactionPollingService.processTransaction` has a pre-existing `assetCode is not defined` crash from #883's `fiatSnapshot` line; left untouched to keep this PR scoped — recommend a separate one-line fix (`asset.assetCode`).
