### PR TITLE
feat: make payment limits admin-configurable, per-asset and observable

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -59,7 +59,6 @@ function wrapStellarError(err) {
 // ====================== PAYMENT INSTRUCTIONS ======================
 async function getPaymentInstructions(req, res, next) {
   try {
-    const limits = getPaymentLimits();
     const targetCurrency = req.school.localCurrency || 'USD';
     const { feeCategory, asset } = req.query;
 
@@ -70,6 +69,12 @@ async function getPaymentInstructions(req, res, next) {
         return res.status(400).json({ error: `Asset ${assetCode} is not accepted by this school`, code: 'ASSET_NOT_ACCEPTED', supportedAssets });
       }
     }
+
+    // Resolved after the asset is known so per-asset limits apply (#1117).
+    const limits = await getPaymentLimits({
+      schoolId: req.schoolId,
+      asset: asset ? asset.split(':')[0] : undefined,
+    });
 
     const student = await Student.findOne({ schoolId: req.schoolId, studentId: req.params.studentId });
 
@@ -132,7 +137,7 @@ async function createPaymentIntent(req, res, next) {
       categoryInfo = { category: fee.category, amount: fee.amount, paid: fee.paid, totalPaid: fee.totalPaid || 0, remainingBalance: fee.remainingBalance || fee.amount };
     }
 
-    const limitValidation = validatePaymentAmount(feeAmount);
+    const limitValidation = await validatePaymentAmount(feeAmount, { schoolId });
     if (!limitValidation.valid) return res.status(400).json({ error: limitValidation.error, code: limitValidation.code });
 
     const memo = crypto.randomBytes(4).toString('hex').toUpperCase();

--- a/backend/src/controllers/paymentLimitsAdminController.js
+++ b/backend/src/controllers/paymentLimitsAdminController.js
@@ -1,0 +1,139 @@
+'use strict';
+
+/**
+ * Admin management of payment limits (#1117).
+ *
+ * Limits are a fraud-prevention control, so every change is audit-logged with
+ * the before and after values. An operator tightening a ceiling mid-incident
+ * leaves the same trail as any other sensitive action, and the previous value
+ * is recoverable from the log rather than only from a deploy diff.
+ */
+
+const {
+  resolveLimits,
+  getStoredLimits,
+  setSystemLimits,
+  setSchoolLimits,
+  clearSchoolLimits,
+} = require('../services/paymentLimitsService');
+const { logAudit } = require('../services/auditService');
+const logger = require('../utils/logger').child('PaymentLimitsAdmin');
+
+const GLOBAL_SCOPE = '__global__';
+
+function actorFrom(req) {
+  return req.user?.email || req.user?.id || req.adminId || 'unknown';
+}
+
+/**
+ * GET /api/admin/payment-limits
+ * Optional ?schoolId= to include that school's override and effective values.
+ */
+async function getLimits(req, res, next) {
+  try {
+    const { schoolId, asset } = req.query;
+    const stored = await getStoredLimits(schoolId);
+    const effective = await resolveLimits({ schoolId, asset });
+
+    res.json({
+      scope: schoolId || GLOBAL_SCOPE,
+      // `source` tells the operator which layer actually supplied the value —
+      // without it, a school override silently masking a global change is
+      // indistinguishable from the change not having applied.
+      effective,
+      stored,
+    });
+  } catch (err) {
+    next(err);
+  }
+}
+
+/**
+ * PUT /api/admin/payment-limits
+ * Body: { default?: {min,max}, assets?: {CODE:{min,max}}, schoolId?: string }
+ * Omitting schoolId sets the global limits.
+ */
+async function updateLimits(req, res, next) {
+  const { schoolId, ...doc } = req.body || {};
+  const actor = actorFrom(req);
+
+  try {
+    const before = await getStoredLimits(schoolId);
+    const stored = schoolId
+      ? await setSchoolLimits(schoolId, doc)
+      : await setSystemLimits(doc);
+
+    await logAudit({
+      schoolId: schoolId || GLOBAL_SCOPE,
+      action: 'PAYMENT_LIMITS_UPDATED',
+      performedBy: actor,
+      targetId: schoolId || GLOBAL_SCOPE,
+      targetType: 'PaymentLimits',
+      details: {
+        scope: schoolId ? 'school' : 'global',
+        before: schoolId ? before.school : before.system,
+        after: stored,
+      },
+      severity: 'high',
+      ipAddress: req.ip || null,
+      userAgent: req.get?.('user-agent') || null,
+    });
+
+    logger.info('Payment limits updated', { scope: schoolId || GLOBAL_SCOPE, actor });
+    res.json({ scope: schoolId || GLOBAL_SCOPE, stored });
+  } catch (err) {
+    if (err.code === 'INVALID_PAYMENT_LIMITS') {
+      // Log rejected attempts too — a series of malformed writes against a
+      // security control is itself worth seeing in the audit trail.
+      await logAudit({
+        schoolId: schoolId || GLOBAL_SCOPE,
+        action: 'PAYMENT_LIMITS_UPDATE_REJECTED',
+        performedBy: actor,
+        targetId: schoolId || GLOBAL_SCOPE,
+        targetType: 'PaymentLimits',
+        details: { attempted: doc },
+        result: 'failure',
+        errorMessage: err.message,
+        ipAddress: req.ip || null,
+      });
+      return res.status(400).json({ error: err.message, code: err.code });
+    }
+    if (err.code === 'NOT_FOUND') {
+      return res.status(404).json({ error: err.message, code: 'NOT_FOUND' });
+    }
+    next(err);
+  }
+}
+
+/**
+ * DELETE /api/admin/payment-limits/:schoolId
+ * Removes a school override so it falls back to the global limits.
+ */
+async function deleteSchoolLimits(req, res, next) {
+  const { schoolId } = req.params;
+  try {
+    const before = await getStoredLimits(schoolId);
+    await clearSchoolLimits(schoolId);
+
+    await logAudit({
+      schoolId,
+      action: 'PAYMENT_LIMITS_CLEARED',
+      performedBy: actorFrom(req),
+      targetId: schoolId,
+      targetType: 'PaymentLimits',
+      details: { before: before.school },
+      severity: 'high',
+      ipAddress: req.ip || null,
+      userAgent: req.get?.('user-agent') || null,
+    });
+
+    res.json({ scope: schoolId, cleared: true });
+  } catch (err) {
+    if (err.code === 'NOT_FOUND') {
+      return res.status(404).json({ error: err.message, code: 'NOT_FOUND' });
+    }
+    next(err);
+  }
+}
+
+module.exports = { getLimits, updateLimits, deleteSchoolLimits };

--- a/backend/src/controllers/paymentQueryController.js
+++ b/backend/src/controllers/paymentQueryController.js
@@ -44,7 +44,7 @@ async function getAcceptedAssets(req, res, next) {
 
 async function getPaymentLimitsEndpoint(req, res, next) {
   try {
-    const limits = getPaymentLimits();
+    const limits = await getPaymentLimits({ schoolId: req.schoolId });
     res.json({
       min: limits.min,
       max: limits.max,

--- a/backend/src/metrics/index.js
+++ b/backend/src/metrics/index.js
@@ -189,6 +189,18 @@ const suspiciousPaymentFlagged = new client.Counter({
   registers: [registry],
 });
 
+// Payment limit rejections (#1117). Without this there is no signal telling
+// operators that the configured limits are being hit often enough to warrant
+// adjusting — the limits were previously a control nobody could observe.
+// `code` distinguishes AMOUNT_TOO_LOW from AMOUNT_TOO_HIGH: a spike in the
+// latter is the fraud/misconfiguration signal worth alerting on.
+const paymentLimitTriggeredTotal = new client.Counter({
+  name: 'payment_limit_triggered_total',
+  help: 'Number of payments rejected by the configured payment limits',
+  labelNames: ['school_id', 'asset', 'code'],
+  registers: [registry],
+});
+
 // Concurrent payment batch metrics — recorded by the concurrentPaymentProcessor
 // after each processBatch() call so batch throughput and per-item outcomes are
 // observable and alertable.
@@ -315,6 +327,7 @@ module.exports = {
   syncDurationSeconds,
   httpRequestDurationSeconds,
   suspiciousPaymentFlagged,
+  paymentLimitTriggeredTotal,
   paymentBatchTotal,
   paymentBatchItemsTotal,
   paymentBatchDurationSeconds,

--- a/backend/src/routes/adminRoutes.js
+++ b/backend/src/routes/adminRoutes.js
@@ -10,6 +10,11 @@ const {
   getDeadLetterVerification,
   retryDeadLetterVerification,
 } = require('../controllers/pendingVerificationAdminController');
+const {
+  getLimits,
+  updateLimits,
+  deleteSchoolLimits,
+} = require('../controllers/paymentLimitsAdminController');
 const { requireAdminAuth } = require('../middleware/auth');
 const { auditContext } = require('../middleware/auditContext');
 
@@ -27,5 +32,11 @@ router.get('/pending-verifications/backlog', requireAdminAuth, getBacklog);
 router.get('/pending-verifications/dead-letter', requireAdminAuth, listDeadLetterVerifications);
 router.get('/pending-verifications/:id', requireAdminAuth, getDeadLetterVerification);
 router.post('/pending-verifications/:id/retry', requireAdminAuth, auditContext, retryDeadLetterVerification);
+
+// Payment limits — runtime-configurable fraud control (#1117). Every mutation
+// is audit-logged by the controller.
+router.get('/payment-limits', requireAdminAuth, getLimits);
+router.put('/payment-limits', requireAdminAuth, auditContext, updateLimits);
+router.delete('/payment-limits/:schoolId', requireAdminAuth, auditContext, deleteSchoolLimits);
 
 module.exports = router;

--- a/backend/src/services/paymentLimitsService.js
+++ b/backend/src/services/paymentLimitsService.js
@@ -1,0 +1,337 @@
+'use strict';
+
+/**
+ * Payment limits resolution (#1117).
+ *
+ * Limits are a fraud-prevention control, so they need to be tunable while an
+ * incident is in progress — not on the next deploy. They now resolve from the
+ * database with the environment variables as a fallback, and an admin can
+ * change them at runtime through /api/admin/payment-limits.
+ *
+ * Resolution order, most specific first:
+ *
+ *   1. School.settings.paymentLimits.assets[ASSET]   per-school, per-asset
+ *   2. School.settings.paymentLimits.default         per-school
+ *   3. SystemConfig 'paymentLimits'.assets[ASSET]    global, per-asset
+ *   4. SystemConfig 'paymentLimits'.default          global
+ *   5. MIN_PAYMENT_AMOUNT / MAX_PAYMENT_AMOUNT       env, the pre-#1117 behaviour
+ *
+ * Falling through to the env values means a deployment that never touches the
+ * admin API behaves exactly as it did before this change.
+ *
+ * Per-asset matters because XLM and USDC occupy very different value ranges: a
+ * ceiling that is sane for XLM is absurd for USDC and vice versa. A deployment
+ * accepts one asset at a time today (see ACCEPTED_ASSETS), so the asset key is
+ * mostly future-proofing — but storing limits without it would bake the same
+ * conflation back into the config model that this issue is about.
+ *
+ * CACHING — resolution sits in the payment hot path, so results are cached in
+ * process for CACHE_TTL_MS. Writes through this module invalidate immediately,
+ * so the instance serving the admin request is correct at once; other instances
+ * converge within the TTL. That bounded staleness is the cost of not doing a
+ * database read per payment, and it is still a different order of magnitude
+ * from requiring a redeploy.
+ */
+
+const Decimal = require('decimal.js');
+const School = require('../models/schoolModel');
+const SystemConfig = require('../models/systemConfigModel');
+const { MIN_PAYMENT_AMOUNT, MAX_PAYMENT_AMOUNT } = require('../config');
+const logger = require('../utils/logger').child('PaymentLimits');
+
+const CONFIG_KEY = 'paymentLimits';
+const CACHE_TTL_MS = parseInt(process.env.PAYMENT_LIMITS_CACHE_TTL_MS || '30000', 10);
+const DEFAULT_ASSET = 'XLM';
+
+// Resolution sits in the payment verification path, so the database read must
+// be bounded. Mongoose *buffers* commands while disconnected rather than
+// rejecting them, so without this a brief database outage would hang payment
+// verification instead of falling back to the env limits.
+const READ_TIMEOUT_MS = parseInt(process.env.PAYMENT_LIMITS_READ_TIMEOUT_MS || '2000', 10);
+
+class LimitsReadTimeout extends Error {
+  constructor() {
+    super(`Payment limits read exceeded ${READ_TIMEOUT_MS}ms`);
+    this.name = 'LimitsReadTimeout';
+  }
+}
+
+function _withTimeout(promise) {
+  let timer;
+  const timeout = new Promise((_resolve, reject) => {
+    timer = setTimeout(() => reject(new LimitsReadTimeout()), READ_TIMEOUT_MS);
+    // Do not hold the event loop open on this timer.
+    if (typeof timer.unref === 'function') timer.unref();
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/** @type {Map<string, {value: object, expiresAt: number}>} */
+const _cache = new Map();
+
+const ENV_LIMITS = Object.freeze({
+  min: MIN_PAYMENT_AMOUNT,
+  max: MAX_PAYMENT_AMOUNT,
+  source: 'env',
+});
+
+function _now() {
+  return Date.now();
+}
+
+function _cacheKey(schoolId) {
+  return schoolId || '__global__';
+}
+
+function _readCache(schoolId) {
+  const hit = _cache.get(_cacheKey(schoolId));
+  if (!hit || hit.expiresAt <= _now()) return null;
+  return hit.value;
+}
+
+function _writeCache(schoolId, value) {
+  _cache.set(_cacheKey(schoolId), { value, expiresAt: _now() + CACHE_TTL_MS });
+}
+
+/**
+ * Drop cached limits. Called after every write so the writing instance never
+ * serves the value it just replaced.
+ *
+ * @param {string} [schoolId] - Omit to clear every entry.
+ */
+function invalidateCache(schoolId) {
+  if (schoolId === undefined) _cache.clear();
+  else _cache.delete(_cacheKey(schoolId));
+}
+
+/**
+ * Validate a { min, max } pair before it is stored or trusted.
+ * Rejects the same conditions config/index.js enforces for the env values, so
+ * a bad admin write cannot put the system in a state a fresh boot would refuse.
+ *
+ * @param {object} limits
+ * @returns {{valid: boolean, error?: string}}
+ */
+function validateLimitPair(limits) {
+  if (!limits || typeof limits !== 'object') {
+    return { valid: false, error: 'Limits must be an object with min and max' };
+  }
+  const { min, max } = limits;
+  for (const [name, value] of [['min', min], ['max', max]]) {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return { valid: false, error: `${name} must be a finite number` };
+    }
+  }
+  if (min < 0) return { valid: false, error: 'min must not be negative' };
+  if (max <= min) return { valid: false, error: 'max must be greater than min' };
+  return { valid: true };
+}
+
+/**
+ * Validate a full limits document ({ default, assets }) before storing it.
+ *
+ * @param {object} doc
+ * @returns {{valid: boolean, error?: string}}
+ */
+function validateLimitsDocument(doc) {
+  if (!doc || typeof doc !== 'object') {
+    return { valid: false, error: 'Payment limits must be an object' };
+  }
+  if (doc.default !== undefined) {
+    const check = validateLimitPair(doc.default);
+    if (!check.valid) return { valid: false, error: `default: ${check.error}` };
+  }
+  if (doc.assets !== undefined) {
+    if (typeof doc.assets !== 'object' || doc.assets === null || Array.isArray(doc.assets)) {
+      return { valid: false, error: 'assets must be an object keyed by asset code' };
+    }
+    for (const [code, pair] of Object.entries(doc.assets)) {
+      const check = validateLimitPair(pair);
+      if (!check.valid) return { valid: false, error: `assets.${code}: ${check.error}` };
+    }
+  }
+  if (doc.default === undefined && doc.assets === undefined) {
+    return { valid: false, error: 'Provide at least one of default or assets' };
+  }
+  return { valid: true };
+}
+
+function _pick(doc, asset, source) {
+  if (!doc || typeof doc !== 'object') return null;
+
+  const assetKey = asset ? String(asset).toUpperCase() : null;
+  if (assetKey && doc.assets && doc.assets[assetKey]) {
+    const pair = doc.assets[assetKey];
+    if (validateLimitPair(pair).valid) {
+      return { min: pair.min, max: pair.max, source: `${source}:asset:${assetKey}` };
+    }
+    logger.warn('Stored per-asset payment limits are invalid; ignoring', { source, asset: assetKey });
+  }
+
+  if (doc.default && validateLimitPair(doc.default).valid) {
+    return { min: doc.default.min, max: doc.default.max, source: `${source}:default` };
+  }
+  if (doc.default) {
+    logger.warn('Stored default payment limits are invalid; ignoring', { source });
+  }
+  return null;
+}
+
+/**
+ * Resolve the effective limits for a school and asset.
+ *
+ * Never throws: a database failure falls back to the env limits rather than
+ * failing open. Losing the ability to read a tightened limit must not turn into
+ * accepting an unbounded payment.
+ *
+ * @param {object} [opts]
+ * @param {string} [opts.schoolId]
+ * @param {string} [opts.asset] - Asset code, e.g. 'XLM'
+ * @returns {Promise<{min: number, max: number, source: string}>}
+ */
+async function resolveLimits({ schoolId, asset } = {}) {
+  const assetKey = (asset || DEFAULT_ASSET).toUpperCase();
+  const cached = _readCache(schoolId);
+  if (cached) {
+    return _pick(cached.school, assetKey, 'school')
+      || _pick(cached.system, assetKey, 'system')
+      || ENV_LIMITS;
+  }
+
+  let schoolDoc = null;
+  let systemDoc = null;
+
+  try {
+    if (schoolId) {
+      const school = await _withTimeout(School.findOne({ schoolId }, { settings: 1 }).lean());
+      schoolDoc = school?.settings?.paymentLimits || null;
+    }
+    systemDoc = await _withTimeout(SystemConfig.get(CONFIG_KEY));
+  } catch (err) {
+    // Fail closed onto the env limits — see the note above. A timeout lands
+    // here too, so a slow or disconnected database degrades to the previous
+    // behaviour instead of stalling payment verification.
+    logger.error('Failed to load payment limits; falling back to env values', {
+      err: err.message,
+      schoolId,
+    });
+    return ENV_LIMITS;
+  }
+
+  _writeCache(schoolId, { school: schoolDoc, system: systemDoc });
+
+  return _pick(schoolDoc, assetKey, 'school')
+    || _pick(systemDoc, assetKey, 'system')
+    || ENV_LIMITS;
+}
+
+/**
+ * Read the stored limits documents without applying resolution, for the admin
+ * UI — an operator needs to see which layer a value actually comes from.
+ *
+ * @param {string} [schoolId]
+ * @returns {Promise<{system: object|null, school: object|null, env: object}>}
+ */
+async function getStoredLimits(schoolId) {
+  const system = await SystemConfig.get(CONFIG_KEY);
+  let school = null;
+  if (schoolId) {
+    const doc = await School.findOne({ schoolId }, { settings: 1 }).lean();
+    school = doc?.settings?.paymentLimits || null;
+  }
+  return { system: system || null, school, env: { ...ENV_LIMITS } };
+}
+
+/**
+ * Replace the global limits document.
+ *
+ * @param {object} doc - { default?: {min,max}, assets?: {CODE: {min,max}} }
+ * @returns {Promise<object>} The stored document
+ */
+async function setSystemLimits(doc) {
+  const check = validateLimitsDocument(doc);
+  if (!check.valid) {
+    throw Object.assign(new Error(check.error), { code: 'INVALID_PAYMENT_LIMITS' });
+  }
+  await SystemConfig.set(CONFIG_KEY, doc);
+  // Global change affects every school's resolution, so drop the whole cache.
+  invalidateCache();
+  return doc;
+}
+
+/**
+ * Replace one school's limits document.
+ *
+ * @param {string} schoolId
+ * @param {object} doc
+ * @returns {Promise<object>} The stored document
+ */
+async function setSchoolLimits(schoolId, doc) {
+  const check = validateLimitsDocument(doc);
+  if (!check.valid) {
+    throw Object.assign(new Error(check.error), { code: 'INVALID_PAYMENT_LIMITS' });
+  }
+  const updated = await School.findOneAndUpdate(
+    { schoolId },
+    { $set: { 'settings.paymentLimits': doc } },
+    { new: true },
+  ).lean();
+  if (!updated) {
+    throw Object.assign(new Error(`School ${schoolId} not found`), { code: 'NOT_FOUND' });
+  }
+  invalidateCache(schoolId);
+  return doc;
+}
+
+/**
+ * Remove a school's override so it falls back to the global limits.
+ *
+ * @param {string} schoolId
+ */
+async function clearSchoolLimits(schoolId) {
+  const updated = await School.findOneAndUpdate(
+    { schoolId },
+    { $unset: { 'settings.paymentLimits': '' } },
+    { new: true },
+  ).lean();
+  if (!updated) {
+    throw Object.assign(new Error(`School ${schoolId} not found`), { code: 'NOT_FOUND' });
+  }
+  invalidateCache(schoolId);
+}
+
+/**
+ * Compare an amount against resolved limits using Decimal, per the rounding
+ * policy in utils/paymentLimits.js.
+ *
+ * @param {number} amount
+ * @param {{min: number, max: number}} limits
+ * @returns {{valid: boolean, error?: string, code?: string}}
+ */
+function compareAgainstLimits(amount, limits) {
+  const d = new Decimal(typeof amount === 'number' && isFinite(amount) ? amount : NaN);
+  if (!d.isFinite() || d.lte(0)) {
+    return { valid: false, error: 'Payment amount must be a valid positive number', code: 'INVALID_AMOUNT' };
+  }
+  if (d.lt(new Decimal(limits.min))) {
+    return { valid: false, error: `Payment amount ${amount} is below the minimum of ${limits.min}`, code: 'AMOUNT_TOO_LOW' };
+  }
+  if (d.gt(new Decimal(limits.max))) {
+    return { valid: false, error: `Payment amount ${amount} exceeds the maximum of ${limits.max}`, code: 'AMOUNT_TOO_HIGH' };
+  }
+  return { valid: true };
+}
+
+module.exports = {
+  CONFIG_KEY,
+  resolveLimits,
+  getStoredLimits,
+  setSystemLimits,
+  setSchoolLimits,
+  clearSchoolLimits,
+  invalidateCache,
+  validateLimitPair,
+  validateLimitsDocument,
+  compareAgainstLimits,
+  _ENV_LIMITS: ENV_LIMITS,
+};

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -501,7 +501,10 @@ async function verifyTransaction(txHash, walletAddress, schoolId = null) {
   const amount = normalizeAmount(payOp.amount);
 
   // 5. Validate payment amount is within configured limits
-  const limitValidation = validatePaymentAmount(amount);
+  const limitValidation = await validatePaymentAmount(amount, {
+    schoolId,
+    asset: asset?.code,
+  });
   if (!limitValidation.valid) {
     const err = new Error(limitValidation.error);
     err.code = limitValidation.code;
@@ -616,7 +619,8 @@ async function syncPaymentsForSchool(school) {
         continue;
       }
 
-      const { payOp, memo } = valid;
+      // `asset` is destructured for the per-asset limit lookup (#1117).
+      const { payOp, memo, asset } = valid;
 
       // Explicit destination check — defence-in-depth beyond extractValidPayment
       if (payOp.to !== stellarAddress) {
@@ -645,7 +649,10 @@ async function syncPaymentsForSchool(school) {
 
       const paymentAmount = parseFloat(payOp.amount);
 
-      const limitValidation = validatePaymentAmount(paymentAmount);
+      const limitValidation = await validatePaymentAmount(paymentAmount, {
+        schoolId,
+        asset: asset?.code,
+      });
       if (!limitValidation.valid) {
         summary.failed++;
         summary.failedDetails.push({ txHash: tx.hash, reason: limitValidation.code });

--- a/backend/src/services/transactionPollingService.js
+++ b/backend/src/services/transactionPollingService.js
@@ -95,7 +95,10 @@ async function processTransaction(tx, school, fencingToken) {
   const paymentAmount = normalizeToNumber(payOp.amount);
 
   // Validate payment amount is within configured limits
-  const limitValidation = validatePaymentAmount(paymentAmount);
+  const limitValidation = await validatePaymentAmount(paymentAmount, {
+    schoolId,
+    asset: asset?.code,
+  });
   if (!limitValidation.valid) {
     logger.warn('Payment outside limits', {
       txHash: tx.hash,

--- a/backend/src/utils/paymentLimits.js
+++ b/backend/src/utils/paymentLimits.js
@@ -10,23 +10,55 @@
  *
  * Rule: never use raw JS Number arithmetic on monetary values. Use Decimal for
  * all comparisons and arithmetic; convert to Number only at output boundaries.
+ *
+ * LIMIT SOURCE (Issue #1117)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Limits used to be read once from MIN_PAYMENT_AMOUNT / MAX_PAYMENT_AMOUNT at
+ * module load, so changing them meant a redeploy. They now resolve per call via
+ * paymentLimitsService, which reads database-backed values and falls back to
+ * those same env vars — a deployment that never uses the admin API keeps its
+ * existing behaviour exactly.
+ *
+ * This made validatePaymentAmount async. Every caller was already inside an
+ * async function, so the change is an added `await` at each site.
  */
 
 const Decimal = require('decimal.js');
-const { MIN_PAYMENT_AMOUNT, MAX_PAYMENT_AMOUNT } = require('../config');
+const {
+  resolveLimits,
+  compareAgainstLimits,
+} = require('../services/paymentLimitsService');
+const { paymentLimitTriggeredTotal } = require('../metrics');
+const logger = require('./logger').child('PaymentLimits');
 
-const D_MIN = new Decimal(MIN_PAYMENT_AMOUNT);
-const D_MAX = new Decimal(MAX_PAYMENT_AMOUNT);
+/**
+ * Validate an amount against the effective limits for a school and asset.
+ *
+ * @param {number} amount
+ * @param {object} [context]
+ * @param {string} [context.schoolId] - Scopes to a school's override
+ * @param {string} [context.asset]    - Asset code, e.g. 'XLM'
+ * @returns {Promise<{valid: boolean, error?: string, code?: string}>}
+ */
+async function validatePaymentAmount(amount, { schoolId, asset } = {}) {
+  const limits = await resolveLimits({ schoolId, asset });
+  const result = compareAgainstLimits(amount, limits);
 
-function validatePaymentAmount(amount) {
-  const d = new Decimal(typeof amount === 'number' && isFinite(amount) ? amount : NaN);
-  if (!d.isFinite() || d.lte(0))
-    return { valid: false, error: 'Payment amount must be a valid positive number', code: 'INVALID_AMOUNT' };
-  if (d.lt(D_MIN))
-    return { valid: false, error: `Payment amount ${amount} is below the minimum of ${MIN_PAYMENT_AMOUNT}`, code: 'AMOUNT_TOO_LOW' };
-  if (d.gt(D_MAX))
-    return { valid: false, error: `Payment amount ${amount} exceeds the maximum of ${MAX_PAYMENT_AMOUNT}`, code: 'AMOUNT_TOO_HIGH' };
-  return { valid: true };
+  if (!result.valid) {
+    try {
+      paymentLimitTriggeredTotal.inc({
+        school_id: schoolId || 'unknown',
+        asset: (asset || 'XLM').toUpperCase(),
+        code: result.code,
+      });
+    } catch (err) {
+      // Never let a metrics failure reject a payment that the limits allow, or
+      // vice versa — observability is not in the correctness path.
+      logger.warn('Failed to record payment limit metric', { err: err.message });
+    }
+  }
+
+  return result;
 }
 
 function validatePaymentAmountAgainstFee(paymentAmount, feeAmount, maxPaymentMultiplier = 3.0) {
@@ -44,8 +76,17 @@ function validatePaymentAmountAgainstFee(paymentAmount, feeAmount, maxPaymentMul
   return { valid: true };
 }
 
-function getPaymentLimits() {
-  return { min: MIN_PAYMENT_AMOUNT, max: MAX_PAYMENT_AMOUNT };
+/**
+ * The effective limits, for display in payment instructions.
+ *
+ * @param {object} [context]
+ * @param {string} [context.schoolId]
+ * @param {string} [context.asset]
+ * @returns {Promise<{min: number, max: number}>}
+ */
+async function getPaymentLimits({ schoolId, asset } = {}) {
+  const { min, max } = await resolveLimits({ schoolId, asset });
+  return { min, max };
 }
 
 module.exports = { validatePaymentAmount, validatePaymentAmountAgainstFee, getPaymentLimits };

--- a/backend/tests/paymentLimitsAdmin.test.js
+++ b/backend/tests/paymentLimitsAdmin.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+/**
+ * Tests for the payment limits admin endpoints (#1117).
+ *
+ * The audit-log assertions are the point: limits are a fraud control, and the
+ * acceptance criteria require every change to be attributable. A change that
+ * lands without an audit entry is the failure mode worth guarding.
+ */
+
+jest.mock('../src/services/paymentLimitsService', () => ({
+  resolveLimits: jest.fn(),
+  getStoredLimits: jest.fn(),
+  setSystemLimits: jest.fn(),
+  setSchoolLimits: jest.fn(),
+  clearSchoolLimits: jest.fn(),
+}));
+jest.mock('../src/services/auditService', () => ({ logAudit: jest.fn() }));
+
+const svc = require('../src/services/paymentLimitsService');
+const { logAudit } = require('../src/services/auditService');
+const { getLimits, updateLimits, deleteSchoolLimits } = require('../src/controllers/paymentLimitsAdminController');
+
+function mockRes() {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.json = jest.fn(() => res);
+  return res;
+}
+
+function mockReq(overrides = {}) {
+  return {
+    query: {}, body: {}, params: {},
+    user: { email: 'admin@school.test' },
+    ip: '203.0.113.7',
+    get: () => 'jest',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  svc.getStoredLimits.mockResolvedValue({ system: null, school: null, env: { min: 0.01, max: 100000 } });
+  svc.resolveLimits.mockResolvedValue({ min: 0.01, max: 100000, source: 'env' });
+});
+
+describe('GET /api/admin/payment-limits', () => {
+  test('returns effective limits with the layer that supplied them', async () => {
+    svc.resolveLimits.mockResolvedValue({ min: 1, max: 500, source: 'system:default' });
+    const res = mockRes();
+    await getLimits(mockReq(), res, jest.fn());
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.effective).toMatchObject({ min: 1, max: 500, source: 'system:default' });
+    expect(body.scope).toBe('__global__');
+  });
+
+  test('scopes to a school when schoolId is supplied', async () => {
+    const res = mockRes();
+    await getLimits(mockReq({ query: { schoolId: 'SCH001', asset: 'USDC' } }), res, jest.fn());
+
+    expect(svc.resolveLimits).toHaveBeenCalledWith({ schoolId: 'SCH001', asset: 'USDC' });
+    expect(res.json.mock.calls[0][0].scope).toBe('SCH001');
+  });
+});
+
+describe('PUT /api/admin/payment-limits', () => {
+  test('updates global limits without a redeployment', async () => {
+    const doc = { default: { min: 1, max: 500 } };
+    svc.setSystemLimits.mockResolvedValue(doc);
+
+    const res = mockRes();
+    await updateLimits(mockReq({ body: doc }), res, jest.fn());
+
+    expect(svc.setSystemLimits).toHaveBeenCalledWith(doc);
+    expect(res.json).toHaveBeenCalledWith({ scope: '__global__', stored: doc });
+  });
+
+  test('audit-logs the change with before and after values', async () => {
+    svc.getStoredLimits.mockResolvedValue({
+      system: { default: { min: 0.01, max: 100000 } }, school: null, env: {},
+    });
+    const after = { default: { min: 1, max: 500 } };
+    svc.setSystemLimits.mockResolvedValue(after);
+
+    await updateLimits(mockReq({ body: after }), mockRes(), jest.fn());
+
+    expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'PAYMENT_LIMITS_UPDATED',
+      performedBy: 'admin@school.test',
+      targetType: 'PaymentLimits',
+      severity: 'high',
+      ipAddress: '203.0.113.7',
+      details: expect.objectContaining({
+        scope: 'global',
+        before: { default: { min: 0.01, max: 100000 } },
+        after,
+      }),
+    }));
+  });
+
+  test('routes a school-scoped update to the school write path', async () => {
+    const doc = { default: { min: 2, max: 50 } };
+    svc.setSchoolLimits.mockResolvedValue(doc);
+
+    const res = mockRes();
+    await updateLimits(mockReq({ body: { schoolId: 'SCH001', ...doc } }), res, jest.fn());
+
+    expect(svc.setSchoolLimits).toHaveBeenCalledWith('SCH001', doc);
+    expect(svc.setSystemLimits).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].scope).toBe('SCH001');
+  });
+
+  test('rejects an invalid document with 400 and audits the attempt', async () => {
+    svc.setSystemLimits.mockRejectedValue(
+      Object.assign(new Error('default: max must be greater than min'), { code: 'INVALID_PAYMENT_LIMITS' }),
+    );
+
+    const res = mockRes();
+    await updateLimits(mockReq({ body: { default: { min: 10, max: 1 } } }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    // A run of malformed writes against a security control is itself a signal.
+    expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'PAYMENT_LIMITS_UPDATE_REJECTED',
+      result: 'failure',
+    }));
+  });
+
+  test('returns 404 for an unknown school', async () => {
+    svc.setSchoolLimits.mockRejectedValue(
+      Object.assign(new Error('School NOPE not found'), { code: 'NOT_FOUND' }),
+    );
+
+    const res = mockRes();
+    await updateLimits(mockReq({ body: { schoolId: 'NOPE', default: { min: 1, max: 2 } } }), res, jest.fn());
+
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  test('passes unexpected errors to the error handler rather than swallowing them', async () => {
+    svc.setSystemLimits.mockRejectedValue(new Error('mongo down'));
+    const next = jest.fn();
+    await updateLimits(mockReq({ body: { default: { min: 1, max: 2 } } }), mockRes(), next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ message: 'mongo down' }));
+  });
+});
+
+describe('DELETE /api/admin/payment-limits/:schoolId', () => {
+  test('clears the override and audit-logs the previous value', async () => {
+    svc.getStoredLimits.mockResolvedValue({
+      system: null, school: { default: { min: 2, max: 50 } }, env: {},
+    });
+
+    const res = mockRes();
+    await deleteSchoolLimits(mockReq({ params: { schoolId: 'SCH001' } }), res, jest.fn());
+
+    expect(svc.clearSchoolLimits).toHaveBeenCalledWith('SCH001');
+    expect(logAudit).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'PAYMENT_LIMITS_CLEARED',
+      details: { before: { default: { min: 2, max: 50 } } },
+    }));
+    expect(res.json).toHaveBeenCalledWith({ scope: 'SCH001', cleared: true });
+  });
+});

--- a/backend/tests/paymentLimitsMetric.test.js
+++ b/backend/tests/paymentLimitsMetric.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+/**
+ * Tests that rejected payments increment payment_limit_triggered_total (#1117).
+ *
+ * The metric is the only signal telling operators the configured limits are
+ * being hit; if it silently stops incrementing, the alerting built on it goes
+ * quiet without anything failing.
+ */
+
+jest.mock('../src/services/paymentLimitsService', () => ({
+  resolveLimits: jest.fn(),
+  compareAgainstLimits: jest.requireActual('../src/services/paymentLimitsService').compareAgainstLimits,
+}));
+jest.mock('../src/config', () => ({ MIN_PAYMENT_AMOUNT: 0.01, MAX_PAYMENT_AMOUNT: 100000 }));
+
+const { resolveLimits } = require('../src/services/paymentLimitsService');
+const { validatePaymentAmount } = require('../src/utils/paymentLimits');
+const { paymentLimitTriggeredTotal, registry } = require('../src/metrics');
+
+async function counterValue(labels) {
+  const metric = await registry.getSingleMetricAsString('payment_limit_triggered_total');
+  const pattern = new RegExp(
+    `payment_limit_triggered_total\\{school_id="${labels.school_id}",asset="${labels.asset}",code="${labels.code}"\\} (\\d+)`,
+  );
+  const match = metric.match(pattern);
+  return match ? Number(match[1]) : 0;
+}
+
+beforeEach(() => {
+  paymentLimitTriggeredTotal.reset();
+  resolveLimits.mockResolvedValue({ min: 1, max: 100, source: 'system:default' });
+});
+
+describe('validatePaymentAmount metric', () => {
+  test('does not increment for an accepted amount', async () => {
+    const result = await validatePaymentAmount(50, { schoolId: 'SCH001', asset: 'XLM' });
+    expect(result.valid).toBe(true);
+    expect(await counterValue({ school_id: 'SCH001', asset: 'XLM', code: 'AMOUNT_TOO_HIGH' })).toBe(0);
+  });
+
+  test('increments with the rejection code for an over-limit amount', async () => {
+    const result = await validatePaymentAmount(500, { schoolId: 'SCH001', asset: 'XLM' });
+    expect(result.code).toBe('AMOUNT_TOO_HIGH');
+    expect(await counterValue({ school_id: 'SCH001', asset: 'XLM', code: 'AMOUNT_TOO_HIGH' })).toBe(1);
+  });
+
+  test('distinguishes AMOUNT_TOO_LOW from AMOUNT_TOO_HIGH', async () => {
+    await validatePaymentAmount(0.5, { schoolId: 'SCH001', asset: 'XLM' });
+    expect(await counterValue({ school_id: 'SCH001', asset: 'XLM', code: 'AMOUNT_TOO_LOW' })).toBe(1);
+    expect(await counterValue({ school_id: 'SCH001', asset: 'XLM', code: 'AMOUNT_TOO_HIGH' })).toBe(0);
+  });
+
+  test('labels rejections by school and asset so alerts can scope to one school', async () => {
+    await validatePaymentAmount(500, { schoolId: 'SCH001', asset: 'XLM' });
+    await validatePaymentAmount(500, { schoolId: 'SCH002', asset: 'USDC' });
+    expect(await counterValue({ school_id: 'SCH001', asset: 'XLM', code: 'AMOUNT_TOO_HIGH' })).toBe(1);
+    expect(await counterValue({ school_id: 'SCH002', asset: 'USDC', code: 'AMOUNT_TOO_HIGH' })).toBe(1);
+  });
+
+  test('falls back to placeholder labels when context is absent', async () => {
+    await validatePaymentAmount(500);
+    expect(await counterValue({ school_id: 'unknown', asset: 'XLM', code: 'AMOUNT_TOO_HIGH' })).toBe(1);
+  });
+
+  test('passes the school and asset through to limit resolution', async () => {
+    await validatePaymentAmount(50, { schoolId: 'SCH001', asset: 'USDC' });
+    expect(resolveLimits).toHaveBeenCalledWith({ schoolId: 'SCH001', asset: 'USDC' });
+  });
+});

--- a/backend/tests/paymentLimitsService.test.js
+++ b/backend/tests/paymentLimitsService.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+/**
+ * Tests for paymentLimitsService (#1117) — DB-backed, admin-configurable,
+ * per-asset payment limits.
+ *
+ * School and SystemConfig are mocked so these stay unit tests; the resolution
+ * order and the fallback-to-env behaviour are the parts worth pinning, since a
+ * regression there either loosens a fraud control silently or breaks payments
+ * for every deployment that never touches the admin API.
+ */
+
+jest.mock('../src/models/schoolModel', () => ({ findOne: jest.fn(), findOneAndUpdate: jest.fn() }));
+jest.mock('../src/models/systemConfigModel', () => ({ get: jest.fn(), set: jest.fn() }));
+jest.mock('../src/config', () => ({ MIN_PAYMENT_AMOUNT: 0.01, MAX_PAYMENT_AMOUNT: 100000 }));
+
+const School = require('../src/models/schoolModel');
+const SystemConfig = require('../src/models/systemConfigModel');
+const svc = require('../src/services/paymentLimitsService');
+
+const lean = (value) => ({ lean: () => Promise.resolve(value) });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  svc.invalidateCache();
+  School.findOne.mockReturnValue(lean(null));
+  SystemConfig.get.mockResolvedValue(null);
+});
+
+describe('resolveLimits — resolution order', () => {
+  test('falls back to env limits when nothing is stored', async () => {
+    const limits = await svc.resolveLimits({ schoolId: 'SCH001' });
+    expect(limits).toEqual({ min: 0.01, max: 100000, source: 'env' });
+  });
+
+  test('global default overrides env', async () => {
+    SystemConfig.get.mockResolvedValue({ default: { min: 1, max: 500 } });
+    const limits = await svc.resolveLimits({ schoolId: 'SCH001' });
+    expect(limits).toMatchObject({ min: 1, max: 500, source: 'system:default' });
+  });
+
+  test('global per-asset overrides global default', async () => {
+    SystemConfig.get.mockResolvedValue({
+      default: { min: 1, max: 500 },
+      assets: { USDC: { min: 5, max: 20000 } },
+    });
+    expect(await svc.resolveLimits({ asset: 'USDC' })).toMatchObject({
+      min: 5, max: 20000, source: 'system:asset:USDC',
+    });
+    // An asset with no specific entry still gets the default.
+    svc.invalidateCache();
+    expect(await svc.resolveLimits({ asset: 'XLM' })).toMatchObject({
+      min: 1, max: 500, source: 'system:default',
+    });
+  });
+
+  test('school default overrides global', async () => {
+    SystemConfig.get.mockResolvedValue({ default: { min: 1, max: 500 } });
+    School.findOne.mockReturnValue(lean({ settings: { paymentLimits: { default: { min: 2, max: 50 } } } }));
+    expect(await svc.resolveLimits({ schoolId: 'SCH001' })).toMatchObject({
+      min: 2, max: 50, source: 'school:default',
+    });
+  });
+
+  test('school per-asset is the most specific layer', async () => {
+    SystemConfig.get.mockResolvedValue({ default: { min: 1, max: 500 } });
+    School.findOne.mockReturnValue(lean({
+      settings: { paymentLimits: { default: { min: 2, max: 50 }, assets: { XLM: { min: 3, max: 30 } } } },
+    }));
+    expect(await svc.resolveLimits({ schoolId: 'SCH001', asset: 'XLM' })).toMatchObject({
+      min: 3, max: 30, source: 'school:asset:XLM',
+    });
+  });
+
+  test('asset codes resolve case-insensitively', async () => {
+    SystemConfig.get.mockResolvedValue({ assets: { USDC: { min: 5, max: 100 } } });
+    expect(await svc.resolveLimits({ asset: 'usdc' })).toMatchObject({ min: 5, max: 100 });
+  });
+
+  test('ignores a stored pair that fails validation rather than trusting it', async () => {
+    // max <= min would invert the control; the env values are the safe answer.
+    SystemConfig.get.mockResolvedValue({ default: { min: 100, max: 1 } });
+    expect(await svc.resolveLimits({})).toEqual({ min: 0.01, max: 100000, source: 'env' });
+  });
+
+  test('falls back to env when the database read hangs', async () => {
+    // Mongoose buffers commands while disconnected rather than rejecting, so a
+    // read can hang indefinitely. Resolution sits in the payment verification
+    // path — without a bound, a database blip stalls verification instead of
+    // degrading to the env limits.
+    process.env.PAYMENT_LIMITS_READ_TIMEOUT_MS = '50';
+    jest.resetModules();
+    const scoped = require('../src/services/paymentLimitsService');
+    SystemConfig.get.mockImplementation(() => new Promise(() => {})); // never settles
+
+    const started = Date.now();
+    const limits = await scoped.resolveLimits({});
+    expect(limits).toEqual({ min: 0.01, max: 100000, source: 'env' });
+    expect(Date.now() - started).toBeLessThan(2000);
+
+    delete process.env.PAYMENT_LIMITS_READ_TIMEOUT_MS;
+    jest.resetModules();
+  });
+
+  test('falls back to env when the database read throws', async () => {
+    // Losing the ability to read a tightened limit must not mean accepting an
+    // unbounded payment.
+    SystemConfig.get.mockRejectedValue(new Error('mongo down'));
+    expect(await svc.resolveLimits({ schoolId: 'SCH001' })).toEqual({
+      min: 0.01, max: 100000, source: 'env',
+    });
+  });
+});
+
+describe('resolveLimits — caching', () => {
+  test('does not re-read the database within the TTL', async () => {
+    SystemConfig.get.mockResolvedValue({ default: { min: 1, max: 500 } });
+    await svc.resolveLimits({ schoolId: 'SCH001' });
+    await svc.resolveLimits({ schoolId: 'SCH001' });
+    expect(SystemConfig.get).toHaveBeenCalledTimes(1);
+  });
+
+  test('a write invalidates the cache so the writer never serves a stale value', async () => {
+    SystemConfig.get.mockResolvedValue({ default: { min: 1, max: 500 } });
+    await svc.resolveLimits({ schoolId: 'SCH001' });
+
+    SystemConfig.set.mockResolvedValue({});
+    SystemConfig.get.mockResolvedValue({ default: { min: 9, max: 90 } });
+    await svc.setSystemLimits({ default: { min: 9, max: 90 } });
+
+    expect(await svc.resolveLimits({ schoolId: 'SCH001' })).toMatchObject({ min: 9, max: 90 });
+  });
+
+  test('a school write does not invalidate another school', async () => {
+    School.findOne.mockReturnValue(lean(null));
+    SystemConfig.get.mockResolvedValue({ default: { min: 1, max: 500 } });
+    await svc.resolveLimits({ schoolId: 'SCH001' });
+    await svc.resolveLimits({ schoolId: 'SCH002' });
+    expect(SystemConfig.get).toHaveBeenCalledTimes(2);
+
+    School.findOneAndUpdate.mockReturnValue(lean({ schoolId: 'SCH002' }));
+    await svc.setSchoolLimits('SCH002', { default: { min: 2, max: 20 } });
+
+    await svc.resolveLimits({ schoolId: 'SCH001' }); // still cached
+    expect(SystemConfig.get).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('validateLimitsDocument', () => {
+  test.each([
+    ['max below min', { default: { min: 10, max: 1 } }],
+    ['negative min', { default: { min: -1, max: 10 } }],
+    ['non-numeric', { default: { min: 'a', max: 10 } }],
+    ['infinite', { default: { min: 0, max: Infinity } }],
+    ['empty document', {}],
+    ['assets as array', { assets: [] }],
+    ['bad asset pair', { assets: { XLM: { min: 5, max: 5 } } }],
+  ])('rejects %s', (_label, doc) => {
+    expect(svc.validateLimitsDocument(doc).valid).toBe(false);
+  });
+
+  test.each([
+    ['default only', { default: { min: 0.01, max: 100 } }],
+    ['assets only', { assets: { XLM: { min: 1, max: 10 } } }],
+    ['both', { default: { min: 1, max: 100 }, assets: { USDC: { min: 5, max: 50 } } }],
+  ])('accepts %s', (_label, doc) => {
+    expect(svc.validateLimitsDocument(doc).valid).toBe(true);
+  });
+});
+
+describe('write paths', () => {
+  test('setSystemLimits rejects an invalid document before storing', async () => {
+    await expect(svc.setSystemLimits({ default: { min: 10, max: 1 } })).rejects.toThrow();
+    expect(SystemConfig.set).not.toHaveBeenCalled();
+  });
+
+  test('setSchoolLimits raises NOT_FOUND for an unknown school', async () => {
+    School.findOneAndUpdate.mockReturnValue(lean(null));
+    await expect(svc.setSchoolLimits('NOPE', { default: { min: 1, max: 2 } }))
+      .rejects.toMatchObject({ code: 'NOT_FOUND' });
+  });
+
+  test('clearSchoolLimits unsets the override', async () => {
+    School.findOneAndUpdate.mockReturnValue(lean({ schoolId: 'SCH001' }));
+    await svc.clearSchoolLimits('SCH001');
+    expect(School.findOneAndUpdate).toHaveBeenCalledWith(
+      { schoolId: 'SCH001' },
+      { $unset: { 'settings.paymentLimits': '' } },
+      { new: true },
+    );
+  });
+});
+
+describe('compareAgainstLimits', () => {
+  const limits = { min: 1, max: 100 };
+
+  test('accepts an in-range amount and the exact boundaries', () => {
+    expect(svc.compareAgainstLimits(50, limits).valid).toBe(true);
+    expect(svc.compareAgainstLimits(1, limits).valid).toBe(true);
+    expect(svc.compareAgainstLimits(100, limits).valid).toBe(true);
+  });
+
+  test('reports the specific reason for out-of-range amounts', () => {
+    expect(svc.compareAgainstLimits(0.5, limits)).toMatchObject({ code: 'AMOUNT_TOO_LOW' });
+    expect(svc.compareAgainstLimits(101, limits)).toMatchObject({ code: 'AMOUNT_TOO_HIGH' });
+  });
+
+  test('rejects non-numeric and non-positive amounts', () => {
+    expect(svc.compareAgainstLimits(NaN, limits)).toMatchObject({ code: 'INVALID_AMOUNT' });
+    expect(svc.compareAgainstLimits(0, limits)).toMatchObject({ code: 'INVALID_AMOUNT' });
+    expect(svc.compareAgainstLimits(-5, limits)).toMatchObject({ code: 'INVALID_AMOUNT' });
+  });
+
+  test('compares in Decimal space, not float space', () => {
+    // 0.1 + 0.2 === 0.30000000000000004 in IEEE-754; a float comparison against
+    // a max of 0.3 would wrongly reject it.
+    expect(svc.compareAgainstLimits(0.1 + 0.2, { min: 0.01, max: 0.3 }))
+      .toMatchObject({ code: 'AMOUNT_TOO_HIGH' });
+    expect(svc.compareAgainstLimits(0.3, { min: 0.01, max: 0.3 }).valid).toBe(true);
+  });
+});

--- a/docs/payment-limits.md
+++ b/docs/payment-limits.md
@@ -11,27 +11,109 @@ The Payment Limits feature provides configurable minimum and maximum thresholds 
 
 ## Configuration
 
-Payment limits are configured via environment variables in the `.env` file:
+Limits resolve at request time from the database, with the environment
+variables as the final fallback. A deployment that never calls the admin API
+behaves exactly as it did before this was introduced.
+
+Resolution order, most specific first:
+
+| # | Source | Scope |
+| - | ------ | ----- |
+| 1 | `School.settings.paymentLimits.assets[CODE]` | One school, one asset |
+| 2 | `School.settings.paymentLimits.default` | One school |
+| 3 | `SystemConfig` key `paymentLimits` → `assets[CODE]` | Global, one asset |
+| 4 | `SystemConfig` key `paymentLimits` → `default` | Global |
+| 5 | `MIN_PAYMENT_AMOUNT` / `MAX_PAYMENT_AMOUNT` | Env fallback |
+
+Per-asset matters because XLM and USDC occupy very different value ranges — a
+ceiling that is sensible for one is meaningless for the other. A deployment
+accepts a single asset at a time today, so the asset key is largely
+future-proofing, but storing limits without it would rebuild the same
+conflation in the config model.
+
+### Environment fallback
 
 ```bash
-# Minimum payment amount in XLM/USDC (default: 0.01)
+# Minimum payment amount (default: 0.01)
 MIN_PAYMENT_AMOUNT=0.01
 
-# Maximum payment amount in XLM/USDC (default: 100000)
+# Maximum payment amount (default: 100000)
 MAX_PAYMENT_AMOUNT=100000
+
+# How long resolved limits are cached in process (default: 30000)
+PAYMENT_LIMITS_CACHE_TTL_MS=30000
 ```
-
-### Default Values
-
-- **Minimum**: 0.01 XLM/USDC
-- **Maximum**: 100,000 XLM/USDC
 
 ### Validation Rules
 
-The system validates that:
-1. `MIN_PAYMENT_AMOUNT` must be a positive number (> 0)
-2. `MAX_PAYMENT_AMOUNT` must be greater than `MIN_PAYMENT_AMOUNT`
-3. If validation fails, the application will not start and will throw a configuration error
+Both the env values at boot and every admin write are checked against the same
+rules:
+
+1. `min` must be a finite, non-negative number
+2. `max` must be a finite number greater than `min`
+3. A bad env value prevents startup; a bad admin write is rejected with `400`
+   and `INVALID_PAYMENT_LIMITS`
+
+A stored value that somehow fails validation is ignored at resolution time and
+the next layer down applies — a corrupt record degrades to a safe limit rather
+than to no limit.
+
+## Managing limits at runtime
+
+Limits are a fraud-prevention control, so they need to be adjustable while an
+incident is happening rather than on the next deploy.
+
+```bash
+# Read effective limits (add ?schoolId= to scope to a school)
+GET /api/admin/payment-limits
+
+# Set global limits
+PUT /api/admin/payment-limits
+{ "default": { "min": 1, "max": 5000 },
+  "assets": { "USDC": { "min": 1, "max": 2000 } } }
+
+# Set one school's limits
+PUT /api/admin/payment-limits
+{ "schoolId": "SCH001", "default": { "min": 2, "max": 800 } }
+
+# Remove a school override, falling back to global
+DELETE /api/admin/payment-limits/SCH001
+```
+
+All three require admin authentication. The `GET` response includes a `source`
+field naming the layer that supplied the effective value — without it, a school
+override silently masking a global change looks identical to the change not
+having applied.
+
+Every mutation is audit-logged at `high` severity with the before and after
+values (`PAYMENT_LIMITS_UPDATED`, `PAYMENT_LIMITS_CLEARED`). Rejected writes are
+logged too, as `PAYMENT_LIMITS_UPDATE_REJECTED` — a run of malformed writes
+against a security control is itself worth seeing.
+
+### Propagation
+
+Resolved limits are cached in process for `PAYMENT_LIMITS_CACHE_TTL_MS`
+(default 30s) because resolution sits in the payment hot path. A write
+invalidates the cache immediately on the instance that served it; other
+instances converge within the TTL. That bounded staleness is the trade for not
+doing a database read per payment, and is still a different order of magnitude
+from requiring a redeployment.
+
+## Monitoring
+
+`payment_limit_triggered_total{school_id,asset,code}` counts payments rejected
+by the limits. Before it existed, the limits were a control with no feedback
+loop — nothing told an operator the configured values had stopped matching real
+payment behaviour.
+
+Two alerts ship in `monitoring/alerts/payment_limits.yml`:
+
+- **PaymentLimitTriggeredFrequently** (warning) — a sustained rejection rate for
+  a school/asset/code. A sustained `AMOUNT_TOO_HIGH` is either a fee structure
+  the ceiling no longer fits, or someone probing with large amounts.
+- **PaymentLimitBlockingMostPayments** (critical) — more than half of received
+  payments rejected, which in practice means a misconfiguration (a limit set in
+  the wrong asset's value range does exactly this) and parents cannot pay.
 
 ## How It Works
 
@@ -222,8 +304,6 @@ If you're adding payment limits to an existing deployment:
 
 Potential improvements to the payment limits feature:
 
-1. **Per-Asset Limits**: Different limits for XLM vs USDC
-2. **Dynamic Limits**: Adjust limits based on student grade level or program
-3. **Rate Limiting**: Limit number of payments per time period
-4. **Admin Interface**: UI for managing limits without redeployment
-5. **Alerts**: Notify admins when limits are frequently triggered
+1. **Dynamic Limits**: Adjust limits based on student grade level or program
+2. **Rate Limiting**: Limit number of payments per time period
+3. **Admin UI**: A front-end for the limits API, which is currently HTTP-only

--- a/monitoring/alerts/payment_limits.yml
+++ b/monitoring/alerts/payment_limits.yml
@@ -1,0 +1,56 @@
+groups:
+  - name: payment_limits
+    interval: 60s
+    rules:
+      # ── Warning: limits are rejecting payments at a sustained rate ───────
+      # payment_limit_triggered_total{school_id,asset,code} is incremented
+      # whenever a payment is rejected by the configured min/max (#1117).
+      # Before this metric, limits were a control with no feedback loop: there
+      # was no signal telling an operator that the configured values were
+      # mismatched to real payment behaviour, and adjusting them needed a
+      # redeploy anyway.
+      #
+      # A sustained AMOUNT_TOO_HIGH rate is the interesting one — it is either
+      # a fee structure the ceiling no longer fits, or someone probing with
+      # large amounts. AMOUNT_TOO_LOW is usually dust or a misconfigured
+      # minimum.
+      - alert: PaymentLimitTriggeredFrequently
+        expr: sum(rate(payment_limit_triggered_total[15m])) by (school_id, asset, code) > 0.01
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Payment limit {{ $labels.code }} rejecting payments for {{ $labels.school_id }}"
+          description: >
+            Payments in {{ $labels.asset }} for school {{ $labels.school_id }}
+            have been rejected as {{ $labels.code }} for 15 minutes
+            ({{ $value | printf "%.4f" }}/s). Either the configured limits no
+            longer match this school's fee structure, or someone is probing with
+            out-of-range amounts. Review the effective limits via
+            GET /api/admin/payment-limits?schoolId={{ $labels.school_id }} and
+            adjust with PUT if warranted — this no longer requires a redeploy.
+
+      # ── Critical: the limits are rejecting most attempted payments ───────
+      # Compares rejections against payments entering the funnel. A high ratio
+      # means the limits are misconfigured badly enough to be an outage for
+      # parents trying to pay, not a fraud signal.
+      - alert: PaymentLimitBlockingMostPayments
+        expr: >
+          sum(rate(payment_limit_triggered_total[15m])) by (school_id)
+            /
+          clamp_min(sum(rate(payment_funnel_total{stage="received"}[15m])) by (school_id), 0.001)
+            > 0.5
+        for: 15m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Payment limits are blocking most payments for {{ $labels.school_id }}"
+          description: >
+            More than half of payments received for school
+            {{ $labels.school_id }} over the last 15 minutes were rejected by
+            the configured payment limits. This is very likely a
+            misconfiguration — a limit set in the wrong asset's value range will
+            do exactly this. Parents cannot pay. Check
+            GET /api/admin/payment-limits?schoolId={{ $labels.school_id }}; the
+            `source` field shows which layer (school override, global, or the
+            env fallback) supplied the active value.

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -5,6 +5,7 @@ global:
 rule_files:
   - "alerts/price_feed.yml"
   - "alerts/horizon_poll.yml"
+  - "alerts/payment_limits.yml"
 
 scrape_configs:
   - job_name: stellaredupay


### PR DESCRIPTION
Closes #1117

## Problem

Payment limits are a fraud-prevention control that could only be changed by editing an environment variable and redeploying. A control you cannot adjust during an incident is not usable as a reactive tool — tightening a ceiling in response to a spike of suspicious amounts meant a full deploy cycle. There was also no per-asset granularity, and no signal at all telling operators the limits were being hit.

## Approach

Limits now resolve at request time through `paymentLimitsService`, most specific layer first:

| # | Source | Scope |
| - | ------ | ----- |
| 1 | `School.settings.paymentLimits.assets[CODE]` | One school, one asset |
| 2 | `School.settings.paymentLimits.default` | One school |
| 3 | `SystemConfig.paymentLimits.assets[CODE]` | Global, one asset |
| 4 | `SystemConfig.paymentLimits.default` | Global |
| 5 | `MIN_PAYMENT_AMOUNT` / `MAX_PAYMENT_AMOUNT` | Env fallback |

**Layer 5 is the important one for review:** a deployment that never calls the admin API resolves to exactly the values it uses today, so this is not a behaviour change for existing installs.

This reuses the existing `SystemConfig` + `School.settings` pattern that `schoolSettingsService` already established rather than introducing a new storage mechanism.

### Admin API

```
GET    /api/admin/payment-limits[?schoolId=&asset=]
PUT    /api/admin/payment-limits          { default?, assets?, schoolId? }
DELETE /api/admin/payment-limits/:schoolId
```

All require `requireAdminAuth`. The `GET` response includes a `source` field naming the layer that supplied the effective value — without it, a school override silently masking a global change is indistinguishable from the change not having applied.

### Audit logging

Every mutation is logged at `high` severity with before and after values (`PAYMENT_LIMITS_UPDATED`, `PAYMENT_LIMITS_CLEARED`). Rejected writes are logged too (`PAYMENT_LIMITS_UPDATE_REJECTED`) — a run of malformed writes against a security control is itself worth seeing in the trail.

### Metric and alerts

`payment_limit_triggered_total{school_id,asset,code}` counts rejections. Two alerts in `monitoring/alerts/payment_limits.yml`:

- **PaymentLimitTriggeredFrequently** (warning) — sustained rejections for a school/asset/code
- **PaymentLimitBlockingMostPayments** (critical) — >50% of received payments rejected, which in practice means misconfiguration and parents cannot pay

## Design decisions worth a maintainer's eye

**`validatePaymentAmount` is now async.** DB-backed limits cannot be resolved synchronously. All four call sites were already inside `async` functions, so each is a one-line `await`. `validatePaymentAmountAgainstFee` is untouched and stays sync — it takes its bound as an argument.

**Resolution is cached in-process for 30s** (`PAYMENT_LIMITS_CACHE_TTL_MS`) because it sits in the payment hot path. A write invalidates immediately on the serving instance; others converge within the TTL. That bounded staleness is the trade for not doing a DB read per payment — and it is still a different order of magnitude from a redeploy. Flagging it explicitly since it's the one genuine compromise here.

**Failures fall back to the env limits, never to "no limit."** If the DB read throws, resolution returns the env values rather than failing open. Losing the ability to read a tightened limit must not become accepting an unbounded payment. Same for a stored record that fails validation — it's ignored and the next layer applies.

**Reads are bounded at 2s** (`PAYMENT_LIMITS_READ_TIMEOUT_MS`). This one was a genuine bug I introduced and caught while baselining: mongoose *buffers* commands while disconnected rather than rejecting them, so the fallback above never fired — the read simply hung, and with it payment verification. `tests/stellar.test.js` surfaced it as a 5s timeout. Now a slow or disconnected database degrades to the env limits instead of stalling the payment path, and there's a regression test that fails if the bound is removed.

**Per-asset is mostly future-proofing.** A deployment accepts one asset at a time today (`ACCEPTED_ASSETS`), so the asset key rarely changes the answer right now. But storing limits without it would rebuild exactly the conflation this issue describes, so the key is in the model from the start.

## Test plan

New tests — 44 passing:

- `backend/tests/paymentLimitsService.test.js` — 29 tests: full resolution order, per-asset precedence, cache behaviour and invalidation, env fallback on DB error *and* on hang, document validation, Decimal comparison
- `backend/tests/paymentLimitsAdmin.test.js` — 9 tests: the three endpoints, and that every mutation produces an audit entry with before/after
- `backend/tests/paymentLimitsMetric.test.js` — 6 tests: the counter increments with correct labels only on rejection

Regression check against a clean `upstream/main` checkout, over the nine suites that touch payment limits or the amount path:

| | Suites | Tests |
| - | ------ | ----- |
| `upstream/main` | 8 failed, 1 passed | 26 failed, 98 passed, 124 total |
| this branch | 8 failed, 1 passed | 26 failed, 98 passed, 124 total |

Identical — the 8 are pre-existing. (Before the read-timeout fix this branch was 9 failed / 28 failed tests; that delta was the bug described above.)

I could not get a clean whole-suite number: `tests/currencyConversion.test.js` calls `process.exit(1)` in its body, which tears down the entire jest run partway through, so any full-suite figure is truncated at an arbitrary point. That's also pre-existing and unrelated.

## ⚠️ `upstream/main` currently has a syntax error, unrelated to this PR

While baselining the suite I hit this in `backend/src/controllers/authController.js:401`:

```js
User.findByIdAndUpdate(user._id, { $set: { [`mfaBackupCodes.${bcIdx].used`]: true } })
//                                                            ^ should be }
```

`node --check` on that file at `upstream/main` fails with `SyntaxError: Missing } in template expression`. It was introduced in 9189d80 ("feat: global unhandled-rejection"). Any suite that loads `authController` — directly or transitively — fails to run, which is a large fraction of the backend suite.

I have deliberately **not** fixed it here, since it is unrelated to payment limits and deserves its own PR. Happy to open one if useful. Flagging it because it makes the CI signal on this PR hard to read.

Two smaller pre-existing issues found the same way, also untouched:

- `backend/.eslintrc.json` is not valid JSON (`Unexpected non-whitespace character after JSON at position 356`), so eslint cannot run against the backend at all.
- `tests/currencyConversion.test.js` calls `process.exit(1)` inside the test body, which kills the whole jest run rather than failing one suite.
