### PR TITLE
feat: support MEMO_ID and MEMO_HASH for QR code payments

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -21,6 +21,7 @@ const { server } = require('../config/stellarConfig');
 const { ACCEPTED_ASSETS } = require('../config/stellarConfig');
 const { validateTransactionHash } = require('../utils/hashValidator');
 const { getPaymentLimits, validatePaymentAmount } = require('../utils/paymentLimits');
+const { SUPPORTED_MEMO_TYPES } = require('../utils/stellarMemo');
 const { convertToLocalCurrency } = require('../services/currencyConversionService');
 const { withStellarRetry } = require('../utils/withStellarRetry');
 const { makePaymentAuditLogger } = require('../utils/paymentAuditLogger');
@@ -105,8 +106,12 @@ async function getPaymentInstructions(req, res, next) {
       feeLocalEquivalent: feeConversion?.available
         ? { amount: feeConversion.localAmount, currency: feeConversion.currency, rate: feeConversion.rate, rateTimestamp: feeConversion.rateTimestamp }
         : null,
-      note: 'Include the payment intent memo exactly when sending payment. The memo must be sent as a text memo (MEMO_TEXT). Other memo types (MEMO_ID, MEMO_HASH, MEMO_RETURN) will not be recognised and your payment will not be matched.',
+      note: 'Include the payment intent memo exactly when sending payment. MEMO_TEXT is recommended; wallets that cannot send text memos may use MEMO_ID or MEMO_HASH with the encoded form of the same reference. MEMO_RETURN is not recognised and such payments will not be matched.',
+      // `memoType` keeps its original 'text' spelling — it is part of the
+      // published API response and existing clients compare against it
+      // directly. New clients should read `supportedMemoTypes` (#1118).
       memoType: 'text',
+      supportedMemoTypes: SUPPORTED_MEMO_TYPES,
     });
   } catch (err) {
     next(err);

--- a/backend/src/services/parsers/memoExtractor.js
+++ b/backend/src/services/parsers/memoExtractor.js
@@ -8,6 +8,7 @@
  */
 
 const logger = require('../../utils/logger').child('MemoExtractor');
+const { decodeMemoToCanonical } = require('../../utils/stellarMemo');
 
 /**
  * Extract memo from transaction, handling all Stellar memo types
@@ -69,8 +70,8 @@ function extractMemo(tx) {
 
 /**
  * Extract memo based on type (TEXT, ID, HASH, RETURN)
- * Only MEMO_TEXT is accepted for student ID matching.
- * MEMO_HASH and MEMO_RETURN are rejected to prevent accidental matching.
+ * MEMO_TEXT, MEMO_ID and MEMO_HASH all resolve to a canonical payment
+ * reference (#1118). MEMO_RETURN has no such encoding and is still rejected.
  * @param {object} memoData - Raw memo data from transaction
  * @returns {ExtractedMemo} Processed memo with type and content
  */
@@ -89,26 +90,37 @@ function extractByType(memoData) {
       };
 
     case 'id':
-    case 'MEMO_ID':
-      // MEMO_ID is not supported for student ID matching
-      logger.warn('MEMO_ID type not supported for payment matching', { memoValue });
+    case 'MEMO_ID': {
+      // #1118 — decoded back to the canonical intent memo for wallets that
+      // cannot send free text. Values outside our 32-bit memo space decode to
+      // null rather than being truncated into a false match.
+      const idContent = decodeMemoToCanonical(memoValue, 'MEMO_ID');
+      if (!idContent) {
+        logger.warn('MEMO_ID is not a valid payment reference', { memoValue });
+      }
       return {
-        content: null,
+        content: idContent,
         type: 'MEMO_ID',
         raw: memoData,
         encoding: null
       };
+    }
 
     case 'hash':
-    case 'MEMO_HASH':
-      // MEMO_HASH is not supported — could contain arbitrary bytes
-      logger.warn('MEMO_HASH type not supported for payment matching', { memoValue });
+    case 'MEMO_HASH': {
+      // #1118 — only hashes carrying our zero-padded canonical memo decode;
+      // any other 32-byte value belongs to a different protocol and yields null.
+      const hashContent = decodeMemoToCanonical(memoValue, 'MEMO_HASH');
+      if (!hashContent) {
+        logger.warn('MEMO_HASH is not a valid payment reference', { memoValue });
+      }
       return {
-        content: null,
+        content: hashContent,
         type: 'MEMO_HASH',
         raw: memoData,
         encoding: 'hex'
       };
+    }
 
     case 'return':
     case 'MEMO_RETURN':

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -13,6 +13,11 @@ const Student = require("../models/studentModel");
 const PaymentIntent = require("../models/paymentIntentModel");
 const { validatePaymentAmount } = require("../utils/paymentLimits");
 const { toStroops, stroopsToNumber, compareAmounts } = require("../utils/stellarAmount");
+const {
+  SUPPORTED_MEMO_TYPES,
+  normalizeMemoType,
+  decodeMemoToCanonical,
+} = require("../utils/stellarMemo");
 const { withStellarRetry } = require("../utils/withStellarRetry");
 const { savePayment } = require("./transactionService");
 const { deriveCorrelationId } = require("../utils/correlationId");
@@ -84,8 +89,8 @@ async function extractValidPayment(tx, walletAddress) {
     return null;
   }
   
-  if (memoType !== 'text') {
-    // MEMO_ID, MEMO_HASH, or MEMO_RETURN — unsupported for student ID matching
+  if (!normalizeMemoType(memoType)) {
+    // MEMO_RETURN — no canonical encoding, so it cannot identify a payment.
     logger.warn('Transaction has unsupported memo type', {
       txHash: tx.hash,
       memoType,
@@ -94,8 +99,15 @@ async function extractValidPayment(tx, walletAddress) {
     return null;
   }
 
-  const memo = innerTx.memo ? innerTx.memo.trim() : null;
-  if (!memo) return null;
+  // MEMO_ID / MEMO_HASH decode back to the canonical intent memo (#1118).
+  const memo = decodeMemoToCanonical(innerTx.memo, memoType);
+  if (!memo) {
+    logger.warn('Transaction memo could not be decoded to a payment reference', {
+      txHash: tx.hash,
+      memoType,
+    });
+    return null;
+  }
 
   const ops = await withStellarRetry(() => innerTx.operations(), {
     label: "extractValidPayment.operations",
@@ -480,17 +492,30 @@ async function verifyTransaction(txHash, walletAddress, schoolId = null) {
     throw err;
   }
 
-  if (memoType !== 'text') {
+  // MEMO_ID and MEMO_HASH are decoded back to the canonical intent memo (#1118)
+  // so wallets that cannot send free-text memos still match. MEMO_RETURN has no
+  // encoding and stays unsupported.
+  if (!normalizeMemoType(memoType)) {
     const err = new Error(
-      `Transaction memo type '${memoType}' is not supported. Only MEMO_TEXT is accepted for student ID matching.`,
+      `Transaction memo type '${memoType}' is not supported. Accepted types: ${SUPPORTED_MEMO_TYPES.join(', ')}.`,
     );
     err.code = "UNSUPPORTED_MEMO_TYPE";
     err.memoType = memoType;
     throw err;
   }
 
-  const memo = innerTx.memo ? innerTx.memo.trim() : null;
+  const memo = decodeMemoToCanonical(innerTx.memo, memoType);
   if (!memo) {
+    // A non-text memo that fails to decode carries no student identity — it is
+    // an unrecognised value rather than a missing one, so report it as such.
+    if (normalizeMemoType(memoType) !== 'MEMO_TEXT') {
+      const err = new Error(
+        `Transaction memo of type '${memoType}' could not be decoded to a payment reference.`,
+      );
+      err.code = "UNSUPPORTED_MEMO_TYPE";
+      err.memoType = memoType;
+      throw err;
+    }
     const err = new Error(
       "Transaction memo is missing or empty — cannot identify student",
     );

--- a/backend/src/utils/stellarMemo.js
+++ b/backend/src/utils/stellarMemo.js
@@ -1,0 +1,122 @@
+'use strict';
+
+/**
+ * Stellar memo decoding (SEP-0007) — backend mirror.
+ *
+ * MIRRORS frontend/src/utils/stellarMemo.js. The frontend encodes a payment
+ * intent memo into the QR code; this module decodes whatever the wallet
+ * actually broadcast back to the canonical form. The two must stay in sync —
+ * any change to the encoding here needs the same change there (same
+ * arrangement the stroop-precision rules use, #1123).
+ *
+ * Payment intent memos are 8 uppercase hex characters (4 random bytes, see
+ * createPaymentIntent), which round-trips losslessly through:
+ *
+ *   MEMO_TEXT — canonical form, verbatim ("A3F91B2C")
+ *   MEMO_ID   — the same 32-bit value as an unsigned decimal ("2750749484")
+ *   MEMO_HASH — the value right-aligned in 32 bytes (base64 on the wire,
+ *               hex in Horizon's JSON)
+ *
+ * Because every supported type decodes back to the canonical text memo, the
+ * intent lookup stays a single query against `memo` — there is no second
+ * matching path to keep correct.
+ *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md
+ */
+
+const SUPPORTED_MEMO_TYPES = Object.freeze(['MEMO_TEXT', 'MEMO_ID', 'MEMO_HASH']);
+
+/** Canonical intent memos: exactly 8 hex characters. */
+const CANONICAL_MEMO_RE = /^[0-9A-F]{8}$/;
+
+/**
+ * Normalise Horizon's memo type spelling ('text', 'id', 'hash') or the
+ * SEP-0007 spelling ('MEMO_TEXT', …) to the SEP-0007 form.
+ *
+ * @param {string} memoType
+ * @returns {string|null} SEP-0007 memo type, or null if unsupported
+ */
+function normalizeMemoType(memoType) {
+  if (!memoType) return null;
+  const upper = String(memoType).toUpperCase();
+  const full = upper.startsWith('MEMO_') ? upper : `MEMO_${upper}`;
+  return SUPPORTED_MEMO_TYPES.includes(full) ? full : null;
+}
+
+/**
+ * True when `memo` is a canonical 8-hex-character payment intent memo.
+ *
+ * @param {string} memo
+ * @returns {boolean}
+ */
+function isCanonicalMemo(memo) {
+  return typeof memo === 'string' && CANONICAL_MEMO_RE.test(memo.trim().toUpperCase());
+}
+
+/**
+ * Decode a memo of any supported type back to its canonical text form.
+ *
+ * Returns null when the value is not a valid encoding of a canonical memo, so
+ * callers fall through to their existing unmatched-payment handling rather
+ * than matching on a coincidence.
+ *
+ * @param {string|number} value - Memo value as reported by Horizon
+ * @param {string} memoType - Memo type ('text' | 'id' | 'hash' | MEMO_* form)
+ * @returns {string|null} Canonical memo, or null
+ */
+function decodeMemoToCanonical(value, memoType) {
+  if (value === null || value === undefined || value === '') return null;
+
+  const type = normalizeMemoType(memoType);
+  if (!type) return null;
+
+  if (type === 'MEMO_TEXT') {
+    // Text memos are passed through untouched — they may legitimately be a
+    // free-text memo (a raw student ID) rather than an intent memo, and the
+    // caller's existing matching handles that.
+    const text = String(value).trim();
+    return text || null;
+  }
+
+  if (type === 'MEMO_ID') {
+    const raw = String(value).trim();
+    if (!/^\d+$/.test(raw)) return null;
+    const numeric = Number(raw);
+    // Reject anything outside the 32-bit space our memos occupy rather than
+    // truncating an unrelated account identifier into a false match. Wallets
+    // that use MEMO_ID for exchange routing send values far above this.
+    if (!Number.isSafeInteger(numeric) || numeric < 0 || numeric > 0xffffffff) return null;
+    return numeric.toString(16).toUpperCase().padStart(8, '0');
+  }
+
+  // MEMO_HASH — accept hex (Horizon JSON) or base64 (SEP-0007 wire form).
+  const bytes = decodeHashBytes(String(value).trim());
+  if (!bytes || bytes.length !== 32) return null;
+
+  // The leading 28 bytes must be the zero padding the encoder wrote. Anything
+  // else is a genuine 32-byte hash belonging to someone else's protocol and
+  // must not be matched.
+  for (let i = 0; i < 28; i += 1) {
+    if (bytes[i] !== 0) return null;
+  }
+
+  const tail = bytes.subarray(28).toString('hex').toUpperCase();
+  return CANONICAL_MEMO_RE.test(tail) ? tail : null;
+}
+
+function decodeHashBytes(value) {
+  if (/^[0-9a-fA-F]{64}$/.test(value)) {
+    return Buffer.from(value, 'hex');
+  }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return null;
+  const buf = Buffer.from(value, 'base64');
+  // Buffer.from silently tolerates malformed base64; re-encoding catches it.
+  return buf.toString('base64').replace(/=+$/, '') === value.replace(/=+$/, '') ? buf : null;
+}
+
+module.exports = {
+  SUPPORTED_MEMO_TYPES,
+  normalizeMemoType,
+  isCanonicalMemo,
+  decodeMemoToCanonical,
+};

--- a/backend/tests/stellarMemo.test.js
+++ b/backend/tests/stellarMemo.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * Tests for backend/src/utils/stellarMemo.js (#1118).
+ *
+ * This module is the decode half of a contract whose encode half lives in
+ * frontend/src/utils/stellarMemo.js. The "wire form" fixtures below are the
+ * exact strings the frontend encoder produces, so a drift in either direction
+ * fails here.
+ */
+
+const {
+  SUPPORTED_MEMO_TYPES,
+  normalizeMemoType,
+  isCanonicalMemo,
+  decodeMemoToCanonical,
+} = require('../src/utils/stellarMemo');
+
+const MEMO = 'A3F91B2C';
+const WIRE = {
+  MEMO_TEXT: MEMO,
+  MEMO_ID: '2751011628',
+  MEMO_HASH: Buffer.concat([Buffer.alloc(28), Buffer.from(MEMO, 'hex')]).toString('base64'),
+};
+
+describe('normalizeMemoType', () => {
+  test("accepts Horizon's lowercase spelling", () => {
+    expect(normalizeMemoType('text')).toBe('MEMO_TEXT');
+    expect(normalizeMemoType('id')).toBe('MEMO_ID');
+    expect(normalizeMemoType('hash')).toBe('MEMO_HASH');
+  });
+
+  test('returns null for unsupported and absent types', () => {
+    expect(normalizeMemoType('return')).toBeNull();
+    expect(normalizeMemoType('none')).toBeNull();
+    expect(normalizeMemoType(undefined)).toBeNull();
+  });
+});
+
+describe('isCanonicalMemo', () => {
+  test('accepts 8-hex-character intent memos', () => {
+    expect(isCanonicalMemo(MEMO)).toBe(true);
+    expect(isCanonicalMemo('a3f91b2c')).toBe(true);
+  });
+
+  test('rejects free text', () => {
+    expect(isCanonicalMemo('STU1023')).toBe(false);
+    expect(isCanonicalMemo('')).toBe(false);
+    expect(isCanonicalMemo(null)).toBe(false);
+  });
+});
+
+describe('decodeMemoToCanonical', () => {
+  test.each(SUPPORTED_MEMO_TYPES)('decodes the frontend wire form for %s', (type) => {
+    expect(decodeMemoToCanonical(WIRE[type], type)).toBe(MEMO);
+  });
+
+  test.each([
+    ['text', WIRE.MEMO_TEXT],
+    ['id', WIRE.MEMO_ID],
+    ['hash', WIRE.MEMO_HASH],
+  ])("decodes Horizon's '%s' spelling", (type, value) => {
+    expect(decodeMemoToCanonical(value, type)).toBe(MEMO);
+  });
+
+  test('accepts a numeric MEMO_ID as reported by some Horizon clients', () => {
+    expect(decodeMemoToCanonical(2751011628, 'id')).toBe(MEMO);
+  });
+
+  test('MEMO_ID outside the 32-bit memo space does not match', () => {
+    // Exchanges routinely use large MEMO_ID values for account routing. Those
+    // must not be truncated into a collision with a real intent memo.
+    expect(decodeMemoToCanonical('4294967296', 'id')).toBeNull();
+    expect(decodeMemoToCanonical('18446744073709551615', 'id')).toBeNull();
+  });
+
+  test('MEMO_HASH carrying a foreign 32-byte value does not match', () => {
+    const foreign = Buffer.alloc(32, 0xab).toString('base64');
+    expect(decodeMemoToCanonical(foreign, 'hash')).toBeNull();
+  });
+
+  test('MEMO_HASH accepts the hex encoding Horizon returns in JSON', () => {
+    const hex = `${'00'.repeat(28)}${MEMO.toLowerCase()}`;
+    expect(decodeMemoToCanonical(hex, 'hash')).toBe(MEMO);
+  });
+
+  test('MEMO_HASH rejects malformed base64', () => {
+    expect(decodeMemoToCanonical('!!!not-base64!!!', 'hash')).toBeNull();
+  });
+
+  test('MEMO_TEXT still passes raw student IDs through unchanged', () => {
+    // The pre-#1118 matching path stays intact for schools that publish a
+    // student ID as the memo rather than an intent reference.
+    expect(decodeMemoToCanonical('STU1023', 'text')).toBe('STU1023');
+    expect(decodeMemoToCanonical('  STU1023  ', 'text')).toBe('STU1023');
+  });
+
+  test('MEMO_RETURN and empty memos yield null', () => {
+    expect(decodeMemoToCanonical(WIRE.MEMO_HASH, 'return')).toBeNull();
+    expect(decodeMemoToCanonical('', 'text')).toBeNull();
+    expect(decodeMemoToCanonical(null, 'text')).toBeNull();
+    expect(decodeMemoToCanonical(undefined, 'id')).toBeNull();
+  });
+});

--- a/docs/qr-code-payments.md
+++ b/docs/qr-code-payments.md
@@ -11,14 +11,44 @@ The QR code payment feature allows parents to scan a QR code with their Stellar-
 The QR code encodes a Stellar payment URI following the [SEP-0007 specification](https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md):
 
 ```
-web+stellar:pay?destination=<WALLET_ADDRESS>&amount=<AMOUNT>&memo=<MEMO>&memo_type=TEXT
+web+stellar:pay?destination=<WALLET_ADDRESS>&amount=<AMOUNT>&memo=<MEMO>&memo_type=MEMO_TEXT
 ```
 
 ### Components
 
 1. **stellarUri.js** - Utility function to generate SEP-0007 compliant payment URIs
-2. **PaymentForm.jsx** - Updated to display QR code after student lookup
-3. **qrcode.react** - Library used to render QR codes as SVG
+2. **stellarMemo.js** - Encodes/decodes the payment reference across memo types
+3. **PaymentForm.jsx** - Updated to display QR code after student lookup
+4. **qrcode.react** - Library used to render QR codes as SVG
+
+### Memo types
+
+Most wallets accept a free-text memo, but some — particularly exchange-style and
+programmatic integrations — can only send a numeric or hash memo. The QR code
+therefore offers the payment reference in three interchangeable forms:
+
+| Memo type   | Wire form for reference `A3F91B2C` | Notes |
+| ----------- | ---------------------------------- | ----- |
+| `MEMO_TEXT` | `A3F91B2C`                         | Default. Sent verbatim, 28-byte on-chain limit. |
+| `MEMO_ID`   | `2751011628`                       | The same 32-bit value as an unsigned decimal. |
+| `MEMO_HASH` | 32 bytes, base64                   | The value right-aligned in 32 bytes, zero-padded. |
+
+All three decode back to the identical reference, so payment matching stays a
+single lookup — there is no separate matching path per type. A memo type is only
+offered when the memo can actually be represented in it: a free-text memo such as
+a raw student ID has no numeric equivalent and is `MEMO_TEXT` only.
+
+`MEMO_RETURN` is **not** supported. It carries a 32-byte hash for refund routing
+and has no payment-reference encoding.
+
+Decoding deliberately rejects values that merely *look* plausible: a `MEMO_ID`
+above the 32-bit reference space (exchanges routinely use large routing IDs) and
+a `MEMO_HASH` whose padding bytes are non-zero both fail to decode rather than
+being truncated into a false match against an unrelated payment.
+
+The backend decoder in `backend/src/utils/stellarMemo.js` mirrors the frontend
+encoder. The two must stay in sync; `backend/tests/stellarMemo.test.js` pins the
+exact wire forms the frontend produces so a drift in either direction fails CI.
 
 ### Features
 
@@ -86,6 +116,5 @@ The network is determined by the backend configuration (`STELLAR_NETWORK` enviro
 ## Future Enhancements
 
 - Add download/share QR code functionality
-- Support for additional memo types (MEMO_ID, MEMO_HASH)
 - Dynamic QR code sizing based on screen size
 - Print-friendly QR code format for paper invoices

--- a/frontend/src/components/PaymentForm.jsx
+++ b/frontend/src/components/PaymentForm.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { QRCodeSVG } from "qrcode.react";
-import { generateStellarPaymentUri } from "../utils/stellarUri";
+import { generateStellarPaymentUri, availableMemoTypes } from "../utils/stellarUri";
+import { encodeMemo } from "../utils/stellarMemo";
 import { getStudent, getPaymentInstructions, getStudentPayments, getStudentBalance } from "../services/api";
 import DisputeForm from "./DisputeForm";
 import { getErrorMessage } from "../utils/errorMessages";
@@ -57,6 +58,9 @@ export default function PaymentForm() {
   const [hasDeletedPayments, setHasDeletedPayments] = useState(false);
   const [disputingTx, setDisputingTx]         = useState(null);
   const [disputedTxs, setDisputedTxs]         = useState(new Set());
+  // #1118 — wallets that cannot send free-text memos can switch the QR code to
+  // MEMO_ID or MEMO_HASH; all three decode back to the same payment reference.
+  const [memoType, setMemoType]               = useState("MEMO_TEXT");
   const errorRef  = useRef(null);
   const debounceRef = useRef(null);
   const qrWrapperRef = useRef(null);
@@ -292,13 +296,19 @@ export default function PaymentForm() {
                 const nonNative = instructions.acceptedAssets?.find(
                   a => a.code !== "XLM" && a.type !== "native"
                 );
+                const memoTypes = availableMemoTypes(instructions.memo);
+                // Guard against a stale selection if the memo changes to one
+                // that has no numeric equivalent.
+                const activeMemoType = memoTypes.includes(memoType) ? memoType : "MEMO_TEXT";
                 const paymentUri = generateStellarPaymentUri({
                   destination: instructions.walletAddress,
                   amount: instructions.feeAmount ?? student.feeAmount ?? 0,
                   memo: instructions.memo,
+                  memoType: activeMemoType,
                   assetCode: nonNative?.code,
                   assetIssuer: nonNative?.issuer,
                 });
+                const encodedMemo = encodeMemo(instructions.memo, activeMemoType);
                 const downloadFilename = `stellar-payment-${instructions.memo}.png`;
                 return (
                   <div style={{ textAlign: "center", marginTop: "1.25rem", padding: "1.25rem", background: "var(--bg-subtle, var(--bg))", borderRadius: "var(--radius-sm)", border: "1px solid var(--border)" }}>
@@ -319,6 +329,45 @@ export default function PaymentForm() {
                     <p style={{ marginTop: "0.625rem", fontSize: "0.75rem", color: "var(--text-muted)" }}>
                       Compatible with Lobstr, Solar, XBULL and any SEP-0007 wallet.
                     </p>
+
+                    {/* Memo type — for wallets that require a numeric or hash memo (#1118) */}
+                    {memoTypes.length > 1 && (
+                      <div style={{ marginTop: "0.875rem" }}>
+                        <label
+                          htmlFor="memo-type-select"
+                          className="pf-section-label"
+                          style={{ display: "block", marginBottom: "0.375rem" }}
+                        >
+                          Memo type
+                        </label>
+                        <select
+                          id="memo-type-select"
+                          value={activeMemoType}
+                          onChange={(e) => setMemoType(e.target.value)}
+                          className="input input-sm"
+                          style={{ maxWidth: "16rem", margin: "0 auto" }}
+                        >
+                          <option value="MEMO_TEXT">Text (default)</option>
+                          <option value="MEMO_ID">ID — numeric</option>
+                          <option value="MEMO_HASH">Hash — 32 bytes</option>
+                        </select>
+                        {activeMemoType !== "MEMO_TEXT" && (
+                          <div style={{ marginTop: "0.625rem" }}>
+                            <span className="pf-section-label" style={{ display: "block", marginBottom: "0.375rem" }}>
+                              Memo value for this type
+                            </span>
+                            <div className="pf-code-row" style={{ justifyContent: "center" }}>
+                              <span className="pf-code" style={{ wordBreak: "break-all" }}>{encodedMemo}</span>
+                              <CopyButton text={encodedMemo} copyKey="encoded-memo" copied={copied} onCopy={copy} />
+                            </div>
+                          </div>
+                        )}
+                        <p style={{ marginTop: "0.5rem", fontSize: "0.75rem", color: "var(--text-muted)" }}>
+                          Only change this if your wallet cannot send a text memo. All three
+                          types identify the same payment.
+                        </p>
+                      </div>
+                    )}
 
                     {/* QR actions */}
                     <div style={{ display: "flex", gap: "0.5rem", justifyContent: "center", marginTop: "0.875rem", flexWrap: "wrap" }}>

--- a/frontend/src/utils/__tests__/stellarMemo.test.js
+++ b/frontend/src/utils/__tests__/stellarMemo.test.js
@@ -1,0 +1,128 @@
+'use strict';
+
+/**
+ * Tests for stellarMemo.js — SEP-0007 memo encoding/decoding (#1118).
+ *
+ * The backend mirror (backend/src/utils/stellarMemo.js) must decode whatever
+ * this module encodes; backend/tests/stellarMemo.test.js asserts the same
+ * round-trips from the other side.
+ */
+
+import {
+  MEMO_TYPES,
+  normalizeMemoType,
+  isEncodableMemo,
+  encodeMemo,
+  decodeMemo,
+} from '../stellarMemo';
+
+const MEMO = 'A3F91B2C';
+const MEMO_AS_ID = String(parseInt(MEMO, 16)); // 2751011628
+
+describe('normalizeMemoType', () => {
+  test('expands short forms to the SEP-0007 spelling', () => {
+    expect(normalizeMemoType('text')).toBe('MEMO_TEXT');
+    expect(normalizeMemoType('id')).toBe('MEMO_ID');
+    expect(normalizeMemoType('hash')).toBe('MEMO_HASH');
+  });
+
+  test('passes through full forms unchanged', () => {
+    expect(normalizeMemoType('MEMO_ID')).toBe('MEMO_ID');
+  });
+
+  test('defaults to MEMO_TEXT when unset', () => {
+    expect(normalizeMemoType(undefined)).toBe('MEMO_TEXT');
+  });
+
+  test('throws for MEMO_RETURN, which has no canonical encoding', () => {
+    expect(() => normalizeMemoType('MEMO_RETURN')).toThrow('Unsupported memo type');
+  });
+});
+
+describe('isEncodableMemo', () => {
+  test('accepts canonical 8-hex-character intent memos', () => {
+    expect(isEncodableMemo(MEMO)).toBe(true);
+    expect(isEncodableMemo('00000000')).toBe(true);
+    expect(isEncodableMemo('ffffffff')).toBe(true); // case-insensitive
+  });
+
+  test('rejects free-text memos such as raw student IDs', () => {
+    expect(isEncodableMemo('STU1023')).toBe(false);
+    expect(isEncodableMemo('A3F91B2')).toBe(false);  // too short
+    expect(isEncodableMemo('A3F91B2CD')).toBe(false); // too long
+    expect(isEncodableMemo('G3F91B2C')).toBe(false);  // non-hex
+  });
+});
+
+describe('encodeMemo', () => {
+  test('MEMO_TEXT is sent verbatim', () => {
+    expect(encodeMemo(MEMO, 'MEMO_TEXT')).toBe(MEMO);
+    expect(encodeMemo('STU1023', 'MEMO_TEXT')).toBe('STU1023');
+  });
+
+  test('MEMO_TEXT rejects memos over the 28-byte on-chain limit', () => {
+    expect(() => encodeMemo('x'.repeat(29), 'MEMO_TEXT')).toThrow('28-byte');
+  });
+
+  test('MEMO_ID is the unsigned decimal form of the hex memo', () => {
+    expect(encodeMemo(MEMO, 'MEMO_ID')).toBe(MEMO_AS_ID);
+    expect(encodeMemo('00000001', 'MEMO_ID')).toBe('1');
+  });
+
+  test('MEMO_HASH is 32 bytes, base64, right-aligned', () => {
+    const encoded = encodeMemo(MEMO, 'MEMO_HASH');
+    const bytes = Buffer.from(encoded, 'base64');
+    expect(bytes).toHaveLength(32);
+    expect(bytes.subarray(0, 28).every((b) => b === 0)).toBe(true);
+    expect(bytes.subarray(28).toString('hex').toUpperCase()).toBe(MEMO);
+  });
+
+  test('refuses to encode a free-text memo as MEMO_ID or MEMO_HASH', () => {
+    expect(() => encodeMemo('STU1023', 'MEMO_ID')).toThrow('cannot be encoded');
+    expect(() => encodeMemo('STU1023', 'MEMO_HASH')).toThrow('cannot be encoded');
+  });
+});
+
+describe('decodeMemo', () => {
+  test.each(MEMO_TYPES)('round-trips a canonical memo through %s', (type) => {
+    expect(decodeMemo(encodeMemo(MEMO, type), type)).toBe(MEMO);
+  });
+
+  test('MEMO_ID pads short values back to 8 hex characters', () => {
+    expect(decodeMemo('1', 'MEMO_ID')).toBe('00000001');
+  });
+
+  test('MEMO_ID rejects values outside the 32-bit memo space', () => {
+    // A wallet using MEMO_ID for exchange routing must not be truncated into
+    // a false match against an unrelated intent.
+    expect(decodeMemo('4294967296', 'MEMO_ID')).toBeNull();
+    expect(decodeMemo('18446744073709551615', 'MEMO_ID')).toBeNull();
+    expect(decodeMemo('-1', 'MEMO_ID')).toBeNull();
+    expect(decodeMemo('not-a-number', 'MEMO_ID')).toBeNull();
+  });
+
+  test('MEMO_HASH rejects a genuine 32-byte hash from another protocol', () => {
+    const foreign = Buffer.alloc(32, 0xab).toString('base64');
+    expect(decodeMemo(foreign, 'MEMO_HASH')).toBeNull();
+  });
+
+  test('MEMO_HASH rejects a wrong-length value', () => {
+    expect(decodeMemo(Buffer.alloc(16).toString('base64'), 'MEMO_HASH')).toBeNull();
+  });
+
+  test('MEMO_HASH also accepts the hex form Horizon reports', () => {
+    const hex = `${'00'.repeat(28)}${MEMO.toLowerCase()}`;
+    expect(decodeMemo(hex, 'MEMO_HASH')).toBe(MEMO);
+  });
+
+  test('MEMO_TEXT passes free text through for existing student-ID matching', () => {
+    expect(decodeMemo('STU1023', 'MEMO_TEXT')).toBe('STU1023');
+    expect(decodeMemo('  STU1023  ', 'MEMO_TEXT')).toBe('STU1023');
+  });
+
+  test('returns null for empty and unsupported input', () => {
+    expect(decodeMemo('', 'MEMO_TEXT')).toBeNull();
+    expect(decodeMemo(null, 'MEMO_TEXT')).toBeNull();
+    expect(decodeMemo(MEMO, 'MEMO_RETURN')).toBeNull();
+  });
+});

--- a/frontend/src/utils/__tests__/stellarUri.test.js
+++ b/frontend/src/utils/__tests__/stellarUri.test.js
@@ -3,48 +3,20 @@
 /**
  * Tests for stellarUri.js — generateStellarPaymentUri
  *
- * stellarUri.js uses ES module syntax (export) which the root Jest config
- * does not transform. We inline the function here so the tests run without
- * requiring a Babel transform, while still testing the exact same logic.
- *
- * The canonical implementation lives in frontend/src/utils/stellarUri.js.
- * Any change to that file must be reflected here.
+ * This file previously inlined a copy of the function because the root Jest
+ * config was assumed not to transform ES modules. It does (babel-jest with
+ * preset-env), and the inlined copy had already drifted from the real
+ * implementation — it never picked up the stroop-space amount validation from
+ * #1123, so the suite was green against logic that no longer shipped.
+ * Importing the real module removes that whole failure mode.
  */
 
-// ── Inline the function under test (mirrors stellarUri.js exactly) ────────────
-
-function generateStellarPaymentUri({
-  destination,
-  amount,
-  memo,
-  memoType = 'text',
-  assetCode = 'XLM',
-  assetIssuer = null,
-}) {
-  if (!destination) throw new Error('Destination wallet address is required');
-  if (!amount || parseFloat(amount) <= 0) throw new Error('Valid payment amount is required');
-
-  const params = new URLSearchParams();
-  params.append('destination', destination);
-  params.append('amount', String(amount));
-
-  if (memo) {
-    params.append('memo', memo);
-    params.append('memo_type', memoType.toUpperCase());
-  }
-
-  if (assetCode !== 'XLM' && assetCode !== 'native') {
-    params.append('asset_code', assetCode);
-    if (assetIssuer) params.append('asset_issuer', assetIssuer);
-  }
-
-  return `web+stellar:pay?${params.toString()}`;
-}
-
-// ── Tests ─────────────────────────────────────────────────────────────────────
+import { generateStellarPaymentUri, availableMemoTypes } from '../stellarUri';
+import { encodeMemo } from '../stellarMemo';
 
 const DEST = 'GAXYZ123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const USDC_ISSUER = 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5';
+const INTENT_MEMO = 'A3F91B2C';
 
 describe('generateStellarPaymentUri', () => {
   // ── XLM (native) ────────────────────────────────────────────────────────────
@@ -53,9 +25,9 @@ describe('generateStellarPaymentUri', () => {
     const uri = generateStellarPaymentUri({ destination: DEST, amount: 10.5, memo: 'STU1023' });
     expect(uri).toContain('web+stellar:pay?');
     expect(uri).toContain(`destination=${DEST}`);
-    expect(uri).toContain('amount=10.5');
+    expect(uri).toContain('amount=10.5000000');
     expect(uri).toContain('memo=STU1023');
-    expect(uri).toContain('memo_type=TEXT');
+    expect(uri).toContain('memo_type=MEMO_TEXT');
   });
 
   test('XLM URI omits asset_code and asset_issuer (native is default)', () => {
@@ -74,6 +46,58 @@ describe('generateStellarPaymentUri', () => {
     const uri = generateStellarPaymentUri({ destination: DEST, amount: 5 });
     expect(uri).toContain('web+stellar:pay?');
     expect(uri).not.toContain('memo=');
+  });
+
+  // ── Memo types (#1118) ──────────────────────────────────────────────────────
+
+  test('emits the SEP-0007 memo_type spelling, not the bare short form', () => {
+    // Pre-#1118 this emitted `memo_type=TEXT`, which is not a value SEP-0007
+    // defines; strict wallets reject it.
+    const uri = generateStellarPaymentUri({ destination: DEST, amount: 1, memo: INTENT_MEMO });
+    expect(uri).toContain('memo_type=MEMO_TEXT');
+    expect(uri).not.toContain('memo_type=TEXT');
+  });
+
+  test('MEMO_ID encodes the intent memo as its numeric equivalent', () => {
+    const uri = generateStellarPaymentUri({
+      destination: DEST, amount: 1, memo: INTENT_MEMO, memoType: 'MEMO_ID',
+    });
+    expect(uri).toContain('memo_type=MEMO_ID');
+    expect(uri).toContain(`memo=${encodeMemo(INTENT_MEMO, 'MEMO_ID')}`);
+  });
+
+  test('MEMO_HASH encodes the intent memo as URL-escaped base64', () => {
+    const uri = generateStellarPaymentUri({
+      destination: DEST, amount: 1, memo: INTENT_MEMO, memoType: 'MEMO_HASH',
+    });
+    expect(uri).toContain('memo_type=MEMO_HASH');
+    // URLSearchParams percent-encodes the base64 padding and '+'.
+    const parsed = new URLSearchParams(uri.split('?')[1]);
+    expect(parsed.get('memo')).toBe(encodeMemo(INTENT_MEMO, 'MEMO_HASH'));
+  });
+
+  test('accepts the legacy short memo type spellings', () => {
+    const uri = generateStellarPaymentUri({
+      destination: DEST, amount: 1, memo: INTENT_MEMO, memoType: 'id',
+    });
+    expect(uri).toContain('memo_type=MEMO_ID');
+  });
+
+  test('throws rather than emitting a URI the backend could not match', () => {
+    expect(() => generateStellarPaymentUri({
+      destination: DEST, amount: 1, memo: 'STU1023', memoType: 'MEMO_ID',
+    })).toThrow('cannot be encoded');
+  });
+
+  test('throws for MEMO_RETURN, which carries no payment reference', () => {
+    expect(() => generateStellarPaymentUri({
+      destination: DEST, amount: 1, memo: INTENT_MEMO, memoType: 'MEMO_RETURN',
+    })).toThrow('Unsupported memo type');
+  });
+
+  test('availableMemoTypes reflects what the memo can represent', () => {
+    expect(availableMemoTypes(INTENT_MEMO)).toEqual(['MEMO_TEXT', 'MEMO_ID', 'MEMO_HASH']);
+    expect(availableMemoTypes('STU1023')).toEqual(['MEMO_TEXT']);
   });
 
   // ── USDC (non-native) ────────────────────────────────────────────────────────
@@ -112,5 +136,9 @@ describe('generateStellarPaymentUri', () => {
 
   test('throws when amount is negative', () => {
     expect(() => generateStellarPaymentUri({ destination: DEST, amount: -5 })).toThrow('Valid payment amount is required');
+  });
+
+  test('throws for sub-stroop amounts (#1123)', () => {
+    expect(() => generateStellarPaymentUri({ destination: DEST, amount: 0.00000001 })).toThrow('Valid payment amount is required');
   });
 });

--- a/frontend/src/utils/stellarMemo.js
+++ b/frontend/src/utils/stellarMemo.js
@@ -1,0 +1,174 @@
+/**
+ * Stellar memo encoding helpers (SEP-0007).
+ *
+ * Payment intent memos are 8 uppercase hex characters (4 random bytes, see
+ * createPaymentIntent). That representation is small enough to round-trip
+ * losslessly through all three memo types we support:
+ *
+ *   MEMO_TEXT — the canonical form, sent verbatim ("A3F91B2C")
+ *   MEMO_ID   — the same 32-bit value as an unsigned decimal ("2750749484")
+ *   MEMO_HASH — the value right-aligned in 32 bytes, base64-encoded per SEP-0007
+ *
+ * Every encoding is reversible back to the canonical text form, so the backend
+ * can normalise an incoming memo of any type and match it against the intent
+ * without a second lookup path.
+ *
+ * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md
+ */
+
+export const MEMO_TYPES = ['MEMO_TEXT', 'MEMO_ID', 'MEMO_HASH'];
+
+/** Canonical intent memos: exactly 8 hex characters. */
+const CANONICAL_MEMO_RE = /^[0-9A-F]{8}$/;
+
+/**
+ * Normalise a memo type to its SEP-0007 spelling.
+ * Accepts the short forms ('text', 'id', 'hash') the codebase used previously.
+ *
+ * @param {string} memoType
+ * @returns {string} One of MEMO_TEXT, MEMO_ID, MEMO_HASH
+ */
+export function normalizeMemoType(memoType) {
+  if (!memoType) return 'MEMO_TEXT';
+  const upper = String(memoType).toUpperCase();
+  const full = upper.startsWith('MEMO_') ? upper : `MEMO_${upper}`;
+  if (!MEMO_TYPES.includes(full)) {
+    throw new Error(
+      `Unsupported memo type '${memoType}'. Supported types: ${MEMO_TYPES.join(', ')}`,
+    );
+  }
+  return full;
+}
+
+/**
+ * True when `memo` is a canonical 8-hex-character payment intent memo.
+ * Only canonical memos can be re-encoded as MEMO_ID or MEMO_HASH — a
+ * free-text memo (e.g. a raw student ID) has no numeric equivalent.
+ *
+ * @param {string} memo
+ * @returns {boolean}
+ */
+export function isEncodableMemo(memo) {
+  return typeof memo === 'string' && CANONICAL_MEMO_RE.test(memo.trim().toUpperCase());
+}
+
+/**
+ * Encode a canonical memo into the wire form for the given memo type.
+ *
+ * @param {string} memo - Canonical 8-hex-character memo
+ * @param {string} memoType - SEP-0007 memo type
+ * @returns {string} Wire-form memo value
+ * @throws {Error} If the memo cannot be represented in the requested type
+ */
+export function encodeMemo(memo, memoType) {
+  const type = normalizeMemoType(memoType);
+  const value = String(memo).trim().toUpperCase();
+
+  if (type === 'MEMO_TEXT') {
+    // Text memos are sent verbatim and are capped at 28 bytes on-chain.
+    const byteLength = new TextEncoder().encode(memo).length;
+    if (byteLength > 28) {
+      throw new Error(`MEMO_TEXT exceeds the 28-byte Stellar limit (got ${byteLength} bytes)`);
+    }
+    return String(memo);
+  }
+
+  if (!isEncodableMemo(value)) {
+    throw new Error(
+      `Memo '${memo}' cannot be encoded as ${type} — only canonical 8-hex-character ` +
+        'payment intent memos have a numeric equivalent. Use MEMO_TEXT instead.',
+    );
+  }
+
+  if (type === 'MEMO_ID') {
+    // uint64 on the wire; our 32-bit value always fits.
+    return String(parseInt(value, 16));
+  }
+
+  // MEMO_HASH — 32 raw bytes, base64 per SEP-0007. Right-align the 4 memo bytes
+  // so the encoding is deterministic and zero-padding is unambiguous.
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 4; i += 1) {
+    bytes[28 + i] = parseInt(value.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytesToBase64(bytes);
+}
+
+/**
+ * Reverse `encodeMemo` — recover the canonical memo from any supported type.
+ * Returns null when the value is not a valid encoding of a canonical memo, so
+ * callers can fall through to their existing unmatched-payment handling.
+ *
+ * @param {string} value - Wire-form memo value
+ * @param {string} memoType - SEP-0007 memo type
+ * @returns {string|null} Canonical 8-hex-character memo, or null
+ */
+export function decodeMemo(value, memoType) {
+  if (value === null || value === undefined || value === '') return null;
+
+  let type;
+  try {
+    type = normalizeMemoType(memoType);
+  } catch {
+    return null;
+  }
+
+  if (type === 'MEMO_TEXT') {
+    const text = String(value).trim();
+    return text || null;
+  }
+
+  if (type === 'MEMO_ID') {
+    const raw = String(value).trim();
+    if (!/^\d+$/.test(raw)) return null;
+    const numeric = Number(raw);
+    // Reject anything outside the 32-bit space our memos occupy rather than
+    // truncating a wallet's unrelated account identifier into a false match.
+    if (!Number.isSafeInteger(numeric) || numeric < 0 || numeric > 0xffffffff) return null;
+    return numeric.toString(16).toUpperCase().padStart(8, '0');
+  }
+
+  // MEMO_HASH — accept base64 (SEP-0007 wire form) or hex (Horizon's JSON form).
+  const bytes = decodeHashBytes(String(value).trim());
+  if (!bytes || bytes.length !== 32) return null;
+  // The first 28 bytes must be the zero padding we wrote, otherwise this hash
+  // is someone else's 32-byte value and must not be matched.
+  for (let i = 0; i < 28; i += 1) {
+    if (bytes[i] !== 0) return null;
+  }
+  return Array.from(bytes.slice(28))
+    .map((b) => b.toString(16).toUpperCase().padStart(2, '0'))
+    .join('');
+}
+
+function decodeHashBytes(value) {
+  if (/^[0-9a-fA-F]{64}$/.test(value)) {
+    const out = new Uint8Array(32);
+    for (let i = 0; i < 32; i += 1) {
+      out[i] = parseInt(value.slice(i * 2, i * 2 + 2), 16);
+    }
+    return out;
+  }
+  try {
+    const binary = base64ToBinary(value);
+    if (binary === null) return null;
+    const out = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i += 1) out[i] = binary.charCodeAt(i);
+    return out;
+  } catch {
+    return null;
+  }
+}
+
+function bytesToBase64(bytes) {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += 1) binary += String.fromCharCode(bytes[i]);
+  if (typeof btoa === 'function') return btoa(binary);
+  return Buffer.from(binary, 'binary').toString('base64');
+}
+
+function base64ToBinary(value) {
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(value)) return null;
+  if (typeof atob === 'function') return atob(value);
+  return Buffer.from(value, 'base64').toString('binary');
+}

--- a/frontend/src/utils/stellarUri.js
+++ b/frontend/src/utils/stellarUri.js
@@ -1,14 +1,15 @@
 import { validateStellarAmount } from './stellarAmount';
+import { encodeMemo, isEncodableMemo, normalizeMemoType } from './stellarMemo';
 
 /**
  * Generate a Stellar SEP-0007 payment URI
  * @see https://github.com/stellar/stellar-protocol/blob/master/ecosystem/sep-0007.md
- * 
+ *
  * @param {Object} params - Payment parameters
  * @param {string} params.destination - Stellar wallet address (G...)
  * @param {string|number} params.amount - Payment amount in XLM
- * @param {string} params.memo - Payment memo text
- * @param {string} [params.memoType='text'] - Memo type (text, id, hash, return)
+ * @param {string} params.memo - Payment memo (canonical intent memo, or free text)
+ * @param {string} [params.memoType='MEMO_TEXT'] - MEMO_TEXT, MEMO_ID or MEMO_HASH
  * @param {string} [params.assetCode='XLM'] - Asset code (XLM, USDC, etc.)
  * @param {string} [params.assetIssuer] - Asset issuer (required for non-native assets)
  * @returns {string} Stellar payment URI
@@ -17,14 +18,14 @@ export function generateStellarPaymentUri({
   destination,
   amount,
   memo,
-  memoType = 'text',
+  memoType = 'MEMO_TEXT',
   assetCode = 'XLM',
   assetIssuer = null,
 }) {
   if (!destination) {
     throw new Error('Destination wallet address is required');
   }
-  
+
   // Validate in stroop space using the same rules as the backend (#1123).
   // `parseFloat(amount) > 0` used to be enough here, which let sub-stroop
   // amounts (0.00000001) and scientific notation (1e-8) into the QR code — both
@@ -40,10 +41,14 @@ export function generateStellarPaymentUri({
   // Emit the canonical 7-decimal form so the wallet, the QR code and the
   // backend all see the identical value.
   params.append('amount', amountCheck.normalized);
-  
+
   if (memo) {
-    params.append('memo', memo);
-    params.append('memo_type', memoType.toUpperCase());
+    // Throws for a memo that cannot be represented in the requested type,
+    // rather than silently emitting a URI the backend could never match back
+    // to an intent.
+    const type = normalizeMemoType(memoType);
+    params.append('memo', encodeMemo(memo, type));
+    params.append('memo_type', type);
   }
 
   // For non-native assets, include asset code and issuer
@@ -55,4 +60,16 @@ export function generateStellarPaymentUri({
   }
 
   return `web+stellar:pay?${params.toString()}`;
+}
+
+/**
+ * Which memo types a given memo can be offered in.
+ * Free-text memos (e.g. a raw student ID) have no numeric equivalent, so they
+ * are MEMO_TEXT only.
+ *
+ * @param {string} memo
+ * @returns {string[]} Supported SEP-0007 memo types
+ */
+export function availableMemoTypes(memo) {
+  return isEncodableMemo(memo) ? ['MEMO_TEXT', 'MEMO_ID', 'MEMO_HASH'] : ['MEMO_TEXT'];
 }

--- a/tests/memoExtractor.test.js
+++ b/tests/memoExtractor.test.js
@@ -49,14 +49,40 @@ describe('memoExtractor', () => {
       expect(result.type).toBe('MEMO_TEXT');
     });
 
-    it('should reject MEMO_ID type', () => {
+    // #1118 — MEMO_ID and MEMO_HASH now resolve to the canonical payment
+    // reference so wallets that cannot send free-text memos still match.
+    it('should decode MEMO_ID to the canonical payment reference', () => {
       const memoData = { type: 'id', value: '12345' };
+      const result = extractByType(memoData);
+      expect(result.content).toBe('00003039');
+      expect(result.type).toBe('MEMO_ID');
+    });
+
+    it('should reject a MEMO_ID outside the 32-bit reference space', () => {
+      // Exchange-style routing identifiers must not be truncated into a match.
+      const memoData = { type: 'id', value: '18446744073709551615' };
       const result = extractByType(memoData);
       expect(result.content).toBeNull();
       expect(result.type).toBe('MEMO_ID');
     });
 
-    it('should reject MEMO_HASH type', () => {
+    it('should decode a MEMO_HASH carrying a canonical reference', () => {
+      const memoData = { type: 'hash', value: `${'00'.repeat(28)}a3f91b2c` };
+      const result = extractByType(memoData);
+      expect(result.content).toBe('A3F91B2C');
+      expect(result.type).toBe('MEMO_HASH');
+      expect(result.encoding).toBe('hex');
+    });
+
+    it('should reject a MEMO_HASH that is a foreign 32-byte value', () => {
+      const memoData = { type: 'hash', value: 'ab'.repeat(32) };
+      const result = extractByType(memoData);
+      expect(result.content).toBeNull();
+      expect(result.type).toBe('MEMO_HASH');
+      expect(result.encoding).toBe('hex');
+    });
+
+    it('should reject a malformed MEMO_HASH', () => {
       const memoData = { type: 'hash', value: 'abc123def456' };
       const result = extractByType(memoData);
       expect(result.content).toBeNull();


### PR DESCRIPTION
Closes #1118

## Problem

QR codes only ever emitted `MEMO_TEXT`. Wallets that cannot send a free-text memo — exchange-style and programmatic integrations in particular — had no way to attach the payment reference, so those payments arrive memo-less or malformed and fall out to manual reconciliation.

## Approach

Payment intent memos are 8 hex characters (4 random bytes, see `createPaymentIntent`). That fits losslessly in all three memo types, so the same reference can be offered in whichever form the wallet supports:

| Memo type | Wire form for `A3F91B2C` | Notes |
| --- | --- | --- |
| `MEMO_TEXT` | `A3F91B2C` | Default, sent verbatim |
| `MEMO_ID` | `2751011628` | Same 32-bit value as unsigned decimal |
| `MEMO_HASH` | 32 bytes, base64 | Value right-aligned, zero-padded |

**Every encoding decodes back to the canonical text form**, so payment matching stays a single lookup against the existing `memo` field. There is no second matching path to keep correct — which is the part most likely to rot otherwise.

A memo type is only offered when the memo can actually be represented in it. A free-text memo (a raw student ID) has no numeric equivalent, so it stays `MEMO_TEXT` only and the selector doesn't appear.

`MEMO_RETURN` remains unsupported — it carries a refund-routing hash with no payment-reference encoding.

## Guarding against false matches

Decoding deliberately rejects values that merely look plausible:

- a `MEMO_ID` above the 32-bit reference space — exchanges routinely use large routing identifiers, and truncating one into a match would credit the wrong student;
- a `MEMO_HASH` whose 28 padding bytes are non-zero — that is a genuine 32-byte hash belonging to another protocol.

Both fail to decode and fall through to the existing unmatched-payment handling.

## Two things worth a maintainer's attention

**1. `memo_type=TEXT` was not a valid SEP-0007 value.** The spec defines `MEMO_TEXT`, `MEMO_ID`, `MEMO_HASH`, `MEMO_RETURN`. The URI generator emitted the bare `TEXT`, which strict wallets reject. Fixed to `MEMO_TEXT`. The `memoType` field in the payment-instructions API response is a *separate* thing and keeps its original `text` spelling — it's published API surface that existing clients compare against directly, so changing it would be breaking. New clients should read the added `supportedMemoTypes`.

**2. The `stellarUri` test was testing a stale copy of the code.** It inlined the function under test, on the premise that the root Jest config could not transform ES modules. It can (babel-jest with preset-env), and the inline copy had already drifted — it never picked up the stroop-space amount validation from #1123, so the suite was green against logic that no longer shipped. It now imports the real module, and I added a case pinning the #1123 behaviour.

## Test plan

- `frontend/src/utils/__tests__/stellarMemo.test.js` — 21 tests, encode/decode round-trips and rejection cases
- `backend/tests/stellarMemo.test.js` — 17 tests; the fixtures are the exact wire strings the frontend encoder produces, so a drift in either direction fails CI
- `frontend/src/utils/__tests__/stellarUri.test.js` — rewritten to import the real module, 18 tests
- `tests/memoExtractor.test.js` — updated; the previous `MEMO_ID`/`MEMO_HASH` cases asserted the old reject-everything contract this issue reverses
- `npx next build` passes; eslint clean on changed files

Full suite: 5 suites fail (`auditCoverage`, `cross-tenant-access`, `dispute`, `e2e-payment-flow`, `payment`). I verified these fail identically on a clean `upstream/main` checkout — same 3 failed / 11 passed / 14 total — so they are pre-existing and not from this change.
