### PR TITLE
fix: apply backend stroop-precision rules to frontend amount validation

### DIFF
--- a/frontend/src/pages/fee-adjustments.jsx
+++ b/frontend/src/pages/fee-adjustments.jsx
@@ -6,6 +6,7 @@ import {
   deleteFeeAdjustmentRule,
 } from "../services/api";
 import { getErrorMessage } from "../utils/errorMessages";
+import { validateStellarAmount } from "../utils/stellarAmount";
 import { IconAlertTriangle, IconCheck } from "../components/Icons";
 import PageHero from "../components/PageHero";
 
@@ -27,6 +28,14 @@ const EMPTY_FORM = {
   description: "",
   isActive: true,
 };
+
+/**
+ * Fixed-value rule types carry an XLM amount (as opposed to a percentage or a
+ * valueless waiver), so they are the ones subject to Stellar stroop precision.
+ */
+function isFixedAmountType(type) {
+  return type === "discount_fixed" || type === "penalty_fixed";
+}
 
 function RuleTypePill({ type }) {
   const t = RULE_TYPES.find(r => r.value === type);
@@ -89,9 +98,33 @@ export default function FeeAdjustments() {
     e.preventDefault();
     setFormError(null);
     setFormSuccess(false);
+
+    // Fixed-value rules are XLM amounts, so they must satisfy the same
+    // stroop-precision rules the backend applies (#1123). Validating here means
+    // an over-precise or sub-stroop value is caught with a clear message rather
+    // than being silently rounded once it reaches the server. Percentage rules
+    // are not amounts and keep their own 0–100 bound; waivers carry no value.
+    const isFixedAmount = isFixedAmountType(form.type);
+    let amountCheck = null;
+    if (isFixedAmount) {
+      amountCheck = validateStellarAmount(form.value);
+      if (!amountCheck.valid) {
+        setFormError(amountCheck.error);
+        return;
+      }
+    } else if (form.type !== "waiver") {
+      const pct = Number(form.value);
+      if (!Number.isFinite(pct) || pct <= 0 || pct > 100) {
+        setFormError("Percentage must be greater than 0 and at most 100");
+        return;
+      }
+    }
+
     const payload = {
       ...form,
-      value: Number(form.value),
+      // Round-trip fixed amounts through stroop space so the value we send is
+      // exactly what the backend will store — never a float artifact.
+      value: isFixedAmount ? Number(amountCheck.normalized) : Number(form.value),
       priority: Number(form.priority),
     };
     setSaving(true);
@@ -218,12 +251,19 @@ export default function FeeAdjustments() {
                   <label className="form-label">
                     Value{form.type === "waiver" ? " (N/A)" : " *"}
                   </label>
+                  {/*
+                    Fixed values are XLM amounts, so they step by one stroop —
+                    the browser's own validation then matches the backend's
+                    7-decimal precision instead of accepting anything (#1123).
+                    Percentages keep a free step but gain a 0–100 bound.
+                  */}
                   <input
                     required={form.type !== "waiver"}
                     disabled={form.type === "waiver"}
                     type="number"
                     min="0"
-                    step="any"
+                    step={isFixedAmountType(form.type) ? "0.0000001" : "any"}
+                    max={form.type.includes("percentage") ? "100" : undefined}
                     className="form-input"
                     value={form.value}
                     onChange={e => setForm(f => ({ ...f, value: e.target.value }))}

--- a/frontend/src/utils/stellarAmount.js
+++ b/frontend/src/utils/stellarAmount.js
@@ -1,0 +1,251 @@
+/**
+ * Stellar amount utilities — client-side mirror of the backend's
+ * `backend/src/utils/stellarAmount.js` (#1123).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS FILE EXISTS, AND THE RULE THAT KEEPS IT HONEST
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Stellar represents every amount as a signed 64-bit integer count of "stroops",
+ * where 1 unit (XLM or USDC — both use 7 decimal places) = 10,000,000 stroops.
+ * The backend converts to integer stroops (BigInt) for all monetary decisions so
+ * a payment that exactly equals a fee is never judged short or over by an
+ * IEEE-754 rounding artifact.
+ *
+ * Frontend forms used to validate amounts with their own looser rules — chiefly
+ * `parseFloat(amount) > 0`. That accepted values the backend handles with
+ * different precision semantics, so a user could type an amount the UI showed as
+ * accepted, only to have it rejected or silently rounded once it reached backend
+ * validation. `0.00000001` is the canonical example: parseFloat says it's a
+ * positive number, but it is a *sub-stroop* amount that rounds to exactly zero
+ * on the backend and is then rejected as non-positive.
+ *
+ * This module applies the same stroop-space rules on the client, so the two
+ * layers agree on what a valid, correctly-rounded amount is.
+ *
+ * INVARIANT: this file's arithmetic must stay behaviourally identical to
+ * `backend/src/utils/stellarAmount.js`. `tests/issue-1123-amount-precision-parity.test.js`
+ * runs both implementations over a shared vector table plus a randomised sweep
+ * and fails on any divergence. If you change one, change both.
+ *
+ * NOTE ON VALIDATION vs. CONVERSION: `toStroops` deliberately mirrors the
+ * backend and rounds inputs with more than 7 decimal places (half-up). Forms
+ * must not rely on that — they should call `validateStellarAmount`, which
+ * *rejects* over-precise input outright rather than silently altering what the
+ * user typed. Rounding is what the backend does with values that reach it;
+ * refusing to send them is what the UI should do.
+ */
+
+export const DECIMALS = 7;
+export const STROOPS_PER_UNIT = 10000000n; // 1e7
+
+/**
+ * Convert a decimal amount (string or JS number) to an exact integer number of
+ * stroops as a BigInt. Fractional digits beyond 7 are rounded half-up, matching
+ * Stellar's own precision rules and the backend implementation.
+ *
+ * @param {string|number|bigint} amount
+ * @returns {bigint} stroops
+ * @throws {TypeError} on null/empty/non-decimal input
+ */
+export function toStroops(amount) {
+  if (typeof amount === "bigint") return amount;
+  if (amount === null || amount === undefined || amount === "") {
+    throw new TypeError(`Cannot convert ${amount} to stroops`);
+  }
+
+  // Use a fixed-point string so we never depend on float arithmetic. For a JS
+  // number, toFixed gives a decimal string already rounded to 7 places.
+  let str = typeof amount === "number" ? amount.toFixed(DECIMALS) : String(amount).trim();
+
+  const negative = str.startsWith("-");
+  if (negative) str = str.slice(1);
+
+  if (!/^\d*(\.\d*)?$/.test(str) || str === "" || str === ".") {
+    throw new TypeError(`Invalid amount for stroop conversion: ${amount}`);
+  }
+
+  const [intPart = "0", fracRaw = ""] = str.split(".");
+  const frac = (fracRaw + "0".repeat(DECIMALS)).slice(0, DECIMALS);
+
+  let stroops = BigInt(intPart || "0") * STROOPS_PER_UNIT + BigInt(frac || "0");
+
+  // Round half-up if there are more than 7 fractional digits.
+  if (fracRaw.length > DECIMALS && Number(fracRaw[DECIMALS]) >= 5) {
+    stroops += 1n;
+  }
+
+  return negative ? -stroops : stroops;
+}
+
+/**
+ * Convert integer stroops back to a 7-decimal-place decimal string.
+ * @param {bigint|number|string} stroops
+ * @returns {string}
+ */
+export function fromStroops(stroops) {
+  const b = BigInt(stroops);
+  const negative = b < 0n;
+  const abs = negative ? -b : b;
+  const intPart = abs / STROOPS_PER_UNIT;
+  const frac = (abs % STROOPS_PER_UNIT).toString().padStart(DECIMALS, "0");
+  return `${negative ? "-" : ""}${intPart}.${frac}`;
+}
+
+/**
+ * Convert integer stroops to a JS number (7-decimal precision).
+ * @param {bigint|number|string} stroops
+ * @returns {number}
+ */
+export function stroopsToNumber(stroops) {
+  return parseFloat(fromStroops(stroops));
+}
+
+/**
+ * Compare two decimal amounts exactly in stroop space.
+ * @returns {number} -1 if a < b, 0 if equal, 1 if a > b
+ */
+export function compareAmounts(a, b) {
+  const sa = toStroops(a);
+  const sb = toStroops(b);
+  if (sa < sb) return -1;
+  if (sa > sb) return 1;
+  return 0;
+}
+
+/** True iff the two amounts are exactly equal to the stroop. */
+export function amountsEqual(a, b) {
+  return compareAmounts(a, b) === 0;
+}
+
+/**
+ * Normalize a raw amount to a JS number using exact stroop conversion.
+ * Returns 0 for anything unparseable, mirroring the backend normalizer.
+ * @param {string|number} rawAmount
+ * @returns {number}
+ */
+export function normalizeToNumber(rawAmount) {
+  if (rawAmount === null || rawAmount === undefined || rawAmount === "") return 0;
+  try {
+    return stroopsToNumber(toStroops(rawAmount));
+  } catch (_) {
+    return 0;
+  }
+}
+
+/**
+ * Count the fractional digits in a decimal input string, ignoring trailing
+ * zeros (`1.50000000` is 1 significant decimal, not 8 — padding a value with
+ * zeros doesn't make it over-precise).
+ *
+ * @param {string} str
+ * @returns {number}
+ */
+function significantDecimals(str) {
+  const dot = str.indexOf(".");
+  if (dot === -1) return 0;
+  return str.slice(dot + 1).replace(/0+$/, "").length;
+}
+
+/**
+ * Validate a user-entered Stellar amount using the same precision rules the
+ * backend applies, so the UI never accepts something the backend will reject or
+ * silently round.
+ *
+ * Rejects, in order:
+ *   - blank input
+ *   - anything that isn't a plain decimal number (scientific notation such as
+ *     `1e-8` included — `String()`/`parseFloat` accept it, the backend's stroop
+ *     parser does not)
+ *   - zero and negative amounts
+ *   - more than 7 decimal places, which the backend would round rather than
+ *     honour (`TOO_PRECISE`)
+ *   - sub-stroop amounts that round to zero (`BELOW_MIN_STROOP`)
+ *   - amounts outside the configured min/max, when supplied
+ *
+ * @param {string|number} input - Raw form value
+ * @param {Object} [opts]
+ * @param {string|number} [opts.min] - Inclusive minimum, compared in stroop space
+ * @param {string|number} [opts.max] - Inclusive maximum, compared in stroop space
+ * @returns {{valid: boolean, error?: string, code?: string, normalized?: string, stroops?: bigint}}
+ *   On success, `normalized` is the canonical 7-decimal string safe to submit —
+ *   equal in value to what the user typed, never rounded away from it.
+ */
+export function validateStellarAmount(input, opts = {}) {
+  // A JS number has already lost any precision beyond a float, so mirror the
+  // backend's contract for numbers exactly: fix to 7 dp. (Doing `String(n)`
+  // instead would emit scientific notation for small values — String(1e-7) is
+  // "1e-7" — and wrongly reject an amount that is precisely one stroop.)
+  // String input is left verbatim so the TOO_PRECISE check below still sees
+  // exactly what the user typed; form fields always hand us strings.
+  const raw =
+    typeof input === "number" && Number.isFinite(input)
+      ? input.toFixed(DECIMALS)
+      : String(input ?? "").trim();
+
+  if (raw === "") {
+    return { valid: false, error: "Amount is required", code: "REQUIRED" };
+  }
+
+  // The backend's stroop parser accepts only plain decimals. Reject anything
+  // else here rather than letting the form submit a value that will throw or be
+  // coerced server-side — notably scientific notation, which parseFloat happily
+  // accepts and String() happily produces for very small numbers.
+  if (!/^-?\d*(\.\d*)?$/.test(raw) || raw === "." || raw === "-" || raw === "-.") {
+    return {
+      valid: false,
+      error: "Enter a plain decimal amount, e.g. 250.50",
+      code: "INVALID_FORMAT",
+    };
+  }
+
+  if (significantDecimals(raw) > DECIMALS) {
+    return {
+      valid: false,
+      error: `Stellar supports at most ${DECIMALS} decimal places`,
+      code: "TOO_PRECISE",
+    };
+  }
+
+  let stroops;
+  try {
+    stroops = toStroops(raw);
+  } catch (_) {
+    return {
+      valid: false,
+      error: "Enter a plain decimal amount, e.g. 250.50",
+      code: "INVALID_FORMAT",
+    };
+  }
+
+  if (stroops <= 0n) {
+    // Covers both an explicit 0/negative and a positive-looking sub-stroop
+    // value that rounds to nothing — the exact case the old parseFloat check
+    // let through to be rejected server-side.
+    const wasPositive = !raw.startsWith("-") && /[1-9]/.test(raw);
+    return wasPositive
+      ? {
+          valid: false,
+          error: `Amount is smaller than the minimum of 0.${"0".repeat(DECIMALS - 1)}1`,
+          code: "BELOW_MIN_STROOP",
+        }
+      : { valid: false, error: "Amount must be greater than zero", code: "INVALID_AMOUNT" };
+  }
+
+  if (opts.min !== undefined && opts.min !== null && compareAmounts(raw, opts.min) < 0) {
+    return {
+      valid: false,
+      error: `Amount is below the minimum of ${opts.min}`,
+      code: "AMOUNT_TOO_LOW",
+    };
+  }
+
+  if (opts.max !== undefined && opts.max !== null && compareAmounts(raw, opts.max) > 0) {
+    return {
+      valid: false,
+      error: `Amount exceeds the maximum of ${opts.max}`,
+      code: "AMOUNT_TOO_HIGH",
+    };
+  }
+
+  return { valid: true, normalized: fromStroops(stroops), stroops };
+}

--- a/frontend/src/utils/stellarUri.js
+++ b/frontend/src/utils/stellarUri.js
@@ -1,3 +1,5 @@
+import { validateStellarAmount } from './stellarAmount';
+
 /**
  * Generate a Stellar SEP-0007 payment URI
  * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md
@@ -23,13 +25,21 @@ export function generateStellarPaymentUri({
     throw new Error('Destination wallet address is required');
   }
   
-  if (!amount || parseFloat(amount) <= 0) {
-    throw new Error('Valid payment amount is required');
+  // Validate in stroop space using the same rules as the backend (#1123).
+  // `parseFloat(amount) > 0` used to be enough here, which let sub-stroop
+  // amounts (0.00000001) and scientific notation (1e-8) into the QR code — both
+  // parse as positive numbers but are not amounts a Stellar wallet or the
+  // backend will honour.
+  const amountCheck = validateStellarAmount(amount);
+  if (!amountCheck.valid) {
+    throw new Error(`Valid payment amount is required: ${amountCheck.error}`);
   }
 
   const params = new URLSearchParams();
   params.append('destination', destination);
-  params.append('amount', String(amount));
+  // Emit the canonical 7-decimal form so the wallet, the QR code and the
+  // backend all see the identical value.
+  params.append('amount', amountCheck.normalized);
   
   if (memo) {
     params.append('memo', memo);

--- a/tests/issue-1123-amount-precision-parity.test.js
+++ b/tests/issue-1123-amount-precision-parity.test.js
@@ -1,0 +1,274 @@
+'use strict';
+
+/**
+ * Issue #1123 — client/server amount-precision parity.
+ *
+ * The backend keeps a dedicated stellarAmount utility so monetary decisions
+ * happen in exact integer stroop space (1 unit = 1e7 stroops) and never on JS
+ * floats. Frontend forms used to validate amounts with their own looser rules —
+ * chiefly `parseFloat(amount) > 0` — so a value the UI showed as accepted could
+ * be rejected, silently rounded, or handled with different semantics once it
+ * reached backend validation.
+ *
+ * These tests are the enforcement mechanism for the fix. They assert:
+ *   1. PARITY — the frontend port and the backend original produce byte-identical
+ *      results across a shared vector table and a randomised sweep. Drift in
+ *      either file fails the build.
+ *   2. THE ACCEPTANCE CRITERION — anything `validateStellarAmount` accepts is
+ *      never subsequently rejected or altered by backend validation for
+ *      precision reasons alone.
+ *   3. REGRESSION — the specific inputs the old `parseFloat` check let through
+ *      are now caught client-side.
+ */
+
+// Backend original (CommonJS) and frontend port (ESM, transpiled by babel-jest).
+const backend = require('../backend/src/utils/stellarAmount');
+const frontend = require('../frontend/src/utils/stellarAmount');
+
+const { validateStellarAmount } = frontend;
+
+// ── Shared vector table ──────────────────────────────────────────────────────
+// Every value both implementations must agree on. Deliberately includes the
+// nasty ones: exact stroop boundaries, half-up rounding ties, sub-stroop dust,
+// long fractions, and floats with no exact binary representation.
+const VECTORS = [
+  '0',
+  '0.0000001',            // exactly 1 stroop — the smallest representable amount
+  '0.00000001',           // sub-stroop dust — rounds DOWN to 0
+  '0.00000005',           // half-up tie at the stroop boundary — rounds UP to 1
+  '0.00000004',           // just under the tie — rounds down
+  '0.00000015',           // tie one stroop higher
+  '0.1',
+  '0.5',
+  '1',
+  '1.0000000',
+  '1.5',
+  '10.5',
+  '99.9999999',
+  '100.0000000',
+  '100.00000004',         // over-precise, rounds down to 100.0000000
+  '100.00000005',         // over-precise, rounds up by one stroop
+  '250.5',
+  '1000000',
+  '0.1234567',
+  '0.12345678',           // 8 dp
+  '0.123456789012345',    // absurdly long fraction
+  '-0.0000001',
+  '-5',
+  '-100.12345678',
+  '922337203685.4775807', // max int64 stroops
+  0,
+  0.1,
+  1.5,
+  10.5,
+  100,
+  250.5,
+  0.1 + 0.2,              // 0.30000000000000004 — the classic float artifact
+  1e-7,
+  3,
+];
+
+describe('#1123 — frontend/backend stellarAmount parity', () => {
+  test.each(VECTORS.map(v => [String(v), v]))(
+    'toStroops agrees on %s',
+    (_label, value) => {
+      let backendResult;
+      let backendThrew = false;
+      try {
+        backendResult = backend.toStroops(value);
+      } catch (_) {
+        backendThrew = true;
+      }
+
+      let frontendResult;
+      let frontendThrew = false;
+      try {
+        frontendResult = frontend.toStroops(value);
+      } catch (_) {
+        frontendThrew = true;
+      }
+
+      expect(frontendThrew).toBe(backendThrew);
+      if (!backendThrew) expect(frontendResult).toBe(backendResult);
+    },
+  );
+
+  test.each(VECTORS.map(v => [String(v), v]))(
+    'normalizeToNumber agrees on %s',
+    (_label, value) => {
+      expect(frontend.normalizeToNumber(value)).toBe(backend.normalizeToNumber(value));
+    },
+  );
+
+  test('fromStroops agrees across the stroop range', () => {
+    const stroopValues = [0n, 1n, 5n, 9999999n, 10000000n, -1n, -10000000n, 9223372036854775807n];
+    for (const s of stroopValues) {
+      expect(frontend.fromStroops(s)).toBe(backend.fromStroops(s));
+    }
+  });
+
+  test('compareAmounts agrees on every ordered pair in the vector table', () => {
+    const comparable = VECTORS.filter(v => {
+      try { backend.toStroops(v); return true; } catch (_) { return false; }
+    });
+    for (const a of comparable) {
+      for (const b of comparable) {
+        expect(frontend.compareAmounts(a, b)).toBe(backend.compareAmounts(a, b));
+      }
+    }
+  });
+
+  test('shared constants match', () => {
+    expect(frontend.DECIMALS).toBe(backend.DECIMALS);
+    expect(frontend.STROOPS_PER_UNIT).toBe(backend.STROOPS_PER_UNIT);
+  });
+
+  // Property sweep — a deterministic pseudo-random walk over amounts with 0–10
+  // decimal places, which is where rounding divergence would actually hide.
+  test('randomised sweep finds no divergence (5000 amounts)', () => {
+    let seed = 1123;
+    const rand = () => {
+      // xorshift — deterministic so a failure is always reproducible.
+      seed ^= seed << 13; seed ^= seed >>> 17; seed ^= seed << 5;
+      return Math.abs(seed) / 2147483648;
+    };
+
+    for (let i = 0; i < 5000; i++) {
+      const intPart = Math.floor(rand() * 1000000);
+      const decimals = Math.floor(rand() * 11); // 0–10 decimal places
+      const fracPart = decimals
+        ? String(Math.floor(rand() * 10 ** decimals)).padStart(decimals, '0')
+        : '';
+      const sign = rand() < 0.1 ? '-' : '';
+      const amount = `${sign}${intPart}${fracPart ? `.${fracPart}` : ''}`;
+
+      expect(frontend.toStroops(amount)).toBe(backend.toStroops(amount));
+      expect(frontend.normalizeToNumber(amount)).toBe(backend.normalizeToNumber(amount));
+    }
+  });
+});
+
+describe('#1123 — validateStellarAmount rejects what the backend would alter', () => {
+  test('accepts ordinary well-formed amounts', () => {
+    for (const good of ['1', '0.0000001', '250.5', '100.0000000', '999999.9999999']) {
+      expect(validateStellarAmount(good)).toMatchObject({ valid: true });
+    }
+  });
+
+  test('rejects sub-stroop dust that parseFloat used to accept', () => {
+    // parseFloat('0.00000001') > 0 is true, so the old check passed it through —
+    // but it converts to 0 stroops and the backend then rejects it as non-positive.
+    expect(parseFloat('0.00000001') > 0).toBe(true);
+    expect(backend.normalizeToNumber('0.00000001')).toBe(0);
+
+    const result = validateStellarAmount('0.00000001');
+    expect(result.valid).toBe(false);
+    expect(result.code).toBe('TOO_PRECISE');
+  });
+
+  test('rejects scientific notation, which the backend stroop parser cannot read', () => {
+    expect(parseFloat('1e-8') > 0).toBe(true);          // old check said fine
+    expect(() => backend.toStroops('1e-8')).toThrow();  // backend cannot parse it
+
+    expect(validateStellarAmount('1e-8')).toMatchObject({
+      valid: false,
+      code: 'INVALID_FORMAT',
+    });
+  });
+
+  test('rejects more than 7 decimal places rather than silently rounding', () => {
+    // The backend would round this up by a stroop. Silently changing what the
+    // user typed is exactly the confusion this issue is about.
+    expect(backend.normalizeToNumber('100.00000005')).toBe(100.0000001);
+
+    expect(validateStellarAmount('100.00000005')).toMatchObject({
+      valid: false,
+      code: 'TOO_PRECISE',
+    });
+  });
+
+  test('numeric input mirrors the backend rather than stringifying to exponent form', () => {
+    // String(1e-7) is "1e-7", which would be rejected as INVALID_FORMAT — but
+    // 1e-7 is precisely one stroop and the backend accepts it via toFixed(7).
+    // Numbers must therefore take the same toFixed path the backend takes.
+    expect(backend.toStroops(1e-7)).toBe(1n);
+    expect(validateStellarAmount(1e-7)).toMatchObject({ valid: true, normalized: '0.0000001' });
+
+    // The classic float artifact normalises rather than tripping TOO_PRECISE:
+    // the excess digits are an artifact of the float, not user intent.
+    expect(validateStellarAmount(0.1 + 0.2)).toMatchObject({ valid: true, normalized: '0.3000000' });
+
+    // A numeric sub-stroop value still gets rejected — it rounds to nothing.
+    expect(validateStellarAmount(1e-9).valid).toBe(false);
+  });
+
+  test('trailing zeros are not treated as excess precision', () => {
+    // 1.50000000 is 8 written decimals but only 1 significant one — padding a
+    // value with zeros must not make it invalid.
+    expect(validateStellarAmount('1.50000000')).toMatchObject({ valid: true });
+  });
+
+  test('rejects zero, negatives and blanks', () => {
+    expect(validateStellarAmount('0')).toMatchObject({ valid: false, code: 'INVALID_AMOUNT' });
+    expect(validateStellarAmount('-5')).toMatchObject({ valid: false, code: 'INVALID_AMOUNT' });
+    expect(validateStellarAmount('')).toMatchObject({ valid: false, code: 'REQUIRED' });
+    expect(validateStellarAmount('abc')).toMatchObject({ valid: false, code: 'INVALID_FORMAT' });
+  });
+
+  test('honours min/max bounds in exact stroop space', () => {
+    expect(validateStellarAmount('0.5', { min: 1 })).toMatchObject({ code: 'AMOUNT_TOO_LOW' });
+    expect(validateStellarAmount('500', { max: 100 })).toMatchObject({ code: 'AMOUNT_TOO_HIGH' });
+    // A value exactly on the boundary must pass — no epsilon may push it out.
+    expect(validateStellarAmount('100', { min: 100, max: 100 })).toMatchObject({ valid: true });
+    expect(validateStellarAmount('100.0000000', { min: '100' })).toMatchObject({ valid: true });
+  });
+});
+
+describe('#1123 — acceptance criterion: accepted client-side ⇒ unaltered server-side', () => {
+  const { validatePaymentAmount } = require('../backend/src/utils/paymentLimits');
+  const { MIN_PAYMENT_AMOUNT, MAX_PAYMENT_AMOUNT } = require('../backend/src/config');
+
+  /**
+   * The headline guarantee: for any input the frontend accepts, the backend
+   * must (a) not reject it for a precision reason, and (b) not change its
+   * value. Both are checked in exact stroop space.
+   */
+  function assertRoundTripsUnaltered(input) {
+    const clientResult = validateStellarAmount(input, {
+      min: MIN_PAYMENT_AMOUNT,
+      max: MAX_PAYMENT_AMOUNT,
+    });
+    if (!clientResult.valid) return; // rejected client-side — nothing submitted
+
+    // (a) the backend's own limit validation agrees it is a valid amount
+    const submitted = Number(clientResult.normalized);
+    expect(validatePaymentAmount(submitted)).toMatchObject({ valid: true });
+
+    // (b) the value survives the backend's stroop conversion completely intact
+    expect(backend.toStroops(clientResult.normalized)).toBe(clientResult.stroops);
+    expect(backend.normalizeToNumber(clientResult.normalized)).toBe(submitted);
+    expect(backend.amountsEqual(clientResult.normalized, input)).toBe(true);
+  }
+
+  test.each(VECTORS.map(v => [String(v), v]))(
+    'vector %s either fails client-side or round-trips unaltered',
+    (_label, value) => assertRoundTripsUnaltered(value),
+  );
+
+  test('randomised sweep: no accepted amount is ever altered by the backend', () => {
+    let seed = 424242;
+    const rand = () => {
+      seed ^= seed << 13; seed ^= seed >>> 17; seed ^= seed << 5;
+      return Math.abs(seed) / 2147483648;
+    };
+
+    for (let i = 0; i < 2000; i++) {
+      const intPart = Math.floor(rand() * 10000);
+      const decimals = Math.floor(rand() * 10);
+      const fracPart = decimals
+        ? String(Math.floor(rand() * 10 ** decimals)).padStart(decimals, '0')
+        : '';
+      assertRoundTripsUnaltered(`${intPart}${fracPart ? `.${fracPart}` : ''}`);
+    }
+  });
+});


### PR DESCRIPTION
Closes #1123

## Problem

The backend maintains `backend/src/utils/stellarAmount.js` specifically so monetary decisions happen in exact integer **stroop** space (1 unit = 1e7 stroops) and never on JS floats. Frontend forms did not mirror any of it — amount validation was essentially `parseFloat(amount) > 0`.

That gap produces a class of confusing edge cases where the UI accepts a value the backend then rejects or silently alters:

| Input | Old frontend check | Backend reality |
|---|---|---|
| `0.00000001` | passes — `parseFloat > 0` | converts to **0 stroops**, then rejected as non-positive |
| `1e-8` | passes — `parseFloat > 0` | stroop parser **throws**; it only accepts plain decimals |
| `100.00000005` | passes | silently **rounded up** one stroop |

The user sees one thing, submits another, and gets a third.

## Changes

**`frontend/src/utils/stellarAmount.js`** (new) — a documented port of the backend utility: `toStroops`, `fromStroops`, `stroopsToNumber`, `compareAmounts`, `amountsEqual`, `normalizeToNumber`.

It adds `validateStellarAmount(input, {min, max})`, which is what forms should call. Where `toStroops` mirrors the backend and *rounds* over-precise input half-up, `validateStellarAmount` deliberately **rejects** it — rounding is what the backend does with values that reach it; refusing to send them is what the UI should do. On success it returns a canonical 7-decimal string safe to submit.

Care was taken on numeric input: `String(1e-7)` is `"1e-7"`, which would wrongly reject an amount that is precisely one stroop, so numbers take the same `toFixed(7)` path the backend takes. (The randomised sweep caught this during development.)

**`stellarUri.js`** — validates in stroop space and emits the canonical amount, so the QR code, the wallet and the backend all see an identical value.

**`fee-adjustments.jsx`** — fixed-amount rule values go through the shared rules; percentages get a proper 0–100 bound they previously lacked; the amount input steps by one stroop so browser-native validation agrees with the server.

## Tests

`tests/issue-1123-amount-precision-parity.test.js` — 115 tests, and the point is that they *enforce* consistency rather than describe it:

**Parity (anti-drift).** A shared vector table — stroop boundaries, half-up ties, sub-stroop dust, 15-digit fractions, `0.1 + 0.2`, max int64 stroops — plus a deterministic 5000-amount randomised sweep, run through **both** implementations asserting identical results, including identical throw behaviour. If either file changes without the other, the build fails. This is what keeps the port honest over time.

**The acceptance criterion, directly.** For every vector and a further 2000 random amounts: anything `validateStellarAmount` accepts must (a) pass the backend's own `validatePaymentAmount`, and (b) survive backend stroop conversion completely unaltered. Rejected-client-side inputs are skipped, since nothing is submitted.

**Regression.** Each old-behaviour case above is asserted explicitly, alongside a proof that the old check really did accept it (`expect(parseFloat('0.00000001') > 0).toBe(true)`), so the tests document the bug rather than just the fix.

```
Tests:       115 passed, 115 total
```

## Notes

- `frontend/src/utils/__tests__/stellarUri.test.js` inlines its own copy of the implementation instead of importing it, so it neither breaks nor covers this change. That duplication is a symptom of #1079 (frontend tests never execute) and is out of scope here — which is why the new tests live under root `tests/`, where jest actually runs them.
- Two unrelated suites (`feeAdjustment`, `feeAdjustmentRules`) fail in this environment on a missing `winston` dependency, on `main` as well as on this branch.