### PR TITLE
fix(#69): replace in-memory _syncLocks with distributed lock

### DIFF
--- a/backend/src/controllers/paymentAdminController.js
+++ b/backend/src/controllers/paymentAdminController.js
@@ -15,6 +15,11 @@ const { syncDurationSeconds } = require('../metrics');
 const { syncPaymentsForSchool } = require('../services/stellarService');
 const { initiateRefund, getRefundsByPayment, getRefundsBySchool } = require('../services/refundService');
 const { generateReconciliationReport } = require('../services/reconciliationService');
+const lock = require('../services/distributedLock');
+
+// TTL for the per-school distributed sync lock (60 s — long enough to complete
+// a full blockchain sync while short enough to auto-expire after a crash).
+const SYNC_LOCK_TTL_MS = parseInt(process.env.SYNC_LOCK_TTL_MS || '60000', 10);
 
 function wrapStellarError(err) {
   if (!err.code) {
@@ -24,14 +29,19 @@ function wrapStellarError(err) {
   return err;
 }
 
-const _syncLocks = new Set();
-
 async function syncAllPayments(req, res, next) {
   const { schoolId } = req;
-  if (_syncLocks.has(schoolId)) {
+
+  // Issue #69 — replace the in-process _syncLocks Set with a cross-replica
+  // distributed lock (Redis SET NX PX, in-process Map fallback when no Redis).
+  // Any replica that cannot acquire the lock immediately returns 409 so the
+  // caller knows a sync is already in flight somewhere in the cluster.
+  const lockKey = `sync:lock:${schoolId}`;
+  const token = await lock.acquire(lockKey, SYNC_LOCK_TTL_MS);
+  if (!token) {
     return res.status(409).json({ error: 'Sync already in progress', code: 'SYNC_IN_PROGRESS' });
   }
-  _syncLocks.add(schoolId);
+
   const stopSyncTimer = syncDurationSeconds.startTimer();
   try {
     const summary = await syncPaymentsForSchool(req.school);
@@ -80,7 +90,7 @@ async function syncAllPayments(req, res, next) {
     next(wrapStellarError(err));
   } finally {
     stopSyncTimer();
-    _syncLocks.delete(schoolId);
+    await lock.release(lockKey, token);
   }
 }
 
@@ -557,5 +567,6 @@ module.exports = {
   verifyReceipt,
   getReconciliationReports,
   generateSchoolReconciliationReport,
-  _syncLocks,
+  // Exposed for testing — callers can introspect the lock state
+  _lock: lock,
 };

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -24,6 +24,11 @@ const { getPaymentLimits, validatePaymentAmount } = require('../utils/paymentLim
 const { convertToLocalCurrency } = require('../services/currencyConversionService');
 const { withStellarRetry } = require('../utils/withStellarRetry');
 const { makePaymentAuditLogger } = require('../utils/paymentAuditLogger');
+const lock = require('../services/distributedLock');
+
+// TTL for the per-school distributed verify lock.  Verify is a fast Horizon
+// round-trip; 30 s is more than enough while still auto-expiring on crash.
+const VERIFY_LOCK_TTL_MS = parseInt(process.env.VERIFY_LOCK_TTL_MS || '30000', 10);
 
 // Permanent error codes that should NOT be retried
 const PERMANENT_FAIL_CODES = [
@@ -279,172 +284,187 @@ async function verifyPayment(req, res, next) {
       });
     }
 
-    let result;
+    // Issue #69 — distributed lock prevents two replicas from concurrently
+    // verifying the same transaction, which would risk a double-write race even
+    // though the unique index on Payment { schoolId, txHash } is the ultimate
+    // dedup guard.  The lock is keyed per (school, txHash) so only identical
+    // concurrent verify calls contend — different hashes proceed in parallel.
+    const verifyLockKey = `sync:lock:${schoolId}:verify:${normalizedHash}`;
+    const verifyToken = await lock.acquire(verifyLockKey, VERIFY_LOCK_TTL_MS);
+    if (!verifyToken) {
+      return res.status(409).json({ error: 'Sync already in progress', code: 'SYNC_IN_PROGRESS' });
+    }
+
     try {
-      // Pass schoolId so verifyTransaction scopes the student lookup to this school (#845).
-      result = await verifyTransaction(normalizedHash, req.school.stellarAddress, schoolId);
-    } catch (stellarErr) {
-      if (PERMANENT_FAIL_CODES.includes(stellarErr.code)) {
-        await audit.failure(stellarErr.message, { txHash: normalizedHash, errorCode: stellarErr.code });
-        await Payment.create({ schoolId, studentId: 'unknown', txHash: normalizedHash, amount: 0, status: 'FAILED', feeValidationStatus: 'unknown' }).catch(() => {});
-        return next(stellarErr);
+      let result;
+      try {
+        // Pass schoolId so verifyTransaction scopes the student lookup to this school (#845).
+        result = await verifyTransaction(normalizedHash, req.school.stellarAddress, schoolId);
+      } catch (stellarErr) {
+        if (PERMANENT_FAIL_CODES.includes(stellarErr.code)) {
+          await audit.failure(stellarErr.message, { txHash: normalizedHash, errorCode: stellarErr.code });
+          await Payment.create({ schoolId, studentId: 'unknown', txHash: normalizedHash, amount: 0, status: 'FAILED', feeValidationStatus: 'unknown' }).catch(() => {});
+          return next(stellarErr);
+        }
+
+        await audit.success({ txHash: normalizedHash, queuedForRetry: true, reason: stellarErr.message });
+        await queueForRetry(normalizedHash, req.body.studentId || null, stellarErr.message, schoolId);
+        return res.status(202).json({
+          message: 'Stellar network is temporarily unavailable. Your transaction has been queued and will be verified automatically.',
+          txHash: normalizedHash,
+          status: 'queued_for_retry',
+        });
       }
 
-      await audit.success({ txHash: normalizedHash, queuedForRetry: true, reason: stellarErr.message });
-      await queueForRetry(normalizedHash, req.body.studentId || null, stellarErr.message, schoolId);
-      return res.status(202).json({
-        message: 'Stellar network is temporarily unavailable. Your transaction has been queued and will be verified automatically.',
+      if (!result) {
+        await audit.failure('Transaction found but contains no valid payment to this school wallet', { txHash: normalizedHash });
+        return res.status(404).json({ error: 'Transaction found but contains no valid payment to this school wallet', code: 'NOT_FOUND' });
+      }
+
+      const studentStrId = result.studentId || result.memo;
+      const studentObj = await Student.findOne({ schoolId, studentId: studentStrId });
+      if (!studentObj) {
+        await audit.failure('Associated student not found', { txHash: normalizedHash, studentId: studentStrId });
+        return res.status(404).json({ error: 'Associated student not found. Cannot record transaction.' });
+      }
+
+      // Intents are a UX convenience; an expired intent must not block crediting (#848).
+      // Mark it expired for bookkeeping but continue to record the payment.
+      const intent = await PaymentIntent.findOne({ memo: result.memo, schoolId });
+      if (intent?.expiresAt && intent.expiresAt < new Date()) {
+        await PaymentIntent.findByIdAndUpdate(intent._id, { status: 'expired' });
+      }
+
+      // Determine cumulative feeValidationStatus (#846).
+      // Partial payments (amount < fee) are accepted — money is already on-chain.
+      // The cumulative total drives the status; per-payment underpaid rejection
+      // is not applied here because a parent may be paying in installments.
+      const prevAgg = await Payment.aggregate([
+        { $match: { schoolId, studentId: studentStrId, deletedAt: null, status: 'SUCCESS' } },
+        { $group: { _id: null, total: { $sum: '$amount' } } },
+      ]);
+      const prevTotal = prevAgg.length ? prevAgg[0].total : 0;
+      const cumulativeTotal = parseFloat((prevTotal + result.amount).toFixed(7));
+      let feeValidationStatus;
+      if (cumulativeTotal < studentObj.feeAmount) feeValidationStatus = 'partial';
+      else if (cumulativeTotal > studentObj.feeAmount) feeValidationStatus = 'overpaid';
+      else feeValidationStatus = 'valid';
+      const computedExcessAmount = feeValidationStatus === 'overpaid'
+        ? parseFloat((cumulativeTotal - studentObj.feeAmount).toFixed(7))
+        : 0;
+
+      const now = new Date();
+      try {
+        await recordPayment({
+          schoolId,
+          studentId: studentStrId,
+          txHash: result.hash,
+          amount: result.amount,
+          feeAmount: result.feeAmount || studentObj.feeAmount,
+          feeValidationStatus,
+          excessAmount: computedExcessAmount,
+          networkFee: result.networkFee,
+          status: 'SUCCESS',
+          memo: result.memo,
+          senderAddress: result.senderAddress || null,
+          ledgerSequence: result.ledger || null,
+          confirmationStatus: 'confirmed',
+          confirmedAt: result.date ? new Date(result.date) : now,
+          verifiedAt: now,
+        });
+      } catch (dupErr) {
+        if (dupErr.code === 'DUPLICATE_TX') {
+          // Concurrent path (poller or another verify call) already recorded this tx.
+          // Fetch and return the existing record as a cache hit.
+          const cached = await Payment.findOne({ schoolId, txHash: normalizedHash });
+          if (cached) {
+            await audit.success({ txHash: normalizedHash, cached: true, studentId: studentStrId, amount: cached.amount });
+            const targetCurrency = req.school.localCurrency || 'USD';
+            const cachedConv = await convertToLocalCurrency(cached.amount, cached.assetCode || 'XLM', targetCurrency);
+            return res.json({
+              verified: true, cached: true, hash: cached.txHash,
+              stellarExplorerUrl: getExplorerUrl(cached.txHash), explorerUrl: getExplorerUrl(cached.txHash),
+              memo: cached.memo, studentId: cached.studentId, amount: cached.amount,
+              assetCode: cached.assetCode, feeAmount: cached.feeAmount,
+              feeValidation: { status: cached.feeValidationStatus, excessAmount: cached.excessAmount },
+              date: cached.confirmedAt || cached.createdAt, status: cached.status,
+              localCurrency: {
+                amount: cachedConv.available ? cachedConv.localAmount : null,
+                currency: cachedConv.currency, rate: cachedConv.rate,
+                rateTimestamp: cachedConv.rateTimestamp, available: cachedConv.available,
+              },
+            });
+          }
+        }
+        throw dupErr;
+      }
+
+      // Update student record immediately after recording (#846) — sync path also does
+      // this, but the verify path never did, leaving totalPaid/remainingBalance stale.
+      await Student.findOneAndUpdate(
+        { schoolId, studentId: studentStrId },
+        {
+          totalPaid: cumulativeTotal,
+          remainingBalance: parseFloat(Math.max(0, studentObj.feeAmount - cumulativeTotal).toFixed(7)),
+          feePaid: cumulativeTotal >= studentObj.feeAmount,
+        },
+      );
+
+      await audit.success({
         txHash: normalizedHash,
-        status: 'queued_for_retry',
-      });
-    }
-
-    if (!result) {
-      await audit.failure('Transaction found but contains no valid payment to this school wallet', { txHash: normalizedHash });
-      return res.status(404).json({ error: 'Transaction found but contains no valid payment to this school wallet', code: 'NOT_FOUND' });
-    }
-
-    const studentStrId = result.studentId || result.memo;
-    const studentObj = await Student.findOne({ schoolId, studentId: studentStrId });
-    if (!studentObj) {
-      await audit.failure('Associated student not found', { txHash: normalizedHash, studentId: studentStrId });
-      return res.status(404).json({ error: 'Associated student not found. Cannot record transaction.' });
-    }
-
-    // Intents are a UX convenience; an expired intent must not block crediting (#848).
-    // Mark it expired for bookkeeping but continue to record the payment.
-    const intent = await PaymentIntent.findOne({ memo: result.memo, schoolId });
-    if (intent?.expiresAt && intent.expiresAt < new Date()) {
-      await PaymentIntent.findByIdAndUpdate(intent._id, { status: 'expired' });
-    }
-
-    // Determine cumulative feeValidationStatus (#846).
-    // Partial payments (amount < fee) are accepted — money is already on-chain.
-    // The cumulative total drives the status; per-payment underpaid rejection
-    // is not applied here because a parent may be paying in installments.
-    const prevAgg = await Payment.aggregate([
-      { $match: { schoolId, studentId: studentStrId, deletedAt: null, status: 'SUCCESS' } },
-      { $group: { _id: null, total: { $sum: '$amount' } } },
-    ]);
-    const prevTotal = prevAgg.length ? prevAgg[0].total : 0;
-    const cumulativeTotal = parseFloat((prevTotal + result.amount).toFixed(7));
-    let feeValidationStatus;
-    if (cumulativeTotal < studentObj.feeAmount) feeValidationStatus = 'partial';
-    else if (cumulativeTotal > studentObj.feeAmount) feeValidationStatus = 'overpaid';
-    else feeValidationStatus = 'valid';
-    const computedExcessAmount = feeValidationStatus === 'overpaid'
-      ? parseFloat((cumulativeTotal - studentObj.feeAmount).toFixed(7))
-      : 0;
-
-    const now = new Date();
-    try {
-      await recordPayment({
-        schoolId,
         studentId: studentStrId,
-        txHash: result.hash,
         amount: result.amount,
+        assetCode: result.assetCode || 'XLM',
+        feeValidationStatus,
+        duration: `${Date.now() - startTime}ms`,
+      });
+
+      // Auto-generate receipt (fire-and-forget)
+      const { createReceipt } = require('../services/receiptService');
+      createReceipt({
+        txHash: result.hash,
+        studentId: studentStrId,
+        schoolId,
+        amount: result.amount,
+        assetCode: result.assetCode || 'XLM',
         feeAmount: result.feeAmount || studentObj.feeAmount,
         feeValidationStatus,
-        excessAmount: computedExcessAmount,
-        networkFee: result.networkFee,
-        status: 'SUCCESS',
         memo: result.memo,
-        senderAddress: result.senderAddress || null,
-        ledgerSequence: result.ledger || null,
-        confirmationStatus: 'confirmed',
         confirmedAt: result.date ? new Date(result.date) : now,
-        verifiedAt: now,
+      }).catch(() => {});
+
+      const targetCurrency = req.school.localCurrency || 'USD';
+      const conversion = await convertToLocalCurrency(result.amount, result.assetCode || 'XLM', targetCurrency);
+      const stellarExplorerUrl = getExplorerUrl(result.hash);
+      const remainingBalance = parseFloat(Math.max(0, studentObj.feeAmount - cumulativeTotal).toFixed(7));
+
+      res.json({
+        verified: true,
+        cached: false,
+        hash: result.hash,
+        stellarExplorerUrl,
+        explorerUrl: stellarExplorerUrl,
+        memo: result.memo,
+        studentId: studentStrId,
+        amount: result.amount,
+        assetCode: result.assetCode,
+        assetType: result.assetType,
+        feeAmount: result.feeAmount || studentObj.feeAmount,
+        feeValidation: { status: feeValidationStatus, excessAmount: computedExcessAmount },
+        remainingBalance,
+        networkFee: result.networkFee,
+        date: result.date,
+        localCurrency: {
+          amount: conversion.available ? conversion.localAmount : null,
+          currency: conversion.currency,
+          rate: conversion.rate,
+          rateTimestamp: conversion.rateTimestamp,
+          available: conversion.available,
+        },
       });
-    } catch (dupErr) {
-      if (dupErr.code === 'DUPLICATE_TX') {
-        // Concurrent path (poller or another verify call) already recorded this tx.
-        // Fetch and return the existing record as a cache hit.
-        const cached = await Payment.findOne({ schoolId, txHash: normalizedHash });
-        if (cached) {
-          await audit.success({ txHash: normalizedHash, cached: true, studentId: studentStrId, amount: cached.amount });
-          const targetCurrency = req.school.localCurrency || 'USD';
-          const cachedConv = await convertToLocalCurrency(cached.amount, cached.assetCode || 'XLM', targetCurrency);
-          return res.json({
-            verified: true, cached: true, hash: cached.txHash,
-            stellarExplorerUrl: getExplorerUrl(cached.txHash), explorerUrl: getExplorerUrl(cached.txHash),
-            memo: cached.memo, studentId: cached.studentId, amount: cached.amount,
-            assetCode: cached.assetCode, feeAmount: cached.feeAmount,
-            feeValidation: { status: cached.feeValidationStatus, excessAmount: cached.excessAmount },
-            date: cached.confirmedAt || cached.createdAt, status: cached.status,
-            localCurrency: {
-              amount: cachedConv.available ? cachedConv.localAmount : null,
-              currency: cachedConv.currency, rate: cachedConv.rate,
-              rateTimestamp: cachedConv.rateTimestamp, available: cachedConv.available,
-            },
-          });
-        }
-      }
-      throw dupErr;
+    } finally {
+      await lock.release(verifyLockKey, verifyToken);
     }
-
-    // Update student record immediately after recording (#846) — sync path also does
-    // this, but the verify path never did, leaving totalPaid/remainingBalance stale.
-    await Student.findOneAndUpdate(
-      { schoolId, studentId: studentStrId },
-      {
-        totalPaid: cumulativeTotal,
-        remainingBalance: parseFloat(Math.max(0, studentObj.feeAmount - cumulativeTotal).toFixed(7)),
-        feePaid: cumulativeTotal >= studentObj.feeAmount,
-      },
-    );
-
-    await audit.success({
-      txHash: normalizedHash,
-      studentId: studentStrId,
-      amount: result.amount,
-      assetCode: result.assetCode || 'XLM',
-      feeValidationStatus,
-      duration: `${Date.now() - startTime}ms`,
-    });
-
-    // Auto-generate receipt (fire-and-forget)
-    const { createReceipt } = require('../services/receiptService');
-    createReceipt({
-      txHash: result.hash,
-      studentId: studentStrId,
-      schoolId,
-      amount: result.amount,
-      assetCode: result.assetCode || 'XLM',
-      feeAmount: result.feeAmount || studentObj.feeAmount,
-      feeValidationStatus,
-      memo: result.memo,
-      confirmedAt: result.date ? new Date(result.date) : now,
-    }).catch(() => {});
-
-    const targetCurrency = req.school.localCurrency || 'USD';
-    const conversion = await convertToLocalCurrency(result.amount, result.assetCode || 'XLM', targetCurrency);
-    const stellarExplorerUrl = getExplorerUrl(result.hash);
-    const remainingBalance = parseFloat(Math.max(0, studentObj.feeAmount - cumulativeTotal).toFixed(7));
-
-    res.json({
-      verified: true,
-      cached: false,
-      hash: result.hash,
-      stellarExplorerUrl,
-      explorerUrl: stellarExplorerUrl,
-      memo: result.memo,
-      studentId: studentStrId,
-      amount: result.amount,
-      assetCode: result.assetCode,
-      assetType: result.assetType,
-      feeAmount: result.feeAmount || studentObj.feeAmount,
-      feeValidation: { status: feeValidationStatus, excessAmount: computedExcessAmount },
-      remainingBalance,
-      networkFee: result.networkFee,
-      date: result.date,
-      localCurrency: {
-        amount: conversion.available ? conversion.localAmount : null,
-        currency: conversion.currency,
-        rate: conversion.rate,
-        rateTimestamp: conversion.rateTimestamp,
-        available: conversion.available,
-      },
-    });
   } catch (err) {
     await makePaymentAuditLogger(req, req.schoolId, req.body?.txHash || 'unknown')
       .failure(err.message, { error: err.message })

--- a/backend/tests/paymentDistributedLock.test.js
+++ b/backend/tests/paymentDistributedLock.test.js
@@ -1,0 +1,302 @@
+'use strict';
+
+/**
+ * Issue #69 — Distributed lock tests for syncAllPayments and verifyPayment.
+ *
+ * Acceptance criteria:
+ *   1. Sync/verify guarded by a cross-replica distributed lock.
+ *   2. Concurrent calls return 409 SYNC_IN_PROGRESS.
+ *   3. Test simulates two replicas sharing a single Redis-like store.
+ *
+ * The verifyPayment lock behavior is tested via a lightweight harness that
+ * reproduces the lock guard from paymentController.js without importing the
+ * full controller (which pulls in @stellar/stellar-sdk, unavailable in the
+ * test environment).  The syncAllPayments tests import the real controller.
+ */
+
+// ── Shared lock store (simulates Redis) ──────────────────────────────────────
+const sharedLockStore = new Map();
+const crypto = require('crypto');
+function newToken() { return crypto.randomBytes(8).toString('hex'); }
+
+const mockLock = {
+  acquire: jest.fn(async (key, ttlMs) => {
+    const now = Date.now();
+    const existing = sharedLockStore.get(key);
+    if (existing && existing.expiresAt > now) return null;
+    const token = newToken();
+    sharedLockStore.set(key, { token, expiresAt: now + ttlMs });
+    return token;
+  }),
+  release: jest.fn(async (key, token) => {
+    const existing = sharedLockStore.get(key);
+    if (existing && existing.token === token) {
+      sharedLockStore.delete(key);
+      return true;
+    }
+    return false;
+  }),
+};
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+jest.mock('../src/services/distributedLock', () => mockLock);
+
+jest.mock('../src/services/stellarService', () => ({
+  syncPaymentsForSchool: jest.fn(async () => ({
+    found: 1, new: 1, matched: 1, unmatched: 0, failed: 0,
+    alreadyProcessed: 0, failedDetails: [],
+  })),
+  finalizeConfirmedPayments: jest.fn(async () => ({})),
+  verifyTransaction: jest.fn(async () => ({
+    hash: 'TX1', memo: 's1', studentId: 's1', amount: 100,
+    assetCode: 'XLM', assetType: 'native', feeAmount: 100,
+    feeValidation: { status: 'valid', excessAmount: 0 },
+    networkFee: 0, date: new Date().toISOString(), ledger: 100,
+    senderAddress: 'GSENDER',
+  })),
+  recordPayment: jest.fn(async () => ({})),
+}));
+jest.mock('../src/services/auditService', () => ({ logAudit: jest.fn(async () => {}) }));
+jest.mock('../src/services/receiptService', () => ({
+  createReceipt: jest.fn(async () => ({})),
+  verifyReceiptSignature: jest.fn(() => true),
+}));
+jest.mock('../src/services/refundService', () => ({
+  initiateRefund: jest.fn(),
+  getRefundsByPayment: jest.fn(async () => []),
+  getRefundsBySchool: jest.fn(async () => []),
+}));
+jest.mock('../src/services/reconciliationService', () => ({
+  generateReconciliationReport: jest.fn(async () => ({ _id: 'r1', drift: 0 })),
+}));
+jest.mock('../src/metrics', () => ({
+  syncDurationSeconds: { startTimer: jest.fn(() => jest.fn()) },
+}));
+jest.mock('../src/models/paymentModel', () => ({
+  findOne: jest.fn(async () => null),
+  aggregate: jest.fn(async () => []),
+  create: jest.fn(async () => ({})),
+}));
+jest.mock('../src/models/studentModel', () => ({
+  findOne: jest.fn(async () => ({ studentId: 's1', schoolId: 'school-1', feeAmount: 100 })),
+  findOneAndUpdate: jest.fn(async () => ({})),
+}));
+jest.mock('../src/models/paymentIntentModel', () => ({
+  findOne: jest.fn(async () => null),
+  findByIdAndUpdate: jest.fn(async () => ({})),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+function makeReq(overrides = {}) {
+  return {
+    schoolId: 'school-1',
+    school: { schoolId: 'school-1', stellarAddress: 'GSCHOOL', localCurrency: 'USD' },
+    body: {},
+    auditContext: null,
+    ...overrides,
+  };
+}
+
+function makeRes() {
+  const res = {
+    _status: 200,
+    _body: null,
+    status(code) { this._status = code; return this; },
+    json(body) { this._body = body; return this; },
+  };
+  return res;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Issue #69 — syncAllPayments distributed lock
+// ═══════════════════════════════════════════════════════════════════════════════
+describe('Issue #69 — syncAllPayments distributed lock', () => {
+  let syncAllPayments;
+  let syncPaymentsForSchool;
+
+  beforeAll(() => {
+    jest.isolateModules(() => {
+      ({ syncAllPayments } = require('../src/controllers/paymentAdminController'));
+      // Capture from same isolated registry so we track the exact mock instance
+      // the controller sees
+      syncPaymentsForSchool = require('../src/services/stellarService').syncPaymentsForSchool;
+    });
+  });
+
+  beforeEach(() => {
+    sharedLockStore.clear();
+    mockLock.acquire.mockClear();
+    mockLock.release.mockClear();
+    syncPaymentsForSchool.mockClear();
+  });
+
+  it('acquires the distributed lock and releases it on success', async () => {
+    const req = makeReq();
+    const res = makeRes();
+
+    await syncAllPayments(req, res, jest.fn());
+
+    expect(mockLock.acquire).toHaveBeenCalledWith('sync:lock:school-1', expect.any(Number));
+    expect(mockLock.release).toHaveBeenCalledWith('sync:lock:school-1', expect.any(String));
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ message: 'Sync complete' });
+  });
+
+  it('returns 409 SYNC_IN_PROGRESS when lock is already held (simulating replica 2)', async () => {
+    // Pre-populate the store as if replica-1 holds the lock
+    sharedLockStore.set('sync:lock:school-1', {
+      token: 'held-by-replica-1', expiresAt: Date.now() + 60000,
+    });
+
+    const res = makeRes();
+    await syncAllPayments(makeReq(), res, jest.fn());
+
+    expect(res._status).toBe(409);
+    expect(res._body).toMatchObject({ code: 'SYNC_IN_PROGRESS' });
+    expect(syncPaymentsForSchool).not.toHaveBeenCalled();
+  });
+
+  it('simulates two replicas calling syncAllPayments concurrently — only one proceeds', async () => {
+    const res1 = makeRes();
+    const res2 = makeRes();
+
+    await Promise.all([
+      syncAllPayments(makeReq(), res1, jest.fn()),
+      syncAllPayments(makeReq(), res2, jest.fn()),
+    ]);
+
+    const statuses = [res1._status, res2._status];
+    expect(statuses).toContain(200);
+    expect(statuses).toContain(409);
+    expect(syncPaymentsForSchool).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the lock even when syncPaymentsForSchool throws', async () => {
+    syncPaymentsForSchool.mockRejectedValueOnce(new Error('Horizon error'));
+
+    const next = jest.fn();
+    await syncAllPayments(makeReq(), makeRes(), next);
+
+    expect(next).toHaveBeenCalled();
+    expect(sharedLockStore.size).toBe(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Issue #69 — verifyPayment distributed lock
+//
+// The full paymentController.js imports @stellar/stellar-sdk which is not
+// available in the test environment.  We exercise the verify lock behavior
+// through a thin harness that calls distributedLock.acquire/release with the
+// same key pattern and semantics as the real handler.  This validates the lock
+// contract without requiring the heavy SDK dependency.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Minimal verifyPayment-style handler that only exercises the distributed lock.
+ * Mirrors the lock guard in paymentController.verifyPayment exactly.
+ */
+async function verifyPaymentLockHarness(req, res, _next, innerFn) {
+  const { schoolId } = req;
+  const { txHash } = req.body;
+
+  // Idempotency fast-path: skip lock for already-cached payments
+  const Payment = require('../src/models/paymentModel');
+  const existing = await Payment.findOne({ schoolId, txHash });
+  if (existing) {
+    return res.status(200).json({ cached: true, hash: txHash });
+  }
+
+  const verifyLockKey = `sync:lock:${schoolId}:verify:${txHash}`;
+  const verifyToken = await mockLock.acquire(verifyLockKey, 30000);
+  if (!verifyToken) {
+    return res.status(409).json({ error: 'Sync already in progress', code: 'SYNC_IN_PROGRESS' });
+  }
+
+  try {
+    const result = await innerFn();
+    return res.status(200).json(result);
+  } finally {
+    await mockLock.release(verifyLockKey, verifyToken);
+  }
+}
+
+describe('Issue #69 — verifyPayment distributed lock', () => {
+  beforeEach(() => {
+    sharedLockStore.clear();
+    mockLock.acquire.mockClear();
+    mockLock.release.mockClear();
+    const Payment = require('../src/models/paymentModel');
+    Payment.findOne.mockResolvedValue(null);
+  });
+
+  it('acquires and releases the verify lock on success', async () => {
+    const req = makeReq({ body: { txHash: 'TX1' } });
+    const res = makeRes();
+
+    await verifyPaymentLockHarness(req, res, jest.fn(), async () => ({ verified: true }));
+
+    expect(mockLock.acquire).toHaveBeenCalledWith(
+      'sync:lock:school-1:verify:TX1', expect.any(Number)
+    );
+    expect(mockLock.release).toHaveBeenCalledWith(
+      'sync:lock:school-1:verify:TX1', expect.any(String)
+    );
+    expect(res._status).toBe(200);
+  });
+
+  it('returns 409 SYNC_IN_PROGRESS when lock is already held by another replica', async () => {
+    sharedLockStore.set('sync:lock:school-1:verify:TX2', {
+      token: 'other-replica', expiresAt: Date.now() + 30000,
+    });
+
+    const res = makeRes();
+    const innerFn = jest.fn();
+    await verifyPaymentLockHarness(makeReq({ body: { txHash: 'TX2' } }), res, jest.fn(), innerFn);
+
+    expect(res._status).toBe(409);
+    expect(res._body).toMatchObject({ code: 'SYNC_IN_PROGRESS' });
+    expect(innerFn).not.toHaveBeenCalled();
+  });
+
+  it('simulates two replicas calling verifyPayment concurrently — only one proceeds', async () => {
+    const innerFn = jest.fn(async () => ({ verified: true }));
+    const res1 = makeRes();
+    const res2 = makeRes();
+
+    await Promise.all([
+      verifyPaymentLockHarness(makeReq({ body: { txHash: 'TX3' } }), res1, jest.fn(), innerFn),
+      verifyPaymentLockHarness(makeReq({ body: { txHash: 'TX3' } }), res2, jest.fn(), innerFn),
+    ]);
+
+    const statuses = [res1._status, res2._status];
+    expect(statuses).toContain(200);
+    expect(statuses).toContain(409);
+    expect(innerFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the lock entirely for already-cached payments (idempotency path)', async () => {
+    const Payment = require('../src/models/paymentModel');
+    Payment.findOne.mockResolvedValueOnce({ txHash: 'TX4', amount: 100 });
+
+    const innerFn = jest.fn();
+    const res = makeRes();
+    await verifyPaymentLockHarness(makeReq({ body: { txHash: 'TX4' } }), res, jest.fn(), innerFn);
+
+    expect(mockLock.acquire).not.toHaveBeenCalled();
+    expect(res._body).toMatchObject({ cached: true });
+    expect(innerFn).not.toHaveBeenCalled();
+  });
+
+  it('releases the lock even when the inner function throws', async () => {
+    const innerFn = jest.fn(async () => { throw new Error('DB error'); });
+    const next = jest.fn();
+    const res = makeRes();
+
+    try {
+      await verifyPaymentLockHarness(makeReq({ body: { txHash: 'TX5' } }), res, next, innerFn);
+    } catch (_) {}
+
+    expect(sharedLockStore.has('sync:lock:school-1:verify:TX5')).toBe(false);
+  });
+});


### PR DESCRIPTION
- Remove per-process _syncLocks Set from paymentAdminController
- Import distributedLock service; acquire sync:lock:<schoolId> before calling syncPaymentsForSchool, release in finally block
- Add distributed lock guard to verifyPayment keyed on sync:lock:<schoolId>:verify:<txHash>; return 409 SYNC_IN_PROGRESS when lock is held by another replica
- Both handlers release the lock in a finally block so crashes never leave stale locks beyond the configured TTL
- Add paymentDistributedLock.test.js: 9 tests covering lock acquisition, 409 on contention, concurrent replica simulation, and lock release on error
closes #858 