### PR TITLE
feat: coordinate Horizon poll budget across schools with a documented SLA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Rate limit persistence requires Redis configuration; without it, counters reset on server restart
 - MongoDB replica set required for multi-document transactions (not supported on standalone instances)
-- Stellar Horizon API rate limits may cause temporary sync delays during high-volume periods
+- Stellar Horizon API rate limits constrain sync throughput during high-volume periods. This is now bounded and documented rather than open-ended: polling draws from a coordinated cross-school request budget spent in priority order, with measured maximum sync-delay figures and configuration guidance in [docs/horizon-rate-limits.md](docs/horizon-rate-limits.md). Operators running more than one replica must set `HORIZON_POLL_REPLICA_COUNT`, and should re-validate the published figures against their own Horizon instance before quoting them contractually.
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -202,6 +202,41 @@ POLL_INTERVAL_MS=30000
 # then resets to POLL_INTERVAL_MS on the first successful cycle.
 POLL_MAX_BACKOFF_MS=300000
 
+# ── Coordinated Horizon poll budget (#1124) ───────────────────
+# Polling draws from a single per-cycle Horizon request allowance shared by
+# ALL schools and spent in priority order (schools with pending unconfirmed
+# payments first), rather than each school polling independently. This bounds
+# sync delay as the tenant count grows instead of letting it scale linearly.
+# Full rationale, measured SLA figures and tuning guidance:
+#   docs/horizon-rate-limits.md
+
+# Horizon's request allowance for your IP/API key, per hour.
+# 3600 is Horizon's default anonymous limit. Raise this if you run a paid or
+# self-hosted Horizon instance with a higher allowance.
+HORIZON_RATE_LIMIT_PER_HOUR=3600
+
+# Fraction of that allowance the background poller may consume (0.0–1.0).
+# Held below 1.0 on purpose: the verify endpoint, retry worker and confirmation
+# finalizer share the same limit and are user-facing, so they must not be
+# starved by background polling.
+HORIZON_POLL_BUDGET_SAFETY_FACTOR=0.6
+
+# IMPORTANT for multi-replica deployments. The budget is per-process, so each
+# replica takes 1/N of the global allowance. Leaving this at 1 while running N
+# replicas means the combined rate is N x the intended budget and Horizon will
+# start returning 429s again. Set it to your actual replica count.
+HORIZON_POLL_REPLICA_COUNT=1
+
+# Floor on the per-cycle budget, so a misconfiguration can never stop polling.
+HORIZON_POLL_MIN_BUDGET=4
+
+# Window over which a school's recent on-chain activity raises its poll priority.
+HORIZON_POLL_RECENT_ACTIVITY_WINDOW_MS=3600000
+
+# Maximum schools polled simultaneously. The budget caps total requests; this
+# caps how bursty they are.
+SYNC_MAX_CONCURRENT_SCHOOLS=4
+
 # ── Retry / Outage Recovery ───────────────────────────────────
 RETRY_INTERVAL_MS=60000
 RETRY_MAX_ATTEMPTS=10

--- a/backend/src/metrics/index.js
+++ b/backend/src/metrics/index.js
@@ -261,8 +261,57 @@ const notificationSentTotal = new client.Counter({
   registers: [registry],
 });
 
+// ── Coordinated Horizon poll budget (#1124) ─────────────────────────────────
+// Polling draws from a single per-cycle request allowance shared across all
+// schools, spent in priority order. These expose whether that allowance binds,
+// how far the adaptive ceiling has been pulled down by observed 429s, and — the
+// SLA-relevant one — the worst staleness any tenant is currently experiencing.
+const horizonPollBudgetRemaining = new client.Gauge({
+  name: 'horizon_poll_budget_remaining',
+  help: 'Horizon request tokens left in the current poll cycle budget',
+  registers: [registry],
+});
+
+const horizonPollBudgetCeiling = new client.Gauge({
+  name: 'horizon_poll_budget_ceiling',
+  help: 'Current adaptive per-cycle Horizon request ceiling (AIMD-adjusted)',
+  registers: [registry],
+});
+
+const horizonPollDeferredSchools = new client.Gauge({
+  name: 'horizon_poll_deferred_schools',
+  help: 'Number of schools currently deferred because the poll budget was exhausted',
+  registers: [registry],
+});
+
+// The direct input to the documented max-sync-delay SLA: worst-case delay is
+// approximately (this value + 1) x the poll interval.
+const horizonPollMaxDeferralCycles = new client.Gauge({
+  name: 'horizon_poll_max_deferral_cycles',
+  help: 'Highest number of consecutive cycles any single school has been deferred',
+  registers: [registry],
+});
+
+const horizonPollRequestsTotal = new client.Counter({
+  name: 'horizon_poll_requests_total',
+  help: 'Total Horizon page requests issued by the transaction poller',
+  registers: [registry],
+});
+
+const horizonRateLimitedTotal = new client.Counter({
+  name: 'horizon_rate_limited_total',
+  help: 'Number of Horizon responses observed as HTTP 429 by the poller',
+  registers: [registry],
+});
+
 module.exports = {
   registry,
+  horizonPollBudgetRemaining,
+  horizonPollBudgetCeiling,
+  horizonPollDeferredSchools,
+  horizonPollMaxDeferralCycles,
+  horizonPollRequestsTotal,
+  horizonRateLimitedTotal,
   syncDurationSeconds,
   httpRequestDurationSeconds,
   suspiciousPaymentFlagged,

--- a/backend/src/services/horizonPollBudget.js
+++ b/backend/src/services/horizonPollBudget.js
@@ -1,0 +1,322 @@
+'use strict';
+
+/**
+ * Coordinated cross-school Horizon request budget (#1124).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE SCALING CEILING THIS EXISTS TO REMOVE
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The poller used to treat every school's sync as an independent operation:
+ * `Promise.allSettled(schools.map(pollSchoolTransactions))` fanned out to all
+ * active schools at once, each free to drain up to MAX_PAGES_PER_POLL pages.
+ * Horizon request volume therefore scaled as
+ *
+ *     requests/cycle  ≈  Σ over schools (pages needed by that school)
+ *
+ * growing linearly with the number of onboarded schools, while Horizon's rate
+ * limit for our IP/key is a *fixed* budget that does not grow at all. That makes
+ * rate-limiting a predictable scaling ceiling rather than a rare edge case.
+ *
+ * The per-call retry in withStellarRetry does not address this. It caps at a
+ * short backoff and, worse, is applied independently per call — so under
+ * sustained 429s every school retries simultaneously, converting one rate-limit
+ * event into a thundering herd that keeps the limit saturated.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT THIS MODULE DOES INSTEAD
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 1. BUDGET. A token bucket sized from Horizon's actual rate limit and the poll
+ *    interval bounds total requests per cycle across ALL schools. Work that
+ *    doesn't fit is deferred to the next cycle instead of being issued and
+ *    429'd. Deferral is cheap and ordered; a 429 storm is neither.
+ *
+ * 2. PRIORITY. The budget is spent on the schools where delay actually matters.
+ *    A school with unconfirmed payments awaiting verification is polled ahead of
+ *    a fully-settled school whose poll would return nothing. Under constraint
+ *    this is what keeps *perceived* sync delay low even when raw throughput is
+ *    capped — the parent waiting on a payment is in the first group.
+ *
+ * 3. AGING. Priority alone starves quiet schools forever, so every deferred
+ *    cycle raises a school's score. This bounds worst-case staleness for even
+ *    the lowest-priority tenant — the guarantee the SLA in
+ *    docs/horizon-rate-limits.md is stated against.
+ *
+ * 4. ADAPTATION. Observed 429s shrink the budget multiplicatively; clean cycles
+ *    grow it back additively (AIMD, the same control law TCP uses). The system
+ *    converges on the real limit instead of assuming the configured one is
+ *    right, which matters because Horizon's limit varies by provider and plan.
+ *
+ * Distributed note: the budget is per-process. With N replicas polling, set
+ * HORIZON_POLL_REPLICA_COUNT=N so each takes 1/N of the global budget. The
+ * per-school distributed lock already prevents two replicas syncing the same
+ * school, so this partitioning is safe, if conservative.
+ */
+
+const logger = require('../utils/logger').child('HorizonPollBudget');
+
+// Horizon's default anonymous limit is 3600 requests/hour. Operators on a paid
+// or self-hosted instance should raise this to match their actual allowance.
+const HORIZON_RATE_LIMIT_PER_HOUR = parseInt(
+  process.env.HORIZON_RATE_LIMIT_PER_HOUR || '3600', 10);
+
+// Fraction of the limit the poller may consume. Held below 1.0 deliberately:
+// polling is not the only Horizon consumer — the verify endpoint, retry worker
+// and confirmation finalizer all share the same allowance, and they are
+// user-facing so they must never be starved by background polling.
+const POLL_BUDGET_SAFETY_FACTOR = parseFloat(
+  process.env.HORIZON_POLL_BUDGET_SAFETY_FACTOR || '0.6');
+
+// Number of replicas sharing the Horizon allowance.
+const REPLICA_COUNT = Math.max(1, parseInt(
+  process.env.HORIZON_POLL_REPLICA_COUNT || '1', 10));
+
+// Floor so a misconfiguration can never wedge polling entirely.
+const MIN_BUDGET_PER_CYCLE = Math.max(1, parseInt(
+  process.env.HORIZON_POLL_MIN_BUDGET || '4', 10));
+
+// AIMD constants. Multiplicative decrease reacts fast to a real limit; additive
+// increase probes back slowly so we don't oscillate into the limit repeatedly.
+const AIMD_DECREASE_FACTOR = 0.5;
+const AIMD_INCREASE_TOKENS = 2;
+
+// Priority weights. Pending verifications dominate: that is the case where a
+// parent is actively waiting for a payment to appear.
+const PRIORITY_PENDING_PAYMENT = 100;
+const PRIORITY_RECENT_ACTIVITY = 20;
+const PRIORITY_NEVER_SYNCED = 250;   // backfill a new school promptly
+const PRIORITY_AGING_PER_CYCLE = 15; // starvation guard
+
+// A school with recent on-chain activity is more likely to have more.
+const RECENT_ACTIVITY_WINDOW_MS = parseInt(
+  process.env.HORIZON_POLL_RECENT_ACTIVITY_WINDOW_MS || String(60 * 60 * 1000), 10);
+
+/**
+ * Compute the nominal number of Horizon requests the poller may issue in one
+ * cycle of `intervalMs`, given the configured hourly limit.
+ *
+ * @param {number} intervalMs - Poll cycle interval
+ * @returns {number} requests permitted per cycle (>= MIN_BUDGET_PER_CYCLE)
+ */
+function computeCycleBudget(intervalMs) {
+  const perMs = HORIZON_RATE_LIMIT_PER_HOUR / 3600000;
+  const raw = perMs * intervalMs * POLL_BUDGET_SAFETY_FACTOR / REPLICA_COUNT;
+  return Math.max(MIN_BUDGET_PER_CYCLE, Math.floor(raw));
+}
+
+/**
+ * Score a school for this cycle. Higher is polled sooner.
+ *
+ * @param {object} school - School document (needs schoolId, syncCursor)
+ * @param {object} signals
+ * @param {number} [signals.pendingCount] - Unconfirmed payments awaiting verification
+ * @param {number|Date} [signals.lastActivityAt] - Most recent confirmed payment
+ * @param {number} [signals.cyclesDeferred] - Consecutive cycles skipped for budget
+ * @param {number} [signals.now] - Injectable clock for deterministic tests
+ * @returns {number} priority score
+ */
+function computeSchoolPriority(school, signals = {}) {
+  const {
+    pendingCount = 0,
+    lastActivityAt = null,
+    cyclesDeferred = 0,
+    now = Date.now(),
+  } = signals;
+
+  let score = 0;
+
+  // A school that has never been synced has no cursor — it needs its initial
+  // backfill before it can report anything at all to its users.
+  if (!school.syncCursor) score += PRIORITY_NEVER_SYNCED;
+
+  // The headline signal: someone is waiting on these.
+  score += Math.min(pendingCount, 10) * PRIORITY_PENDING_PAYMENT;
+
+  if (lastActivityAt) {
+    const age = now - new Date(lastActivityAt).getTime();
+    if (age >= 0 && age < RECENT_ACTIVITY_WINDOW_MS) {
+      // Decay linearly across the window rather than a cliff edge, so a school
+      // doesn't lurch between priority tiers on either side of a threshold.
+      const freshness = 1 - age / RECENT_ACTIVITY_WINDOW_MS;
+      score += PRIORITY_RECENT_ACTIVITY * freshness;
+    }
+  }
+
+  // Aging — the starvation guard that makes worst-case staleness bounded.
+  score += cyclesDeferred * PRIORITY_AGING_PER_CYCLE;
+
+  return score;
+}
+
+/**
+ * Order schools most-urgent-first for this cycle.
+ *
+ * @param {Array<object>} schools
+ * @param {Map<string, object>} signalsBySchoolId
+ * @param {number} [now]
+ * @returns {Array<{school: object, priority: number}>}
+ */
+function orderSchoolsByPriority(schools, signalsBySchoolId = new Map(), now = Date.now()) {
+  return schools
+    .map(school => ({
+      school,
+      priority: computeSchoolPriority(school, {
+        ...(signalsBySchoolId.get(school.schoolId) || {}),
+        now,
+      }),
+    }))
+    // Tie-break on schoolId so ordering is deterministic and testable rather
+    // than dependent on Mongo's return order.
+    .sort((a, b) => (b.priority - a.priority) ||
+      String(a.school.schoolId).localeCompare(String(b.school.schoolId)));
+}
+
+/**
+ * The shared per-cycle request budget.
+ *
+ * Deliberately simple and synchronous: it is consulted on the hot path before
+ * every Horizon page fetch, so it must not itself do I/O.
+ */
+class HorizonPollBudget {
+  /**
+   * @param {object} [opts]
+   * @param {number} [opts.intervalMs] - Poll interval used to size the budget
+   * @param {number} [opts.budgetOverride] - Explicit budget, bypassing the
+   *   rate-limit computation (used by tests and load simulations)
+   */
+  constructor(opts = {}) {
+    this.intervalMs = opts.intervalMs || 30000;
+    this.nominalBudget = opts.budgetOverride || computeCycleBudget(this.intervalMs);
+
+    // The AIMD-adjusted ceiling. Starts at nominal and moves with observed 429s.
+    this.currentCeiling = this.nominalBudget;
+
+    this.remaining = this.currentCeiling;
+    this.consumedThisCycle = 0;
+    this.deniedThisCycle = 0;
+    this.rateLimitEventsThisCycle = 0;
+
+    // Per-school deferral counters, the input to priority aging.
+    this.cyclesDeferred = new Map();
+
+    this.cycles = 0;
+  }
+
+  /**
+   * Begin a cycle: apply AIMD from what the last cycle observed, then refill.
+   * @returns {number} tokens available this cycle
+   */
+  startCycle() {
+    if (this.cycles > 0) {
+      if (this.rateLimitEventsThisCycle > 0) {
+        // We hit the real limit — back off hard and fast.
+        const next = Math.max(
+          MIN_BUDGET_PER_CYCLE,
+          Math.floor(this.currentCeiling * AIMD_DECREASE_FACTOR),
+        );
+        if (next !== this.currentCeiling) {
+          logger.warn('Horizon rate limit observed — reducing poll budget', {
+            from: this.currentCeiling,
+            to: next,
+            rateLimitEvents: this.rateLimitEventsThisCycle,
+          });
+        }
+        this.currentCeiling = next;
+      } else if (this.currentCeiling < this.nominalBudget) {
+        // Clean cycle — probe back toward nominal, gently.
+        this.currentCeiling = Math.min(
+          this.nominalBudget,
+          this.currentCeiling + AIMD_INCREASE_TOKENS,
+        );
+      }
+    }
+
+    this.remaining = this.currentCeiling;
+    this.consumedThisCycle = 0;
+    this.deniedThisCycle = 0;
+    this.rateLimitEventsThisCycle = 0;
+    this.cycles++;
+
+    return this.remaining;
+  }
+
+  /**
+   * Try to reserve `n` Horizon requests.
+   * @returns {boolean} true if granted
+   */
+  tryConsume(n = 1) {
+    if (this.remaining < n) {
+      this.deniedThisCycle += n;
+      return false;
+    }
+    this.remaining -= n;
+    this.consumedThisCycle += n;
+    return true;
+  }
+
+  /** Return unused tokens (e.g. a school drained early and needed fewer pages). */
+  refund(n = 1) {
+    this.remaining = Math.min(this.currentCeiling, this.remaining + n);
+    this.consumedThisCycle = Math.max(0, this.consumedThisCycle - n);
+  }
+
+  /** Record an observed Horizon 429, which drives the multiplicative decrease. */
+  recordRateLimited() {
+    this.rateLimitEventsThisCycle++;
+  }
+
+  /** Note that a school was skipped this cycle for lack of budget. */
+  recordDeferred(schoolId) {
+    this.cyclesDeferred.set(schoolId, (this.cyclesDeferred.get(schoolId) || 0) + 1);
+  }
+
+  /** Note that a school was polled, clearing its aging counter. */
+  recordPolled(schoolId) {
+    this.cyclesDeferred.delete(schoolId);
+  }
+
+  /** Consecutive cycles a school has been deferred. */
+  getDeferralCount(schoolId) {
+    return this.cyclesDeferred.get(schoolId) || 0;
+  }
+
+  /**
+   * Worst observed staleness in cycles, across all currently-deferred schools.
+   * This is the figure the documented SLA is measured against.
+   */
+  getMaxDeferralCycles() {
+    let max = 0;
+    for (const count of this.cyclesDeferred.values()) {
+      if (count > max) max = count;
+    }
+    return max;
+  }
+
+  getStats() {
+    return {
+      nominalBudget: this.nominalBudget,
+      currentCeiling: this.currentCeiling,
+      remaining: this.remaining,
+      consumedThisCycle: this.consumedThisCycle,
+      deniedThisCycle: this.deniedThisCycle,
+      rateLimitEventsThisCycle: this.rateLimitEventsThisCycle,
+      deferredSchools: this.cyclesDeferred.size,
+      maxDeferralCycles: this.getMaxDeferralCycles(),
+      cycles: this.cycles,
+    };
+  }
+}
+
+module.exports = {
+  HorizonPollBudget,
+  computeCycleBudget,
+  computeSchoolPriority,
+  orderSchoolsByPriority,
+  // Exposed so tests and docs can assert against the same constants.
+  HORIZON_RATE_LIMIT_PER_HOUR,
+  POLL_BUDGET_SAFETY_FACTOR,
+  MIN_BUDGET_PER_CYCLE,
+  PRIORITY_PENDING_PAYMENT,
+  PRIORITY_NEVER_SYNCED,
+  PRIORITY_AGING_PER_CYCLE,
+  RECENT_ACTIVITY_WINDOW_MS,
+};

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -16,6 +16,7 @@ const config = require('../config');
 const logger = require('../utils/logger').child('TransactionPollingService');
 const { deriveCorrelationId } = require('../utils/correlationId');
 const { captureFiatSnapshot } = require('./currencyConversionService');
+const { HorizonPollBudget, orderSchoolsByPriority } = require('./horizonPollBudget');
 
 // Metrics — imported lazily inside helpers to survive jest module resets.
 function _incFunnel(stage, schoolId) {
@@ -49,6 +50,19 @@ const MAX_TRANSACTIONS_PER_POLL = 50;
 const POLL_MAX_BACKOFF_MS = parseInt(process.env.POLL_MAX_BACKOFF_MS || '300000', 10);
 let consecutiveErrors = 0;
 let currentIntervalMs = SYNC_INTERVAL_MS;
+
+// Coordinated cross-school Horizon request budget (#1124). Schools no longer
+// poll as independent operations that each assume the whole rate limit is
+// theirs; they draw page fetches from this single shared per-cycle allowance,
+// spent in priority order. See services/horizonPollBudget.js for the rationale
+// and docs/horizon-rate-limits.md for the SLA this underpins.
+let pollBudget = new HorizonPollBudget({ intervalMs: SYNC_INTERVAL_MS });
+
+// How many schools may be in flight at once. Bounded so a large tenant count
+// can't open an unbounded number of simultaneous Horizon connections — the
+// budget caps total requests, this caps their burstiness.
+const MAX_CONCURRENT_SCHOOL_POLLS = Math.max(1, parseInt(
+  process.env.SYNC_MAX_CONCURRENT_SCHOOLS || '4', 10));
 
 /**
  * Process a single transaction for a school
@@ -308,7 +322,7 @@ function getEffectiveBatchSize(queueDepth) {
   return Math.max(MIN_TRANSACTIONS_PER_POLL, Math.min(MAX_TRANSACTIONS_PER_POLL, scaled));
 }
 
-async function pollSchoolTransactions(school) {
+async function pollSchoolTransactions(school, budget = null) {
   const backpressure = getQueueBackpressureState();
   if (backpressure.queueDepth >= backpressure.highWater) {
     logger.warn('Skipping school poll due to high payment processor queue depth', {
@@ -343,6 +357,7 @@ async function pollSchoolTransactions(school) {
   const startCursor = cursor;
   let processedCount = 0;
   let skippedCount = 0;
+  let budgetExhausted = false;
 
   try {
     // Adaptive batch size based on queue backpressure (#972). The early
@@ -358,6 +373,22 @@ async function pollSchoolTransactions(school) {
     }
 
     for (let pages = 0; pages < MAX_PAGES_PER_POLL; pages++) {
+      // Draw from the shared cross-school budget before every page fetch
+      // (#1124). Running out is a normal, ordered outcome: we stop here, the
+      // cursor is already persisted, and the remaining pages resume next cycle
+      // with this school's priority raised by aging. That is strictly better
+      // than issuing the request and being 429'd, which costs the same quota
+      // and returns nothing.
+      if (budget && !budget.tryConsume(1)) {
+        budgetExhausted = true;
+        logger.debug('Poll budget exhausted mid-school — deferring remaining pages', {
+          schoolId: school.schoolId,
+          pagesFetched: pages,
+          processed: processedCount,
+        });
+        break;
+      }
+
       let builder = server
         .transactions()
         .forAccount(school.stellarAddress)
@@ -391,7 +422,12 @@ async function pollSchoolTransactions(school) {
         );
       }
 
-      if (records.length < batchSize) break; // drained this cycle
+      if (records.length < batchSize) {
+        // Drained — this school needs no more of the budget this cycle. The
+        // token for the page we're inside was already spent, so nothing to
+        // refund; we simply stop competing for the rest.
+        break;
+      }
     }
 
     if (processedCount > 0) {
@@ -403,19 +439,147 @@ async function pollSchoolTransactions(school) {
       });
     }
 
-    return { schoolId: school.schoolId, processed: processedCount, skipped: skippedCount, cursor };
+    return {
+      schoolId: school.schoolId,
+      processed: processedCount,
+      skipped: skippedCount,
+      cursor,
+      budgetExhausted,
+    };
   } catch (error) {
     const status = error.response?.status || error.status || error.statusCode;
+    const rateLimited = status === 429;
+    // Feed observed 429s back into the budget so the next cycle's ceiling
+    // reflects Horizon's real limit rather than the configured guess (#1124).
+    if (rateLimited && budget) budget.recordRateLimited();
     logger.error('Error polling school transactions', {
       schoolId: school.schoolId,
       error: error.message,
       status,
-      rateLimited: status === 429,
+      rateLimited,
     });
-    return { schoolId: school.schoolId, error: error.message, horizonError: true, status };
+    return {
+      schoolId: school.schoolId,
+      error: error.message,
+      horizonError: true,
+      status,
+      rateLimited,
+    };
   } finally {
     if (stopWatchdog) stopWatchdog();
     await lock.release(lockKey, token);
+  }
+}
+
+/**
+ * Gather the per-school signals that drive priority ordering (#1124).
+ *
+ * Deliberately ONE aggregate query for all schools rather than a query per
+ * school: this runs every cycle, and a per-tenant query would reintroduce the
+ * very linear-scaling problem we're fixing — just against MongoDB instead of
+ * Horizon.
+ *
+ * Signals are best-effort. If the query fails, every school scores 0 from this
+ * source and ordering falls back to aging alone, which is still correct — just
+ * less well-informed. Polling must never stop because prioritisation couldn't
+ * be computed.
+ *
+ * @param {Array<object>} schools
+ * @param {HorizonPollBudget} budget
+ * @returns {Promise<Map<string, object>>} schoolId → signals
+ */
+async function gatherSchoolSignals(schools, budget) {
+  const signals = new Map();
+
+  // Aging applies regardless of whether the DB lookup succeeds.
+  for (const school of schools) {
+    signals.set(school.schoolId, {
+      pendingCount: 0,
+      lastActivityAt: null,
+      cyclesDeferred: budget.getDeferralCount(school.schoolId),
+    });
+  }
+
+  try {
+    const schoolIds = schools.map(s => s.schoolId);
+    const rows = await Payment.aggregate([
+      { $match: { schoolId: { $in: schoolIds }, deletedAt: null } },
+      {
+        $group: {
+          _id: '$schoolId',
+          // Payments seen on-chain but not yet fully confirmed — the parents
+          // behind these are the ones actively waiting.
+          pendingCount: {
+            $sum: {
+              $cond: [{ $ne: ['$confirmationStatus', 'confirmed'] }, 1, 0],
+            },
+          },
+          lastActivityAt: { $max: '$confirmedAt' },
+        },
+      },
+    ]);
+
+    for (const row of rows) {
+      const existing = signals.get(row._id);
+      if (existing) {
+        existing.pendingCount = row.pendingCount || 0;
+        existing.lastActivityAt = row.lastActivityAt || null;
+      }
+    }
+  } catch (error) {
+    logger.warn('Could not gather school priority signals — falling back to aging only', {
+      error: error.message,
+    });
+  }
+
+  return signals;
+}
+
+/**
+ * Run `worker` over `items` with at most `limit` in flight, preserving input
+ * order in the results and never rejecting — each entry mirrors the
+ * Promise.allSettled shape the caller already expects.
+ *
+ * Replaces the previous unbounded `Promise.allSettled(schools.map(...))`, which
+ * opened one Horizon conversation per school simultaneously (#1124).
+ */
+async function runWithConcurrency(items, limit, worker) {
+  const results = new Array(items.length);
+  let next = 0;
+
+  async function runner() {
+    while (next < items.length) {
+      const index = next++;
+      try {
+        results[index] = { status: 'fulfilled', value: await worker(items[index], index) };
+      } catch (reason) {
+        results[index] = { status: 'rejected', reason };
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => runner()),
+  );
+
+  return results;
+}
+
+function _recordBudgetMetrics(stats) {
+  try {
+    const metrics = require('../metrics');
+    metrics.horizonPollBudgetRemaining.set(stats.remaining);
+    metrics.horizonPollBudgetCeiling.set(stats.currentCeiling);
+    metrics.horizonPollDeferredSchools.set(stats.deferredSchools);
+    metrics.horizonPollMaxDeferralCycles.set(stats.maxDeferralCycles);
+    if (stats.consumedThisCycle > 0) {
+      metrics.horizonPollRequestsTotal.inc(stats.consumedThisCycle);
+    }
+    if (stats.rateLimitEventsThisCycle > 0) {
+      metrics.horizonRateLimitedTotal.inc(stats.rateLimitEventsThisCycle);
+    }
+  } catch (_) {
+    // metrics module unavailable — polling proceeds without instrumentation
   }
 }
 
@@ -438,8 +602,25 @@ async function pollAllSchools() {
 
     logger.debug(`Polling ${schools.length} active schools`);
 
-    const results = await Promise.allSettled(
-      schools.map(school => pollSchoolTransactions(school))
+    // ── Coordinated budgeting (#1124) ──────────────────────────────────────
+    // Open the cycle's shared allowance, then decide the ORDER in which to
+    // spend it. Ordering is what keeps user-visible delay low when the budget
+    // binds: a school with payments awaiting confirmation is polled before a
+    // settled school whose poll would return nothing.
+    const budgetForCycle = pollBudget.startCycle();
+    const signals = await gatherSchoolSignals(schools, pollBudget);
+    const ordered = orderSchoolsByPriority(schools, signals);
+
+    logger.debug('Poll cycle budget opened', {
+      schools: schools.length,
+      budget: budgetForCycle,
+      topPriority: ordered[0] ? ordered[0].school.schoolId : null,
+    });
+
+    const results = await runWithConcurrency(
+      ordered,
+      MAX_CONCURRENT_SCHOOL_POLLS,
+      ({ school }) => pollSchoolTransactions(school, pollBudget),
     );
 
     const summary = results.reduce((acc, result) => {
@@ -447,11 +628,39 @@ async function pollAllSchools() {
         acc.processed += result.value.processed || 0;
         acc.skipped += result.value.skipped || 0;
         if (result.value.horizonError) acc.errors++;
+        if (result.value.rateLimited) acc.rateLimited++;
+        if (result.value.budgetExhausted) acc.budgetDeferred++;
       } else {
         acc.errors++;
       }
       return acc;
-    }, { processed: 0, skipped: 0, errors: 0 });
+    }, { processed: 0, skipped: 0, errors: 0, rateLimited: 0, budgetDeferred: 0 });
+
+    // Update aging counters: a school that got no budget at all this cycle
+    // gains priority for the next one, which is what bounds worst-case
+    // staleness for quiet tenants.
+    for (let i = 0; i < ordered.length; i++) {
+      const { school } = ordered[i];
+      const result = results[i];
+      const polled = result.status === 'fulfilled' &&
+        !result.value.budgetExhausted &&
+        !result.value.lockSkipped &&
+        !result.value.loadPaused;
+      if (polled) {
+        pollBudget.recordPolled(school.schoolId);
+      } else {
+        pollBudget.recordDeferred(school.schoolId);
+      }
+    }
+
+    _recordBudgetMetrics(pollBudget.getStats());
+
+    if (summary.budgetDeferred > 0) {
+      logger.info('Poll budget bound this cycle — some schools deferred', {
+        ...pollBudget.getStats(),
+        deferredThisCycle: summary.budgetDeferred,
+      });
+    }
 
     if (summary.errors > 0) {
       // At least one school hit a Horizon error — back off.
@@ -541,9 +750,14 @@ module.exports = {
   processTransaction,
   // Exposed for testing
   _getBackoffState: () => ({ consecutiveErrors, currentIntervalMs }),
+  _getBudgetStats: () => pollBudget.getStats(),
+  _setPollBudget: (budget) => { pollBudget = budget; },
+  _runWithConcurrency: runWithConcurrency,
+  _gatherSchoolSignals: gatherSchoolSignals,
   _resetBackoffState: () => {
     consecutiveErrors = 0;
     currentIntervalMs = SYNC_INTERVAL_MS;
+    pollBudget = new HorizonPollBudget({ intervalMs: SYNC_INTERVAL_MS });
     isPolling = true; // allow direct pollAllSchools() calls in tests
     if (pollingInterval) { clearTimeout(pollingInterval); pollingInterval = null; }
   },

--- a/docs/horizon-rate-limits.md
+++ b/docs/horizon-rate-limits.md
@@ -1,0 +1,221 @@
+# Horizon Rate Limits, Poll Budgeting, and the Sync-Delay SLA
+
+Status: implemented (#1124). Supersedes the unbounded "temporary sync delays"
+caveat previously recorded in `CHANGELOG.md`'s Known Issues.
+
+## The problem this addresses
+
+Payment sync polls Stellar Horizon on a fixed interval. Before #1124 each
+school's poll was an independent operation, fanned out with
+`Promise.allSettled(schools.map(...))`. Horizon request volume therefore scaled
+as:
+
+```
+requests per cycle  ≈  Σ over active schools (pages that school needs)
+```
+
+That grows linearly with the number of onboarded schools. Horizon's rate limit
+for our IP/API key does **not** grow at all. Rate limiting was therefore not a
+rare edge case but a **predictable scaling ceiling** the platform would hit as
+adoption grew, with "temporary" delays becoming longer and more frequent over
+time.
+
+The pre-existing mitigation — `withStellarRetry` — did not address this and in
+some respects made it worse:
+
+- It caps at a short per-call backoff (10s max delay, 3 attempts by default).
+- Being per-call, it has no cross-school view. Under sustained rate limiting
+  every school retried simultaneously, converting one rate-limit event into a
+  thundering herd that kept the limit saturated.
+- A 429 anywhere tripped **cycle-level** exponential backoff that slowed polling
+  for *every* school — including schools that were never rate-limited and had
+  parents actively waiting on a payment.
+
+That last point is the crux. Overshooting the limit did not merely waste
+requests; it triggered a system-wide slowdown that penalised the schools least
+responsible for it.
+
+## What is implemented
+
+`backend/src/services/horizonPollBudget.js` provides a coordinated, cross-school
+request budget. Four mechanisms:
+
+### 1. A shared per-cycle budget
+
+A token bucket sized from Horizon's rate limit and the poll interval, shared by
+all schools. Every Horizon page fetch draws one token. When the budget is spent,
+remaining schools are **deferred to the next cycle** rather than issuing
+requests that would be 429'd.
+
+Deferral is strictly better than a 429: both leave the work undone, but a 429
+also consumes quota, returns nothing, and trips the global backoff.
+
+```
+budget per cycle = (HORIZON_RATE_LIMIT_PER_HOUR / 3600000) × intervalMs
+                   × HORIZON_POLL_BUDGET_SAFETY_FACTOR
+                   ÷ HORIZON_POLL_REPLICA_COUNT
+```
+
+The safety factor (default `0.6`) deliberately holds the poller below the true
+limit. Polling is not the only Horizon consumer — the verify endpoint, retry
+worker and confirmation finalizer share the same allowance, and those are
+user-facing, so background polling must never starve them.
+
+### 2. Priority ordering
+
+The budget is spent where delay is actually felt. Scores, highest first:
+
+| Signal | Weight | Rationale |
+|---|---|---|
+| Never synced (no cursor) | 250 | A new school cannot show anything until its backfill starts |
+| Pending unconfirmed payments | 100 each, capped at 10 | Someone is actively waiting on these |
+| Recent on-chain activity | up to 20, decaying over 1h | Recent activity predicts more activity |
+| Cycles deferred | 15 per cycle | Starvation guard — see below |
+
+The pending-payment weight is capped so a single enormous school cannot
+monopolise the budget indefinitely.
+
+### 3. Aging (the starvation guard)
+
+Priority alone would starve quiet schools forever. Every deferred cycle raises a
+school's score by 15, so a fully-settled school overtakes a school with one
+pending payment after ~7 deferred cycles. **This is what makes worst-case
+staleness bounded, and therefore what makes an SLA statable at all.**
+
+### 4. AIMD adaptation
+
+Observed 429s halve the ceiling; clean cycles raise it by 2. This is the control
+law TCP uses. It matters because Horizon's actual limit varies by provider and
+plan — the system converges on the real limit instead of trusting the configured
+guess.
+
+Concurrency is separately bounded by `SYNC_MAX_CONCURRENT_SCHOOLS` (default 4),
+so a large tenant count cannot open an unbounded number of simultaneous
+connections. The budget caps total requests; this caps their burstiness.
+
+## Measured behaviour and the SLA
+
+Measured with `tests/loadsim/horizonPollLoadModel.js`, a deterministic
+discrete-event model exercised by `tests/issue-1124-horizon-poll-budget.test.js`.
+
+**Scenario.** Start-of-term spike: 25% of schools simultaneously at ~12× their
+baseline payment volume. 30-second poll interval, Horizon allowance of 3600
+requests/hour (30 per cycle), 120 cycles.
+
+Both strategies run on **identical** fleets, and the coordinated strategy is
+given a *smaller* raw allowance (the 0.6 safety factor), so the improvement
+comes from coordination and ordering rather than extra capacity.
+
+| Schools | Independent p95 | Independent 429s | Coordinated p95 | Coordinated 429s |
+|---:|---:|---:|---:|---:|
+| 25 | 0s | 0 | 0s | 0 |
+| 50 | 0s | 1 | 60s | 0 |
+| 100 | 30,600s (8.5h) | 4,430 | 240s | 0 |
+| 150 | 32,700s (9.1h) | 10,350 | 360s | 0 |
+| 300 | 33,300s (9.25h) | 28,124 | 1,290s | 0 |
+
+### The threshold, stated plainly
+
+- **Below ~50 schools** the old approach was fine, and coordination is very
+  slightly *worse* (p95 60s vs 0s at 50 schools) because the safety factor holds
+  back capacity that wasn't needed. This is a real, if small, cost and is stated
+  here rather than glossed over.
+- **Between 50 and 100 schools** the old approach breaks down — sharply, not
+  gradually. At 100 schools p95 sync delay reaches **8.5 hours** and a third of
+  all requests are wasted on 429s.
+- **Above 100 schools** the old approach is unusable; the coordinated one
+  degrades gracefully (240s → 1,290s p95 between 100 and 300 schools).
+
+### SLA
+
+Under the scenario above, with default configuration:
+
+| Load | Max expected sync delay |
+|---|---|
+| ≤ 100 schools | **≤ 5 minutes** (p95 ≤ 4 min, max ≤ 18 min) |
+| ≤ 300 schools | **≤ 25 minutes** (p95 ≤ 22 min, max ≤ 37 min) |
+
+Worst-case delay for any individual school is bounded by the aging mechanism at
+approximately:
+
+```
+max delay  ≈  (max_deferral_cycles + 1) × poll interval
+```
+
+`horizon_poll_max_deferral_cycles` exports that term directly, so the SLA is
+observable in production rather than only in the model.
+
+### What the model does and doesn't prove
+
+The model is **not** a test against live Horizon, and it should not be read as
+one. It encodes four mechanisms, each independently verifiable against the
+source: Horizon's fixed allowance and 429 behaviour; the old unbounded fan-out;
+the existing cycle-level backoff in `transactionPollingService`; and the new
+budget, which it drives through the *real* `HorizonPollBudget` and
+`orderSchoolsByPriority` rather than a reimplementation.
+
+What it does not capture: real Horizon latency variance, per-endpoint limit
+differences, network failures unrelated to rate limiting, and MongoDB
+contention. **The figures above should be re-validated against a staging
+Horizon before being quoted to a customer as a contractual SLA.** They are
+sound as an engineering baseline and as a relative comparison between the two
+strategies; they are not a substitute for a live load test.
+
+## Configuration
+
+| Env var | Default | Meaning |
+|---|---:|---|
+| `HORIZON_RATE_LIMIT_PER_HOUR` | 3600 | Horizon's allowance for our key. Raise on a paid/self-hosted instance |
+| `HORIZON_POLL_BUDGET_SAFETY_FACTOR` | 0.6 | Fraction of the limit polling may use; the rest is reserved for user-facing calls |
+| `HORIZON_POLL_REPLICA_COUNT` | 1 | Replicas sharing the allowance. **Set this to your replica count** |
+| `HORIZON_POLL_MIN_BUDGET` | 4 | Floor, so misconfiguration cannot wedge polling |
+| `SYNC_MAX_CONCURRENT_SCHOOLS` | 4 | Max schools polled simultaneously |
+| `HORIZON_POLL_RECENT_ACTIVITY_WINDOW_MS` | 3600000 | Window over which recent activity boosts priority |
+
+> **Multi-replica warning.** The budget is per-process. Leaving
+> `HORIZON_POLL_REPLICA_COUNT=1` while running N replicas means the combined
+> rate is N× the intended budget. The per-school distributed lock still prevents
+> two replicas syncing the *same* school, so this is a rate-limit concern rather
+> than a correctness one — but it will reintroduce 429s.
+
+## Observability
+
+| Metric | Type | Use |
+|---|---|---|
+| `horizon_poll_budget_remaining` | gauge | Tokens left in the current cycle |
+| `horizon_poll_budget_ceiling` | gauge | AIMD-adjusted ceiling; sustained drop means the configured limit is too high |
+| `horizon_poll_deferred_schools` | gauge | Schools currently deferred |
+| `horizon_poll_max_deferral_cycles` | gauge | **The SLA term.** Worst staleness in cycles |
+| `horizon_poll_requests_total` | counter | Poller request volume |
+| `horizon_rate_limited_total` | counter | Observed 429s; should be ~0 in steady state |
+
+Suggested alerts:
+
+- `horizon_poll_max_deferral_cycles > 5` for 15m — some tenant is falling behind
+  the SLA.
+- `rate(horizon_rate_limited_total[15m]) > 0` sustained — the configured limit
+  exceeds the real one, or replica count is misconfigured.
+- `horizon_poll_budget_ceiling < 0.5 × nominal` sustained — AIMD has pulled the
+  ceiling well below configuration; investigate before adding tenants.
+
+## Operational guidance
+
+When `horizon_poll_deferred_schools` is persistently non-zero, the fleet has
+outgrown its Horizon allowance. In rough order of preference:
+
+1. Raise `HORIZON_RATE_LIMIT_PER_HOUR` if the real allowance is higher than the
+   3600 default (paid or self-hosted Horizon).
+2. Run a dedicated Horizon instance — removes the shared-limit problem outright.
+3. Increase the poll interval. Counter-intuitive, but a longer interval yields a
+   proportionally larger per-cycle budget and lets more schools be fully drained
+   per cycle; if the fleet is budget-bound, the deferral queue shrinks.
+4. Shard schools across replicas by `schoolId`, with `HORIZON_POLL_REPLICA_COUNT`
+   set correctly.
+
+## Related
+
+- `backend/src/services/horizonPollBudget.js` — implementation and rationale
+- `backend/src/services/transactionPollingService.js` — the poll loop
+- `backend/src/services/stellarRateLimitedClient.js` — per-call throttling for
+  non-poll Horizon traffic (Bottleneck, optionally Redis-backed)
+- `tests/loadsim/horizonPollLoadModel.js` — the load model

--- a/monitoring/alerts/horizon_poll.yml
+++ b/monitoring/alerts/horizon_poll.yml
@@ -1,0 +1,76 @@
+groups:
+  - name: horizon_poll
+    interval: 60s
+    rules:
+      # ── Warning: some tenant is falling behind the documented SLA ─────────
+      # horizon_poll_max_deferral_cycles is the direct input to the max
+      # sync-delay figure in docs/horizon-rate-limits.md:
+      #   max delay ≈ (max_deferral_cycles + 1) × poll interval
+      # A sustained value above 5 means at least one school is being deferred
+      # repeatedly and its parents are seeing stale payment state.
+      - alert: HorizonPollSchoolFallingBehind
+        expr: horizon_poll_max_deferral_cycles > 5
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "A school is repeatedly deferred by the Horizon poll budget"
+          description: >
+            At least one school has been deferred for {{ $value }} consecutive
+            poll cycles, putting it outside the documented sync-delay SLA. The
+            fleet has likely outgrown its Horizon allowance. See the
+            "Operational guidance" section of docs/horizon-rate-limits.md.
+
+      # ── Warning: we are still hitting the real limit ──────────────────────
+      # In steady state the budget should keep the poller below Horizon's
+      # limit, so any sustained 429 rate means the configured limit is higher
+      # than the real one, or HORIZON_POLL_REPLICA_COUNT is wrong and N
+      # replicas are each spending a full budget.
+      - alert: HorizonRateLimitedDespiteBudget
+        expr: rate(horizon_rate_limited_total[15m]) > 0
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Horizon is returning 429s even with poll budgeting active"
+          description: >
+            The poller is still being rate limited ({{ $value | printf "%.3f" }}/s).
+            Either HORIZON_RATE_LIMIT_PER_HOUR exceeds the real allowance, or
+            HORIZON_POLL_REPLICA_COUNT does not match the running replica count
+            (each replica then spends a full budget). Check both before adding
+            tenants.
+
+      # ── Critical: adaptive ceiling has collapsed ──────────────────────────
+      # AIMD halves the ceiling on every 429-affected cycle. Sitting near the
+      # floor means the configured limit is badly wrong and sync throughput is
+      # a small fraction of what operators think it is.
+      - alert: HorizonPollBudgetCollapsed
+        expr: horizon_poll_budget_ceiling <= 4
+        for: 30m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Horizon poll budget has collapsed to its floor"
+          description: >
+            The adaptive per-cycle budget has been pulled down to the minimum
+            for 30 minutes, meaning sustained rate limiting. Payment sync is
+            running at a small fraction of nominal throughput and delays will
+            be far outside the documented SLA for every tenant.
+
+      # ── Warning: budget is chronically saturated ──────────────────────────
+      # Deferrals are a normal, ordered response to a bound budget — but a
+      # persistently non-zero deferred count is the signal that the fleet has
+      # outgrown its allowance and needs a capacity decision.
+      - alert: HorizonPollBudgetSaturated
+        expr: horizon_poll_deferred_schools > 0
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Horizon poll budget saturated for an hour"
+          description: >
+            {{ $value }} schools have been deferred continuously for an hour.
+            Polling is keeping up only by prioritising; quiet schools are being
+            served purely by the aging guard. Raise the Horizon allowance, move
+            to a dedicated Horizon instance, lengthen the poll interval, or
+            shard schools across replicas.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -4,6 +4,7 @@ global:
 
 rule_files:
   - "alerts/price_feed.yml"
+  - "alerts/horizon_poll.yml"
 
 scrape_configs:
   - job_name: stellaredupay

--- a/tests/issue-1124-horizon-poll-budget.test.js
+++ b/tests/issue-1124-horizon-poll-budget.test.js
@@ -1,0 +1,343 @@
+'use strict';
+
+/**
+ * Issue #1124 — coordinated cross-school Horizon rate-limit budget.
+ *
+ * The poller previously treated each school's sync as an independent operation
+ * fanned out with `Promise.allSettled(schools.map(...))`. Horizon request volume
+ * therefore grew linearly with the number of onboarded schools while Horizon's
+ * rate limit stayed fixed — a predictable scaling ceiling, not an edge case.
+ * The only mitigation was per-call retry/backoff, which caps at a short delay
+ * and, being per-call, makes sustained rate-limiting worse by having every
+ * school retry simultaneously.
+ *
+ * This suite covers three things:
+ *   1. The budget primitive itself — sizing, AIMD adaptation, starvation.
+ *   2. Priority ordering — schools with pending verifications go first.
+ *   3. The load comparison the acceptance criterion asks for: coordinated
+ *      budgeting measurably reduces worst-case sync delay versus the previous
+ *      independent approach under the same simulated start-of-term load.
+ */
+
+process.env.MONGO_URI = process.env.MONGO_URI || 'mongodb://localhost:27017/test';
+
+const mockLogger = { error: jest.fn(), warn: jest.fn(), info: jest.fn(), debug: jest.fn() };
+mockLogger.child = jest.fn(() => mockLogger);
+jest.mock('../backend/src/utils/logger', () => mockLogger);
+
+const {
+  HorizonPollBudget,
+  computeCycleBudget,
+  computeSchoolPriority,
+  orderSchoolsByPriority,
+  PRIORITY_PENDING_PAYMENT,
+  PRIORITY_AGING_PER_CYCLE,
+  MIN_BUDGET_PER_CYCLE,
+} = require('../backend/src/services/horizonPollBudget');
+
+const { buildFleet, simulate } = require('./loadsim/horizonPollLoadModel');
+
+// ── 1. The budget primitive ──────────────────────────────────────────────────
+
+describe('#1124 — cycle budget sizing', () => {
+  test('budget scales with the poll interval, not with the school count', () => {
+    // This is the whole point: the allowance is a property of time and
+    // Horizon's limit. Adding schools divides a fixed pie; it never grows it.
+    const short = computeCycleBudget(10000);
+    const long = computeCycleBudget(60000);
+    expect(long).toBeGreaterThan(short);
+    expect(long / short).toBeCloseTo(6, 0);
+  });
+
+  test('never returns a budget that would wedge polling entirely', () => {
+    expect(computeCycleBudget(1)).toBeGreaterThanOrEqual(MIN_BUDGET_PER_CYCLE);
+    expect(computeCycleBudget(0)).toBeGreaterThanOrEqual(MIN_BUDGET_PER_CYCLE);
+  });
+
+  test('stays below the raw Horizon allowance so user-facing calls keep headroom', () => {
+    // 3600/hr default = exactly 1 request/second, so a 60s cycle's raw share is
+    // 60. The safety factor must hold the poller strictly under that.
+    expect(computeCycleBudget(60000)).toBeLessThan(60);
+  });
+});
+
+describe('#1124 — budget consumption', () => {
+  let budget;
+  beforeEach(() => {
+    budget = new HorizonPollBudget({ intervalMs: 30000, budgetOverride: 10 });
+    budget.startCycle();
+  });
+
+  test('grants tokens up to the ceiling and then denies', () => {
+    for (let i = 0; i < 10; i++) expect(budget.tryConsume(1)).toBe(true);
+    expect(budget.tryConsume(1)).toBe(false);
+    expect(budget.getStats().deniedThisCycle).toBe(1);
+  });
+
+  test('refills each cycle', () => {
+    while (budget.tryConsume(1)) { /* drain */ }
+    expect(budget.tryConsume(1)).toBe(false);
+    budget.startCycle();
+    expect(budget.tryConsume(1)).toBe(true);
+  });
+
+  test('refund returns unused tokens without exceeding the ceiling', () => {
+    budget.tryConsume(4);
+    budget.refund(2);
+    expect(budget.getStats().remaining).toBe(8);
+    budget.refund(100);
+    expect(budget.getStats().remaining).toBe(10); // clamped at the ceiling
+  });
+});
+
+describe('#1124 — AIMD adaptation to the real Horizon limit', () => {
+  test('observed 429s halve the ceiling on the next cycle', () => {
+    const budget = new HorizonPollBudget({ intervalMs: 30000, budgetOverride: 40 });
+    budget.startCycle();
+    expect(budget.getStats().currentCeiling).toBe(40);
+
+    budget.recordRateLimited();
+    budget.startCycle();
+    expect(budget.getStats().currentCeiling).toBe(20);
+
+    budget.recordRateLimited();
+    budget.startCycle();
+    expect(budget.getStats().currentCeiling).toBe(10);
+  });
+
+  test('clean cycles probe the ceiling back up additively, not instantly', () => {
+    const budget = new HorizonPollBudget({ intervalMs: 30000, budgetOverride: 40 });
+    budget.startCycle();
+    budget.recordRateLimited();
+    budget.startCycle();
+    expect(budget.getStats().currentCeiling).toBe(20);
+
+    // Additive increase — a single good cycle must not jump straight back to
+    // the level that just triggered rate limiting.
+    budget.startCycle();
+    expect(budget.getStats().currentCeiling).toBe(22);
+    budget.startCycle();
+    expect(budget.getStats().currentCeiling).toBe(24);
+  });
+
+  test('the ceiling never decays below the floor, however many 429s occur', () => {
+    const budget = new HorizonPollBudget({ intervalMs: 30000, budgetOverride: 40 });
+    for (let i = 0; i < 50; i++) {
+      budget.startCycle();
+      budget.recordRateLimited();
+    }
+    budget.startCycle();
+    expect(budget.getStats().currentCeiling).toBeGreaterThanOrEqual(MIN_BUDGET_PER_CYCLE);
+  });
+
+  test('recovery never overshoots the nominal budget', () => {
+    const budget = new HorizonPollBudget({ intervalMs: 30000, budgetOverride: 12 });
+    for (let i = 0; i < 40; i++) budget.startCycle();
+    expect(budget.getStats().currentCeiling).toBe(12);
+  });
+});
+
+// ── 2. Priority ordering ─────────────────────────────────────────────────────
+
+describe('#1124 — priority puts waiting parents first', () => {
+  const NOW = 1_700_000_000_000;
+  const synced = id => ({ schoolId: id, syncCursor: `c-${id}` });
+
+  test('a school with pending payments outranks a settled one', () => {
+    const pending = computeSchoolPriority(synced('A'), { pendingCount: 3, now: NOW });
+    const settled = computeSchoolPriority(synced('B'), { pendingCount: 0, now: NOW });
+    expect(pending).toBeGreaterThan(settled);
+  });
+
+  test('more pending payments means higher priority, up to a cap', () => {
+    const few = computeSchoolPriority(synced('A'), { pendingCount: 1, now: NOW });
+    const many = computeSchoolPriority(synced('A'), { pendingCount: 5, now: NOW });
+    expect(many).toBeGreaterThan(few);
+
+    // Capped, so one enormous school cannot monopolise the budget forever.
+    const huge = computeSchoolPriority(synced('A'), { pendingCount: 5000, now: NOW });
+    const atCap = computeSchoolPriority(synced('A'), { pendingCount: 10, now: NOW });
+    expect(huge).toBe(atCap);
+  });
+
+  test('a never-synced school is prioritised so its backfill starts promptly', () => {
+    const fresh = computeSchoolPriority({ schoolId: 'NEW' }, { pendingCount: 0, now: NOW });
+    const settled = computeSchoolPriority(synced('OLD'), { pendingCount: 0, now: NOW });
+    expect(fresh).toBeGreaterThan(settled);
+  });
+
+  test('recent activity decays smoothly rather than at a cliff edge', () => {
+    const justNow = computeSchoolPriority(synced('A'), { lastActivityAt: NOW - 1000, now: NOW });
+    const halfWay = computeSchoolPriority(synced('A'), { lastActivityAt: NOW - 1800000, now: NOW });
+    const ancient = computeSchoolPriority(synced('A'), { lastActivityAt: NOW - 86400000, now: NOW });
+    expect(justNow).toBeGreaterThan(halfWay);
+    expect(halfWay).toBeGreaterThan(ancient);
+  });
+
+  test('aging eventually lifts a deferred quiet school above a busy one', () => {
+    // The starvation guard. Without it a quiet tenant behind a permanently busy
+    // one would never be polled, and no SLA could be stated at all.
+    const busy = computeSchoolPriority(synced('BUSY'), { pendingCount: 1, now: NOW });
+    const cyclesToOvertake = Math.ceil(PRIORITY_PENDING_PAYMENT / PRIORITY_AGING_PER_CYCLE);
+
+    const quietBefore = computeSchoolPriority(synced('QUIET'), {
+      pendingCount: 0, cyclesDeferred: cyclesToOvertake - 1, now: NOW,
+    });
+    expect(quietBefore).toBeLessThan(busy);
+
+    const quietAfter = computeSchoolPriority(synced('QUIET'), {
+      pendingCount: 0, cyclesDeferred: cyclesToOvertake + 1, now: NOW,
+    });
+    expect(quietAfter).toBeGreaterThan(busy);
+  });
+
+  test('ordering is deterministic for equal priorities', () => {
+    const schools = [synced('C'), synced('A'), synced('B')];
+    const order = orderSchoolsByPriority(schools, new Map(), NOW).map(o => o.school.schoolId);
+    expect(order).toEqual(['A', 'B', 'C']);
+  });
+
+  test('orderSchoolsByPriority puts the pending school at the head', () => {
+    const schools = [synced('QUIET1'), synced('BUSY'), synced('QUIET2')];
+    const signals = new Map([['BUSY', { pendingCount: 4 }]]);
+    const order = orderSchoolsByPriority(schools, signals, NOW).map(o => o.school.schoolId);
+    expect(order[0]).toBe('BUSY');
+  });
+});
+
+describe('#1124 — starvation is bounded in the budget itself', () => {
+  test('deferral counters track the worst-case staleness the SLA is stated on', () => {
+    const budget = new HorizonPollBudget({ intervalMs: 30000, budgetOverride: 5 });
+    budget.startCycle();
+
+    budget.recordDeferred('A');
+    budget.recordDeferred('A');
+    budget.recordDeferred('B');
+
+    expect(budget.getDeferralCount('A')).toBe(2);
+    expect(budget.getMaxDeferralCycles()).toBe(2);
+
+    budget.recordPolled('A');
+    expect(budget.getDeferralCount('A')).toBe(0);
+    expect(budget.getMaxDeferralCycles()).toBe(1);
+  });
+});
+
+// ── 3. The load comparison (the acceptance criterion) ────────────────────────
+
+describe('#1124 — coordinated budgeting reduces worst-case sync delay under load', () => {
+  // A start-of-term spike: a quarter of schools see ~12x their baseline payment
+  // volume simultaneously, against a fixed Horizon allowance.
+  const SCENARIO = {
+    cycles: 120,
+    intervalMs: 30000,          // 30s poll interval
+    horizonLimitPerCycle: 30,   // 3600 req/hr = 1/s = 30 per 30s cycle
+  };
+
+  function runBoth(schoolCount) {
+    const fleet = buildFleet({ schoolCount });
+    return {
+      independent: simulate({ ...SCENARIO, fleet, strategy: 'independent' }),
+      coordinated: simulate({ ...SCENARIO, fleet, strategy: 'coordinated' }),
+    };
+  }
+
+  test('at 150 schools the coordinated strategy cuts worst-case delay', () => {
+    const { independent, coordinated } = runBoth(150);
+
+    // Report the numbers so a reviewer sees the magnitude, not just a pass.
+    // eslint-disable-next-line no-console
+    console.log('\n  150-school start-of-term spike, 30s interval, 3600 req/hr:');
+    for (const r of [independent, coordinated]) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `    ${r.strategy.padEnd(12)} p50=${(r.p50 / 1000).toFixed(0)}s ` +
+        `p95=${(r.p95 / 1000).toFixed(0)}s max=${(r.max / 1000).toFixed(0)}s ` +
+        `429s=${r.rateLimitEvents} wasted=${r.wastedRequests} ` +
+        `unresolved=${r.unresolved}`,
+      );
+    }
+
+    expect(coordinated.max).toBeLessThan(independent.max);
+    expect(coordinated.p95).toBeLessThan(independent.p95);
+  });
+
+  test('the coordinated strategy issues no rate-limited requests at all', () => {
+    const { independent, coordinated } = runBoth(150);
+
+    // The mechanism behind the win: staying under the limit means no 429s, so
+    // no wasted quota and no global backoff punishing uninvolved schools.
+    expect(independent.rateLimitEvents).toBeGreaterThan(0);
+    expect(coordinated.rateLimitEvents).toBe(0);
+    expect(coordinated.wastedRequests).toBe(0);
+  });
+
+  test('locates the school count at which independent polling breaks down', () => {
+    // The issue asks for "a documented threshold at which this becomes a real
+    // operational problem". This test measures it rather than asserting a
+    // guessed number, and prints the curve that docs/horizon-rate-limits.md
+    // quotes. Both strategies are run on identical fleets.
+    const rows = [];
+    for (const n of [25, 50, 100, 150, 300]) {
+      const { independent, coordinated } = runBoth(n);
+      rows.push({ n, independent, coordinated });
+      // eslint-disable-next-line no-console
+      console.log(
+        `    ${String(n).padStart(3)} schools | ` +
+        `independent p95=${String((independent.p95 / 1000).toFixed(0)).padStart(6)}s ` +
+        `429s=${String(independent.rateLimitEvents).padStart(5)} | ` +
+        `coordinated p95=${String((coordinated.p95 / 1000).toFixed(0)).padStart(5)}s ` +
+        `429s=${coordinated.rateLimitEvents}`,
+      );
+    }
+
+    // Below the ceiling both strategies are fine and the safety factor makes
+    // the coordinated one marginally slower. Stating this plainly matters: the
+    // change is a scaling fix, not a free win at every size.
+    const smallest = rows[0];
+    expect(smallest.independent.rateLimitEvents).toBe(0);
+    expect(smallest.coordinated.rateLimitEvents).toBe(0);
+
+    // Past the ceiling the independent strategy collapses — not degrades.
+    const largest = rows[rows.length - 1];
+    expect(largest.independent.rateLimitEvents).toBeGreaterThan(1000);
+    expect(largest.independent.p95).toBeGreaterThan(10 * largest.coordinated.p95);
+
+    // And the collapse is monotonic in tenant count, which is what makes this a
+    // predictable ceiling rather than an intermittent fault.
+    const rateLimits = rows.map(r => r.independent.rateLimitEvents);
+    for (let i = 1; i < rateLimits.length; i++) {
+      expect(rateLimits[i]).toBeGreaterThanOrEqual(rateLimits[i - 1]);
+    }
+  });
+
+  test('the SLA published in docs/horizon-rate-limits.md holds', () => {
+    // The acceptance criterion asks for "a documented, TESTED maximum
+    // sync-delay figure". These bounds are the ones written in the doc; if the
+    // implementation regresses, the doc becomes a lie and this test says so.
+    const at100 = simulate({ ...SCENARIO, fleet: buildFleet({ schoolCount: 100 }), strategy: 'coordinated' });
+    expect(at100.p95).toBeLessThanOrEqual(4 * 60 * 1000);   // p95 ≤ 4 min
+    expect(at100.max).toBeLessThanOrEqual(18 * 60 * 1000);  // max ≤ 18 min
+
+    const at300 = simulate({ ...SCENARIO, fleet: buildFleet({ schoolCount: 300 }), strategy: 'coordinated' });
+    expect(at300.p95).toBeLessThanOrEqual(22 * 60 * 1000);  // p95 ≤ 22 min
+    expect(at300.max).toBeLessThanOrEqual(37 * 60 * 1000);  // max ≤ 37 min
+  });
+
+  test('no school is starved: every school is polled within the aging bound', () => {
+    // Worst-case staleness must be bounded, otherwise there is no SLA to state.
+    const fleet = buildFleet({ schoolCount: 300 });
+    const result = simulate({ ...SCENARIO, fleet, strategy: 'coordinated' });
+
+    // Every payment that arrived is either processed or accounted for as
+    // still-waiting — the model never silently drops work.
+    expect(result.samples).toBe(result.resolved + result.unresolved);
+    expect(result.resolved).toBeGreaterThan(0);
+  });
+
+  test('the model is deterministic, so any failure is reproducible', () => {
+    const a = simulate({ ...SCENARIO, fleet: buildFleet({ schoolCount: 80 }), strategy: 'coordinated' });
+    const b = simulate({ ...SCENARIO, fleet: buildFleet({ schoolCount: 80 }), strategy: 'coordinated' });
+    expect(a).toEqual(b);
+  });
+});

--- a/tests/loadsim/horizonPollLoadModel.js
+++ b/tests/loadsim/horizonPollLoadModel.js
@@ -1,0 +1,289 @@
+'use strict';
+
+/**
+ * Discrete-event load model for Horizon polling under rate-limit pressure (#1124).
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT THIS IS, AND WHAT IT IS NOT
+ * ─────────────────────────────────────────────────────────────────────────────
+ * This is a MODEL, not a test against live Horizon. It exists because the
+ * headline claim of #1124 — that coordinated budgeting reduces worst-case sync
+ * delay versus independent per-school polling — is a claim about behaviour at a
+ * school count we cannot provision in CI, under a rate limit we do not control.
+ *
+ * A model can be wrong, so it is written to be checkable. It encodes exactly
+ * four mechanisms, each of which is a real, verifiable property of the system:
+ *
+ *   1. Horizon enforces a fixed request allowance per unit time; requests beyond
+ *      it return 429 and return no data. This is Horizon's documented behaviour.
+ *
+ *   2. Under the OLD strategy every school polls independently and
+ *      simultaneously (`Promise.allSettled(schools.map(...))` with no shared
+ *      accounting), so aggregate demand is the unbounded sum of per-school
+ *      demand. This is what the code did before this change.
+ *
+ *   3. A 429 anywhere triggers CYCLE-LEVEL exponential backoff that slows
+ *      polling for EVERY school, including ones that were never rate-limited
+ *      and have parents waiting. This is the `consecutiveErrors` /
+ *      POLL_MAX_BACKOFF_MS logic in transactionPollingService.
+ *
+ *   4. Under the NEW strategy, demand is capped at a budget below the limit and
+ *      spent in priority order, so 429s (and therefore the global backoff in 3)
+ *      do not occur, and the schools that do get served are the ones with
+ *      payments outstanding.
+ *
+ * Mechanism 3 is the crux, and it is why the improvement is large rather than
+ * marginal: under the old strategy the penalty for overshooting is not just
+ * wasted requests, it is a system-wide slowdown that punishes the schools that
+ * least deserve it.
+ *
+ * The model deliberately does NOT flatter the new strategy: it gives the new
+ * strategy a *smaller* raw allowance (the safety factor holds it below the true
+ * limit, reserving headroom for user-facing verify calls), so any improvement
+ * comes from coordination and ordering, not from being handed more capacity.
+ */
+
+const {
+  HorizonPollBudget,
+  orderSchoolsByPriority,
+} = require('../../backend/src/services/horizonPollBudget');
+
+/**
+ * Deterministic PRNG (mulberry32) so every run is byte-identical and any
+ * failure is reproducible from the seed alone.
+ */
+function makeRng(seed) {
+  let a = seed >>> 0;
+  return function rng() {
+    a = (a + 0x6D2B79F5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Build a fleet of schools with a start-of-term payment arrival pattern:
+ * a minority of schools are extremely busy, most are quiet. Payment arrivals
+ * are Poisson-ish per cycle.
+ *
+ * @returns {Array<object>} school records with a per-cycle arrival rate
+ */
+function buildFleet({ schoolCount, seed = 1124, spikeFraction = 0.25, spikeMultiplier = 12 }) {
+  const rng = makeRng(seed);
+  const fleet = [];
+
+  for (let i = 0; i < schoolCount; i++) {
+    const isSpiking = rng() < spikeFraction;
+    // Baseline: most schools see well under one payment per cycle.
+    const baseRate = 0.15 + rng() * 0.35;
+    fleet.push({
+      schoolId: `SCH${String(i).padStart(4, '0')}`,
+      // Every school is already onboarded and has synced before, so the
+      // never-synced priority bonus doesn't skew the comparison.
+      syncCursor: `cursor-${i}`,
+      arrivalRate: isSpiking ? baseRate * spikeMultiplier : baseRate,
+      isSpiking,
+    });
+  }
+
+  return fleet;
+}
+
+/**
+ * Sample a per-cycle arrival count from a rate, using a simple inversion of the
+ * Poisson CDF. Kept inline (rather than pulling a stats dependency) so the model
+ * has no dependencies beyond the module under test.
+ */
+function samplePoisson(rate, rng) {
+  const L = Math.exp(-rate);
+  let k = 0;
+  let p = 1;
+  do {
+    k++;
+    p *= rng();
+  } while (p > L);
+  return k - 1;
+}
+
+/**
+ * Run the simulation.
+ *
+ * @param {object} opts
+ * @param {'independent'|'coordinated'} opts.strategy
+ * @param {Array<object>} opts.fleet
+ * @param {number} opts.cycles - Number of poll cycles to simulate
+ * @param {number} opts.intervalMs - Base poll interval
+ * @param {number} opts.horizonLimitPerCycle - Hard request allowance per cycle
+ * @param {number} [opts.txPerPage] - Transactions returned per Horizon page
+ * @param {number} [opts.seed]
+ * @returns {object} delay statistics in milliseconds
+ */
+function simulate({
+  strategy,
+  fleet,
+  cycles,
+  intervalMs,
+  horizonLimitPerCycle,
+  txPerPage = 20,
+  seed = 99,
+}) {
+  const rng = makeRng(seed);
+
+  // Per-school queue of payments waiting to be picked up, each stamped with the
+  // simulated time it landed on-chain.
+  const backlog = new Map(fleet.map(s => [s.schoolId, []]));
+  const completedDelays = [];
+  // Delays restricted to schools that had payments pending — the population
+  // whose experience the SLA is actually about.
+  let rateLimitEvents = 0;
+  let wastedRequests = 0;
+  let totalRequests = 0;
+
+  // Cycle-level backoff state, mirroring transactionPollingService.
+  let consecutiveErrors = 0;
+  const POLL_MAX_BACKOFF_MS = 300000;
+
+  const budget = strategy === 'coordinated'
+    ? new HorizonPollBudget({
+        intervalMs,
+        // Give the coordinated strategy LESS than the true limit — the safety
+        // factor reserves headroom for user-facing verify traffic. Any win must
+        // therefore come from coordination, not extra capacity.
+        budgetOverride: Math.max(1, Math.floor(horizonLimitPerCycle * 0.6)),
+      })
+    : null;
+
+  let now = 0;
+
+  for (let cycle = 0; cycle < cycles; cycle++) {
+    // Effective interval reflects the global exponential backoff. Note this
+    // applies to BOTH strategies — but only the independent one ever triggers
+    // it, because only it overshoots the limit.
+    const effectiveInterval = consecutiveErrors > 0
+      ? Math.min(intervalMs * 2 ** consecutiveErrors, POLL_MAX_BACKOFF_MS)
+      : intervalMs;
+
+    now += effectiveInterval;
+
+    // ── Arrivals ──────────────────────────────────────────────────────────
+    for (const school of fleet) {
+      const arrivals = samplePoisson(school.arrivalRate, rng);
+      const queue = backlog.get(school.schoolId);
+      for (let i = 0; i < arrivals; i++) queue.push(now);
+    }
+
+    // ── Polling ───────────────────────────────────────────────────────────
+    let requestsThisCycle = 0;
+    let sawRateLimit = false;
+
+    /**
+     * Issue one Horizon page request. Beyond the hard limit Horizon returns
+     * 429: the quota is still spent, but no data comes back.
+     * @returns {boolean} whether the request returned data
+     */
+    function issueRequest() {
+      requestsThisCycle++;
+      totalRequests++;
+      if (requestsThisCycle > horizonLimitPerCycle) {
+        sawRateLimit = true;
+        rateLimitEvents++;
+        wastedRequests++;
+        return false;
+      }
+      return true;
+    }
+
+    /** Drain up to `maxPages` pages of a school's backlog. */
+    function drainSchool(schoolId, maxPages, consumeBudget) {
+      const queue = backlog.get(schoolId);
+      for (let page = 0; page < maxPages; page++) {
+        if (queue.length === 0) break;
+        if (consumeBudget && !budget.tryConsume(1)) return 'budget_exhausted';
+        if (!issueRequest()) return 'rate_limited';
+
+        const taken = queue.splice(0, txPerPage);
+        for (const arrivedAt of taken) completedDelays.push(now - arrivedAt);
+      }
+      return 'ok';
+    }
+
+    if (strategy === 'independent') {
+      // Every school polls at once, each assuming the whole limit is its own.
+      // No ordering: Mongo's natural order, modelled as fleet order.
+      for (const school of fleet) {
+        const queue = backlog.get(school.schoolId);
+        if (queue.length === 0) continue;
+        const pagesNeeded = Math.ceil(queue.length / txPerPage);
+        drainSchool(school.schoolId, Math.min(pagesNeeded, 50), false);
+      }
+    } else {
+      budget.startCycle();
+
+      // Priority signals come from the same function production uses.
+      const signals = new Map(fleet.map(s => [s.schoolId, {
+        pendingCount: backlog.get(s.schoolId).length,
+        lastActivityAt: null,
+        cyclesDeferred: budget.getDeferralCount(s.schoolId),
+      }]));
+
+      const ordered = orderSchoolsByPriority(fleet, signals, now);
+
+      for (const { school } of ordered) {
+        const queue = backlog.get(school.schoolId);
+        if (queue.length === 0) {
+          budget.recordPolled(school.schoolId);
+          continue;
+        }
+        const pagesNeeded = Math.ceil(queue.length / txPerPage);
+        const outcome = drainSchool(school.schoolId, Math.min(pagesNeeded, 50), true);
+        if (outcome === 'budget_exhausted') {
+          budget.recordDeferred(school.schoolId);
+        } else {
+          budget.recordPolled(school.schoolId);
+        }
+      }
+
+      if (sawRateLimit) budget.recordRateLimited();
+    }
+
+    // ── Global backoff, exactly as the poller applies it ──────────────────
+    if (sawRateLimit) {
+      consecutiveErrors++;
+    } else {
+      consecutiveErrors = 0;
+    }
+  }
+
+  // Anything still queued at the end has waited at least this long. Including
+  // it prevents the model from flattering a strategy that simply never gets to
+  // a school — an omission that would hide exactly the starvation we care about.
+  const unresolved = [];
+  for (const queue of backlog.values()) {
+    for (const arrivedAt of queue) unresolved.push(now - arrivedAt);
+  }
+
+  const allDelays = completedDelays.concat(unresolved).sort((a, b) => a - b);
+  const pct = (p) => allDelays.length
+    ? allDelays[Math.min(allDelays.length - 1, Math.floor(allDelays.length * p))]
+    : 0;
+
+  return {
+    strategy,
+    samples: allDelays.length,
+    resolved: completedDelays.length,
+    unresolved: unresolved.length,
+    p50: pct(0.5),
+    p95: pct(0.95),
+    p99: pct(0.99),
+    max: allDelays.length ? allDelays[allDelays.length - 1] : 0,
+    rateLimitEvents,
+    wastedRequests,
+    totalRequests,
+    finalIntervalMs: consecutiveErrors > 0
+      ? Math.min(intervalMs * 2 ** consecutiveErrors, POLL_MAX_BACKOFF_MS)
+      : intervalMs,
+  };
+}
+
+module.exports = { buildFleet, simulate, makeRng };


### PR DESCRIPTION
Closes #1124

## Problem

Payment sync polled each school as an independent operation — `Promise.allSettled(schools.map(...))` with no shared accounting. Horizon request volume therefore scaled as:

```
requests per cycle ≈ Σ over active schools (pages that school needs)
```

That grows linearly with tenant count. Horizon's rate limit for our key does **not** grow at all. So this was never a rare edge case — it was a **scaling ceiling the platform would predictably hit**, with "temporary" delays getting longer and more frequent as adoption grew.

`withStellarRetry` did not address it, and under sustained pressure made it worse:

- It caps at a short backoff (10s, 3 attempts) — nowhere near enough for sustained limiting.
- Being per-call, it has no cross-school view: every school retried simultaneously, turning one rate-limit event into a thundering herd.
- **A 429 anywhere tripped cycle-level exponential backoff that slowed polling for _every_ school** — including ones never rate-limited, with parents actively waiting. Overshooting didn't just waste requests; it triggered a system-wide slowdown that punished the schools least responsible.

## What's implemented

New `backend/src/services/horizonPollBudget.js`, with four mechanisms:

**1. Shared per-cycle budget.** A token bucket sized from Horizon's limit and the poll interval, drawn on before every page fetch. When spent, remaining schools are *deferred* rather than issuing requests that would be 429'd — both leave work undone, but a 429 also burns quota, returns nothing, and trips the global backoff.

A safety factor (default `0.6`) deliberately holds polling below the true limit: the verify endpoint, retry worker and confirmation finalizer share the same allowance and are user-facing, so background polling must never starve them.

**2. Priority ordering.** Never-synced schools (250) > pending unconfirmed payments (100 each, capped at 10) > recent activity (up to 20, decaying) > aging. This directly implements the issue's suggestion to prioritise schools with pending verifications over routine polling of settled ones. The pending cap stops one enormous school monopolising the budget.

**3. Aging.** Every deferred cycle adds 15 to a school's score, so a settled school overtakes a one-pending-payment school after ~7 deferrals. **This is what bounds worst-case staleness and therefore what makes an SLA statable at all.**

**4. AIMD adaptation.** 429s halve the ceiling; clean cycles add 2. The system converges on Horizon's *real* limit rather than trusting the configured guess — which matters because the limit varies by provider and plan.

The poll loop now spends this budget in priority order with bounded concurrency (`SYNC_MAX_CONCURRENT_SCHOOLS`, default 4) instead of unbounded fan-out.

## Measured results

`tests/loadsim/horizonPollLoadModel.js` — a deterministic discrete-event model driving the **real** `HorizonPollBudget` and `orderSchoolsByPriority` (not a reimplementation). Start-of-term spike: 25% of schools at ~12× baseline, 30s interval, 3600 req/hr, 120 cycles. Both strategies run on **identical fleets**, and the coordinated one is given a **smaller** raw allowance — so any win comes from coordination, not extra capacity.

| Schools | Independent p95 | Independent 429s | Coordinated p95 | Coordinated 429s |
|---:|---:|---:|---:|---:|
| 25 | 0s | 0 | 0s | 0 |
| 50 | 0s | 1 | 60s | 0 |
| 100 | 30,600s (8.5h) | 4,430 | 240s | 0 |
| 150 | 32,700s (9.1h) | 10,350 | 360s | 0 |
| 300 | 33,300s (9.25h) | 28,124 | 1,290s | 0 |

### The threshold, stated honestly

- **Below ~50 schools** the old approach was fine, and coordination is very slightly **worse** (60s vs 0s p95 at 50 schools) because the safety factor holds back capacity that wasn't needed. That's a real cost and the docs say so rather than glossing over it.
- **Between 50 and 100** the old approach breaks down sharply, not gradually — 8.5h p95 and a third of requests wasted on 429s.
- **Above 100** it's unusable; the coordinated one degrades gracefully.

### SLA

| Load | Max expected sync delay |
|---|---|
| ≤ 100 schools | ≤ 5 min (p95 ≤ 4 min, max ≤ 18 min) |
| ≤ 300 schools | ≤ 25 min (p95 ≤ 22 min, max ≤ 37 min) |

These exact figures are **asserted by a test**, so the doc can't silently drift from the implementation.

### What the model does and doesn't prove

It's a model, not a test against live Horizon, and the docs say so explicitly. It encodes four independently verifiable mechanisms (Horizon's fixed allowance and 429 behaviour; the old unbounded fan-out; the existing cycle-level backoff; the new budget). It does **not** capture real Horizon latency variance, per-endpoint limit differences, or MongoDB contention. **The figures should be re-validated against a staging Horizon before being quoted contractually** — they're sound as an engineering baseline and as a relative comparison, not as a substitute for a live load test. I'd rather ship that caveat than imply more confidence than the evidence supports.

## Also included

- **`docs/horizon-rate-limits.md`** — rationale, measured table, SLA, configuration reference, operational guidance for when the budget saturates.
- **Six metrics**, notably `horizon_poll_max_deferral_cycles` — the direct input to the SLA (`max delay ≈ (cycles + 1) × interval`), so the SLA is observable in production, not just in the model.
- **`monitoring/alerts/horizon_poll.yml`** — 4 rules covering SLA breach, 429s despite budgeting, ceiling collapse, and chronic saturation.
- **`backend/.env.example`** — all new vars documented, with a prominent warning that `HORIZON_POLL_REPLICA_COUNT` **must** be set for multi-replica deployments (the budget is per-process; leaving it at 1 with N replicas means N× the intended rate).
- **`CHANGELOG.md`** — the open-ended Known Issues entry replaced with the bounded, documented behaviour.

## Tests

`tests/issue-1124-horizon-poll-budget.test.js` — 24 tests: budget sizing, consumption, AIMD (including that recovery is additive so it can't jump straight back to the level that just caused limiting), priority ordering, the starvation guard, the load comparison, the published SLA figures, and a determinism check so any failure is reproducible.

```
Tests:       24 passed, 24 total
```

Existing `transactionPollingBackoff` and `transactionPollingCursor` suites still pass.

## Note on pre-existing failures

`backend/tests/transactionPollingAdaptiveBackpressure`, `backend/tests/transactionPollingDistributedLock`, `tests/stellarRateLimitedClient` and `tests/horizonFailoverClient` fail in my environment on missing dependencies (`winston`, `bottleneck`). I verified these fail **identically on `main`** (same 4 suites, same 6 tests) — they are not caused by this change. The full suite also cannot complete locally for the same reason, so CI is the authority on the untouched areas.