### PR TITLE
docs: add threat model and operator runbooks

### DIFF
--- a/docs/issue-intake.md
+++ b/docs/issue-intake.md
@@ -1,0 +1,36 @@
+# Issue Intake Path
+
+StellarEduPay accepts contribution and operations issues through GitHub Issues in this repository. This page defines the intake path so operators, maintainers, and contributors know where to file reports and what information to include.
+
+## Where To File
+
+Use GitHub Issues for bugs in frontend, backend API, worker, queue, webhook, database, Horizon/Stellar integration, documentation gaps, operator runbook updates, and feature requests.
+
+Do not paste secrets, private keys, production tokens, user private data, or unreleased vulnerability details into public issues.
+
+## Security-Sensitive Reports
+
+If a report includes a live exploit, secret, private user data, or a way to move funds without authorization, do not file full details publicly. Open only a minimal public tracking issue if needed and contact maintainers through the private channel documented by the project owner.
+
+## Bug Report Template
+
+- Environment: local, staging, testnet, or production.
+- Component: frontend, backend API, worker, queue, webhook, database, Horizon/Stellar.
+- Expected behavior.
+- Actual behavior.
+- Reproduction steps.
+- Safe request ID, payment ID, tenant ID, or transaction hash if available.
+- Screenshots or logs with secrets removed.
+
+## Operational Issue Template
+
+- Incident time window in UTC.
+- Affected tenants or users, if safe to share.
+- Dependency involved: Redis, Horizon, Mongo, webhook provider, SSE, deployment, or signing.
+- Current user impact.
+- Actions already taken.
+- Whether writes or workers are paused.
+
+## Maintainer Triage
+
+Maintainers should tag incoming issues by area, severity, status, and contributor fit. Payment, custody, authorization, tenant-isolation, or webhook issues should be reviewed before assignment.

--- a/docs/operator-runbooks.md
+++ b/docs/operator-runbooks.md
@@ -1,0 +1,54 @@
+# StellarEduPay Operator Runbooks
+
+These runbooks cover the main operational failures for the async payment path: Redis or queue outage, Horizon outage, Mongo or database outage, stuck payments, key rotation, and restore.
+
+## General Incident Steps
+
+1. Open an incident record with time, environment, reporter, and affected tenants.
+2. Assign an incident commander, API operator, database operator, and communications owner.
+3. Freeze non-essential deployments.
+4. Preserve logs, queue state, deployment SHA, and database snapshot metadata.
+5. Decide whether to run in read-only mode, maintenance mode, or full recovery mode.
+
+## Redis Or Queue Down
+
+Symptoms: payment requests are accepted but not processed, workers cannot dequeue jobs, retry counts stop changing, or queue health checks fail.
+
+Response: put payment creation into read-only mode if jobs cannot be durably enqueued, stop failing workers if they increase load, check connection strings and capacity, confirm queued jobs are preserved, and restart workers after health is restored.
+
+Recovery checks: no duplicate jobs for the same idempotency key, dead-letter queue reviewed, stuck payments retried or marked manual-review, and user-visible status is accurate.
+
+## Horizon Or Stellar Network Down
+
+Symptoms: transaction submission fails or times out, ledger reads are delayed, payments remain submitted or unknown, or reconciliation jobs fail across many tenants.
+
+Response: stop new submissions if failures are widespread, keep reconciliation retries with bounded backoff, switch to an approved backup endpoint only if configured, and do not mark unknown payments as failed until ledger status is confirmed.
+
+## Mongo Or Database Down
+
+Symptoms: API cannot load sessions, tenants, or payments; workers cannot persist status changes; audit event writes fail.
+
+Response: stop new payment writes, stop workers before they perform external writes that cannot be persisted, preserve logs and metrics, restore service or fail over, and run integrity checks before re-enabling workers.
+
+## Stuck Payments
+
+Triage payment ID, tenant ID, user ID, idempotency key, amount, asset, destination, current state, last worker attempt, transaction hash, and last Horizon response.
+
+Procedure: if a transaction hash exists, query Stellar/Horizon directly. If confirmed, update payment state with an audit reason. If failed, mark failed with the failure reason. If no hash exists and no transfer occurred, retry from queued state. If state is ambiguous, keep manual-review and do not retry automatically.
+
+## Key Rotation
+
+Rotate JWT or session secrets, webhook secrets, database credentials, queue credentials, deployment tokens, and Stellar signing credentials when compromise is suspected, operator membership changes, or the scheduled interval expires.
+
+Rotation order: create replacement secret, deploy dual-read support if required, rotate provider-side secret, redeploy API and workers, revoke old secret, verify operations, and record rotation time and operator.
+
+## Restore Procedure
+
+1. Stop API writes and workers.
+2. Create a forensic snapshot of the current database.
+3. Restore the latest known-good backup into staging.
+4. Run migrations and integrity checks against staging.
+5. Compare restored payments with on-chain transaction state.
+6. Decide whether to promote the backup or repair selected records.
+7. Communicate RPO impact before production promotion.
+8. Resume workers only after database and queue state are consistent.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,48 @@
+# StellarEduPay Threat Model
+
+This threat model uses STRIDE to document major risks for a multi-tenant, money-moving Stellar payment system.
+
+## Scope
+
+In scope: authentication, tenant isolation, payment creation, transaction submission, reconciliation, webhook ingestion, queue processing, operator actions, key rotation, database integrity, and audit logs.
+
+## Assets
+
+- User identities and sessions.
+- Tenant configuration and payment policies.
+- Payment records, transaction hashes, and audit events.
+- Stellar signing keys or delegated signing credentials.
+- Webhook secrets and provider credentials.
+- Database backups.
+- Operator accounts and deployment credentials.
+
+## STRIDE Analysis
+
+| Category | Risk | Impact | Mitigation |
+| --- | --- | --- | --- |
+| Spoofing | Stolen session or API token | Unauthorized payment requests | Short-lived sessions, secure cookies, token rotation, session revocation |
+| Spoofing | Forged webhook callback | False payment confirmation | Verify signatures, timestamp tolerance, replay protection |
+| Tampering | Client changes amount, asset, or destination | Funds sent incorrectly | Server-side validation, tenant policy checks, immutable audit event |
+| Tampering | Queue payload replayed | Duplicate payment execution | Idempotency keys and worker-side revalidation |
+| Repudiation | Operator changes payment state without trace | No accountability | Immutable audit events with operator identity and reason |
+| Information Disclosure | Tenant data leaks across accounts | Privacy and compliance issue | Tenant-scoped queries and authorization tests |
+| Information Disclosure | Secrets appear in logs | Credential compromise | Structured redaction, secret scanning, log access controls |
+| Denial of Service | Redis or queue unavailable | Payments stuck or delayed | Write pause, retry queues, recovery runbooks |
+| Denial of Service | Horizon unavailable | Unknown transaction status | Submission pause and reconciliation retry |
+| Elevation of Privilege | User reaches admin actions | Unauthorized recovery or config changes | Role-based access control and admin audit log |
+
+## Money-Moving Controls
+
+- Every payment request must have a tenant, authenticated actor, idempotency key, amount, asset, destination, and purpose.
+- Workers must reload canonical payment state before submitting a transaction.
+- Reconciliation must tolerate duplicate callbacks and delayed ledger confirmation.
+- Manual recovery must require an operator reason and produce an audit event.
+- Refund or emergency actions must be reviewed by two operators when production funds are involved.
+
+## Webhook Controls
+
+Verify provider signatures before parsing business fields, reject callbacks outside the allowed timestamp window, store raw and normalized event IDs for deduplication, and never trust webhook state alone when on-chain state can be checked.
+
+## Tenant Isolation Controls
+
+Every query for user-visible payment data must include tenant scope. Tenant IDs must come from authenticated server-side context, not request body alone. Tests should cover cross-tenant reads, writes, webhook events, and SSE subscriptions.


### PR DESCRIPTION
Closes #939

## Summary
- add a STRIDE threat model covering auth, multi-tenancy, custody, webhooks, and operator actions
- add operator runbooks for Redis, Horizon, database outages, stuck payments, key rotation, and restore
- document the GitHub issue-intake path and report templates

## Validation
- Documentation-only change; no runtime tests required

Note: submitted by usmmrs0002-hub via Codex-assisted workflow.