### PR TITLE
fix: log receipt-generation failures instead of swallowing them

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -432,7 +432,24 @@ async function verifyPayment(req, res, next) {
         feeValidationStatus,
         memo: result.memo,
         confirmedAt: result.date ? new Date(result.date) : now,
-      }).catch(() => {});
+      }).catch(err => {
+        // Fire-and-forget, but never silent (#1122). A systemic receipt failure
+        // (bad template, receipt-model fault, downstream outage) must leave a
+        // log trail and a metric, not wait for a parent to report it missing.
+        logger.error('[PaymentController] receipt generation failed', {
+          txHash: result.hash,
+          correlationId: req.correlationId,
+          schoolId,
+          studentId: studentStrId,
+          error: err.message,
+          stack: err.stack,
+        });
+        try {
+          require('../metrics').receiptGenerationFailuresTotal.inc({ source: 'verify_controller' });
+        } catch (_) {
+          // metrics module unavailable — logging above is still the primary signal
+        }
+      });
 
       const targetCurrency = req.school.localCurrency || 'USD';
       const conversion = await convertToLocalCurrency(result.amount, result.assetCode || 'XLM', targetCurrency);

--- a/backend/src/metrics/index.js
+++ b/backend/src/metrics/index.js
@@ -261,8 +261,21 @@ const notificationSentTotal = new client.Counter({
   registers: [registry],
 });
 
+// receipt_generation_failures_total{source} — counts receipt-generation
+// failures so a systemic outage (bad template, receipt-model/DB fault,
+// downstream dependency down) is visible and alertable instead of only
+// surfacing when a parent reports a missing receipt (#1122). Sources:
+// 'verify_controller' (inline fire-and-forget path), 'payment_saved_subscriber'.
+const receiptGenerationFailuresTotal = new client.Counter({
+  name: 'receipt_generation_failures_total',
+  help: 'Number of receipt-generation failures grouped by the code path that attempted it',
+  labelNames: ['source'],
+  registers: [registry],
+});
+
 module.exports = {
   registry,
+  receiptGenerationFailuresTotal,
   syncDurationSeconds,
   httpRequestDurationSeconds,
   suspiciousPaymentFlagged,

--- a/backend/src/services/paymentSavedSubscribers.js
+++ b/backend/src/services/paymentSavedSubscribers.js
@@ -70,6 +70,11 @@ async function onPaymentSavedReceipt(payment) {
     await createReceipt(payment);
   } catch (err) {
     logger.error('Receipt subscriber failed', { txHash: payment.txHash, correlationId: payment.correlationId, error: err.message });
+    try {
+      require('../metrics').receiptGenerationFailuresTotal.inc({ source: 'payment_saved_subscriber' });
+    } catch (_) {
+      // metrics module unavailable — logging above is still the primary signal
+    }
   }
 }
 

--- a/monitoring/alerts/receipts.yml
+++ b/monitoring/alerts/receipts.yml
@@ -1,0 +1,48 @@
+groups:
+  - name: receipts
+    interval: 60s
+    rules:
+      # ── Warning: receipts are failing at a low but sustained rate ────────
+      # receipt_generation_failures_total{source} is incremented by both the
+      # inline verify path and the payment-saved subscriber (#1122). Before
+      # that metric existed, the inline path swallowed errors entirely and a
+      # broken receipt pipeline was invisible until a parent complained.
+      #
+      # Any sustained non-zero rate is worth a look: receipt generation is
+      # idempotent and should not fail transiently at volume.
+      - alert: ReceiptGenerationFailures
+        expr: sum(rate(receipt_generation_failures_total[10m])) by (source) > 0
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Receipt generation failing via {{ $labels.source }}"
+          description: >
+            Receipt generation has been failing on the {{ $labels.source }} path
+            for 10 minutes ({{ $value | printf "%.3f" }}/s). Payments are still
+            being confirmed on-chain, but parents and admins will not receive
+            receipts. Search logs for "receipt generation failed" or "Receipt
+            subscriber failed" to get the txHash and underlying error.
+
+      # ── Critical: receipts are failing for essentially every payment ─────
+      # Compares receipt failures against confirmed-payment throughput. A ratio
+      # near 1 means the receipt pipeline is systemically down (bad template,
+      # receipt-model/DB fault, downstream dependency outage) rather than
+      # hitting isolated bad records.
+      - alert: ReceiptGenerationSystemicFailure
+        expr: >
+          sum(rate(receipt_generation_failures_total[15m]))
+            /
+          clamp_min(sum(rate(payment_funnel_total{stage="confirmed"}[15m])), 0.001)
+            > 0.5
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Receipt generation is systemically broken"
+          description: >
+            More than half of confirmed payments have failed to produce a
+            receipt over the last 15 minutes. This is an outage of the receipt
+            pipeline, not isolated bad data. Payments themselves are unaffected
+            (funds are on-chain and recorded), but every affected payment will
+            need its receipt backfilled once the root cause is fixed.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -4,6 +4,7 @@ global:
 
 rule_files:
   - "alerts/price_feed.yml"
+  - "alerts/receipts.yml"
 
 scrape_configs:
   - job_name: stellaredupay

--- a/tests/issue-1122-receipt-failure-logging.test.js
+++ b/tests/issue-1122-receipt-failure-logging.test.js
@@ -1,0 +1,212 @@
+'use strict';
+
+/**
+ * Issue #1122 — receipt-generation failures must never be silently swallowed.
+ *
+ * paymentController's fire-and-forget createReceipt() call used to end in a bare
+ * `.catch(() => {})`, so a systemic receipt outage (bad template, receipt-model
+ * fault, downstream dependency down) produced no log line, no metric, and no
+ * operational signal of any kind — it would only surface when a parent reported
+ * a missing receipt, with no trail to say when it started or why.
+ *
+ * These tests assert the failure is observable on BOTH receipt paths:
+ *   1. the inline verify-controller path (paymentController.verifyPayment)
+ *   2. the payment-saved subscriber path
+ * and that a failing receipt never breaks the payment response itself — the
+ * payment is already on-chain and must still be confirmed to the caller.
+ */
+
+process.env.MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/test';
+
+const TX_HASH = 'a'.repeat(64);
+const SCHOOL_ID = 'SCH-1122';
+const STUDENT_ID = 'STU-1122';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockLogger = { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
+mockLogger.child = jest.fn(() => mockLogger);
+jest.mock('../backend/src/utils/logger', () => mockLogger);
+
+const receiptError = Object.assign(new Error('receipt template missing'), {
+  stack: 'Error: receipt template missing\n    at renderTemplate',
+});
+const mockCreateReceipt = jest.fn(() => Promise.reject(receiptError));
+jest.mock('../backend/src/services/receiptService', () => ({
+  createReceipt: mockCreateReceipt,
+  getReceiptByTxHash: jest.fn(),
+}));
+
+const mockReceiptFailures = { inc: jest.fn() };
+jest.mock('../backend/src/metrics', () => ({
+  receiptGenerationFailuresTotal: mockReceiptFailures,
+}));
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  Networks: { PUBLIC: 'public', TESTNET: 'testnet' },
+  Asset: { native: () => ({ code: 'XLM' }) },
+}), { virtual: true });
+
+jest.mock('../backend/src/services/stellarService', () => ({
+  verifyTransaction: jest.fn(() => Promise.resolve({
+    hash: 'a'.repeat(64),
+    amount: 250,
+    memo: 'STU-1122',
+    studentId: 'STU-1122',
+    assetCode: 'XLM',
+    feeAmount: 250,
+    networkFee: 0.00001,
+    ledger: 42,
+    date: '2026-01-01T00:00:00.000Z',
+    senderAddress: 'GSENDER',
+  })),
+  recordPayment: jest.fn(() => Promise.resolve()),
+  validatePaymentWithDynamicFee: jest.fn(),
+}));
+
+jest.mock('../backend/src/services/distributedLock', () => ({
+  acquire: jest.fn(() => Promise.resolve({ token: 't', fencingToken: 1 })),
+  release: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../backend/src/services/currencyConversionService', () => ({
+  convertToLocalCurrency: jest.fn(() => Promise.resolve({
+    available: false, localAmount: null, currency: 'USD', rate: null, rateTimestamp: null,
+  })),
+}));
+
+jest.mock('../backend/src/utils/paymentAuditLogger', () => ({
+  makePaymentAuditLogger: () => ({
+    success: jest.fn(() => Promise.resolve()),
+    failure: jest.fn(() => Promise.resolve()),
+  }),
+}));
+
+jest.mock('../backend/src/models/paymentModel', () => ({
+  findOne: jest.fn(() => Promise.resolve(null)),
+  aggregate: jest.fn(() => Promise.resolve([])),
+  create: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../backend/src/models/paymentIntentModel', () => ({
+  findOne: jest.fn(() => Promise.resolve(null)),
+  findByIdAndUpdate: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../backend/src/models/studentModel', () => ({
+  findOne: jest.fn(() => Promise.resolve({
+    schoolId: 'SCH-1122', studentId: 'STU-1122', name: 'Test Student', feeAmount: 250,
+  })),
+  findOneAndUpdate: jest.fn(() => Promise.resolve()),
+}));
+
+jest.mock('../backend/src/config/stellarConfig', () => ({
+  server: {},
+  ACCEPTED_ASSETS: [{ code: 'XLM', type: 'native' }],
+}));
+
+const { verifyPayment } = require('../backend/src/controllers/paymentController');
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildReqRes() {
+  const req = {
+    schoolId: SCHOOL_ID,
+    correlationId: 'corr-1122',
+    body: { txHash: TX_HASH },
+    school: { schoolId: SCHOOL_ID, stellarAddress: 'GSCHOOL', localCurrency: 'USD' },
+  };
+  const res = { json: jest.fn(), status: jest.fn(() => res) };
+  return { req, res };
+}
+
+/** Let the fire-and-forget receipt rejection settle before asserting. */
+const flushMicrotasks = () => new Promise(resolve => setImmediate(resolve));
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('#1122 — verify-controller receipt failures are logged, not swallowed', () => {
+  beforeEach(() => {
+    mockLogger.error.mockClear();
+    mockReceiptFailures.inc.mockClear();
+    mockCreateReceipt.mockClear();
+  });
+
+  test('a failing createReceipt produces an error log with diagnostic context', async () => {
+    const { req, res } = buildReqRes();
+
+    await verifyPayment(req, res, jest.fn());
+    await flushMicrotasks();
+
+    expect(mockCreateReceipt).toHaveBeenCalledTimes(1);
+
+    const receiptLog = mockLogger.error.mock.calls.find(([msg]) => /receipt/i.test(msg));
+    expect(receiptLog).toBeDefined();
+
+    // Context must be enough to diagnose root cause: which payment, which
+    // tenant/student, and the underlying error itself.
+    const [, context] = receiptLog;
+    expect(context).toMatchObject({
+      txHash: TX_HASH,
+      schoolId: SCHOOL_ID,
+      studentId: STUDENT_ID,
+      error: 'receipt template missing',
+    });
+    expect(context.stack).toContain('renderTemplate');
+  });
+
+  test('a failing createReceipt increments the receipt-failure metric', async () => {
+    const { req, res } = buildReqRes();
+
+    await verifyPayment(req, res, jest.fn());
+    await flushMicrotasks();
+
+    expect(mockReceiptFailures.inc).toHaveBeenCalledWith({ source: 'verify_controller' });
+  });
+
+  test('the payment is still confirmed to the caller despite the receipt failure', async () => {
+    const { req, res } = buildReqRes();
+    const next = jest.fn();
+
+    await verifyPayment(req, res, next);
+    await flushMicrotasks();
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ verified: true, hash: TX_HASH }),
+    );
+  });
+
+  test('a successful createReceipt logs no receipt error and moves no metric', async () => {
+    mockCreateReceipt.mockImplementationOnce(() => Promise.resolve({ txHash: TX_HASH }));
+    const { req, res } = buildReqRes();
+
+    await verifyPayment(req, res, jest.fn());
+    await flushMicrotasks();
+
+    expect(mockLogger.error.mock.calls.filter(([msg]) => /receipt/i.test(msg))).toHaveLength(0);
+    expect(mockReceiptFailures.inc).not.toHaveBeenCalled();
+  });
+});
+
+describe('#1122 — subscriber receipt failures are also metered', () => {
+  beforeEach(() => {
+    mockLogger.error.mockClear();
+    mockReceiptFailures.inc.mockClear();
+    mockCreateReceipt.mockClear();
+  });
+
+  test('onPaymentSavedReceipt logs and increments on failure without throwing', async () => {
+    const { onPaymentSavedReceipt } = require('../backend/src/services/paymentSavedSubscribers');
+
+    await expect(
+      onPaymentSavedReceipt({ txHash: TX_HASH, schoolId: SCHOOL_ID, studentId: STUDENT_ID }),
+    ).resolves.toBeUndefined();
+
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Receipt subscriber failed',
+      expect.objectContaining({ txHash: TX_HASH, error: 'receipt template missing' }),
+    );
+    expect(mockReceiptFailures.inc).toHaveBeenCalledWith({ source: 'payment_saved_subscriber' });
+  });
+});


### PR DESCRIPTION
paymentController's fire-and-forget createReceipt() call ended in a bare `.catch(() => {})`, discarding every receipt-generation error with no log line, no metric, and no operational signal — inconsistent with the rest of the same file, which logs failures on comparable async side-effect calls.

A systemic receipt failure (bad template, receipt-model/DB fault, downstream outage) was therefore completely invisible: nobody would know receipts had stopped generating until a parent reported one missing, with no trail showing when it started or why.

- Replace the empty catch with a logger.error carrying txHash, correlationId, schoolId, studentId and the underlying error/stack.
- Add a receipt_generation_failures_total{source} counter, incremented on both receipt paths (inline verify controller and payment-saved subscriber), so the failure is alertable and not only greppable.
- Add monitoring/alerts/receipts.yml with a warning rule on any sustained failure rate and a critical rule when failures outpace confirmed payments, wired into prometheus.yml's rule_files.
- Add tests asserting a failing createReceipt is logged with diagnostic context and increments the metric, that a successful one stays quiet, and that a receipt failure never breaks the payment response itself.

Closes #1122