### PR TITLE
fix: record deleted-student memo matches for review; verify completed-intent fallback

### DIFF
--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -639,6 +639,28 @@ async function syncPaymentsForSchool(school) {
       } else {
         student = await Student.findOne({ schoolId, studentId: memo });
       }
+
+      // A memo (or a still-pending intent) can point at a student who has since
+      // been soft-deleted (#77/#390). The funds already left the payer's wallet,
+      // so record them against the deleted student (studentDeleted=true) for the
+      // existing deleted-student payments audit view (getDeletedStudentPayments)
+      // instead of dropping them into the generic unmatched bucket, where they'd
+      // be indistinguishable from a mistyped memo and never surfaced for review.
+      let studentDeleted = false;
+      if (!student) {
+        const targetStudentId = intent ? intent.studentId : memo;
+        student = await Student.findOne({
+          schoolId,
+          studentId: targetStudentId,
+          deletedAt: { $ne: null },
+        });
+        studentDeleted = Boolean(student);
+        if (studentDeleted) {
+          logger.warn('Transaction matched a soft-deleted student — recording for manual review', {
+            txHash: tx.hash, schoolId, studentId: targetStudentId,
+          });
+        }
+      }
       if (!student) { summary.unmatched++; continue; }
 
       summary.matched++;
@@ -737,9 +759,10 @@ async function syncPaymentsForSchool(school) {
             confirmationStatus,
             confirmationState: confirmation.state,
             confirmedAt: txDate,
+            studentDeleted,
           }, { session });
 
-          if (isConfirmed && !isSuspicious) {
+          if (isConfirmed && !isSuspicious && !studentDeleted) {
             const updateData = {
               totalPaid: cumulativeTotal,
               remainingBalance: parseFloat(Math.max(0, student.feeAmount - cumulativeTotal).toFixed(7)),

--- a/docs/testing-sync-payments.md
+++ b/docs/testing-sync-payments.md
@@ -233,6 +233,39 @@ These tests complement existing tests in `stellar.test.js`:
 - `parseIncomingTransaction` - Tests transaction parsing
 - `validatePaymentAgainstFee` - Tests fee validation
 
+### 4. Transaction with Memo Matching a Soft-Deleted Student
+
+**Scenario**: A transaction's memo (or a still-pending intent it resolves to)
+identifies a student who has since been soft-deleted (`deletedAt` set).
+
+**Test**: `records payment for memo matching a soft-deleted student instead of
+dropping it (flagged for manual review)`
+
+**Verified behavior**: The funds already left the payer's wallet, so the
+payment is recorded with `studentDeleted: true` — the same flag used
+elsewhere when an existing student (with prior payments) is deleted — instead
+of being dropped into the generic unmatched-memo bucket. The (deleted)
+student's stored balance is never mutated. The payment is visible via the
+existing `getDeletedStudentPayments` audit endpoint for manual review, and is
+excluded from active reports/balances by the existing `studentDeleted: { $ne:
+true }` filters used throughout reporting and student-balance code.
+
+### 5. Transaction with Memo Matching an Already-Completed Payment Intent
+
+**Scenario**: A transaction's memo matches a `PaymentIntent` that has already
+transitioned to `status: 'completed'` (e.g. a delayed or duplicate
+submission arriving after the intent was already fully paid).
+
+**Test**: `credits a transaction whose memo matches an already-completed
+payment intent (intent-decoupled fallback match)`
+
+**Verified behavior**: The `status: 'pending'` intent lookup finds nothing,
+so the sync falls back to matching the student directly by `studentId` (the
+intent-decoupled crediting path from #848). The transaction is credited to
+the student as an additional payment (raising `totalPaid`, and marking the
+payment `overpaid` if it exceeds the fee) rather than being dropped — funds
+are never silently lost.
+
 ## Future Enhancements
 
 Potential additional test scenarios:
@@ -241,8 +274,6 @@ Potential additional test scenarios:
 2. Transaction with memo containing special characters
 3. Transaction with memo that's too long
 4. Multiple transactions with same unmatched memo
-5. Transaction with memo matching deleted student
-6. Transaction with memo matching completed payment intent
 
 ## Acceptance Criteria
 
@@ -252,3 +283,5 @@ Potential additional test scenarios:
 ✅ Both cases are covered by passing tests
 ✅ No Student documents are updated for invalid transactions
 ✅ Sync process continues gracefully after encountering invalid transactions
+✅ Memo-matches-deleted-student transactions are recorded (studentDeleted: true) for manual review, not dropped
+✅ Memo-matches-completed-intent transactions are credited via the intent-decoupled fallback, not dropped

--- a/tests/stellar.test.js
+++ b/tests/stellar.test.js
@@ -17,6 +17,26 @@ jest.mock('@stellar/stellar-sdk', () => ({
   Asset: { native: jest.fn(() => ({ isNative: () => true })) },
 }), { virtual: true });
 
+// syncPaymentsForSchool's "matched" path wraps the write in a session/transaction —
+// mock mongoose so no real MongoDB connection is required.
+var mockWithTransaction = jest.fn(async (cb) => cb());
+var mockEndSession = jest.fn().mockResolvedValue(undefined);
+var mockStartSession = jest.fn().mockResolvedValue({
+  withTransaction: mockWithTransaction,
+  endSession: mockEndSession,
+});
+// stellarService.js resolves 'mongoose' from backend/node_modules (its own
+// install, separate from the root-level copy) — mock that exact resolved
+// path so the session stub actually intercepts the call.
+jest.mock(require.resolve('../backend/node_modules/mongoose'), () => ({
+  connection: { startSession: mockStartSession },
+}));
+
+// savePayment (transactionService) writes an outbox event alongside the payment.
+jest.mock('../backend/src/models/outboxModel', () => ({
+  create: jest.fn().mockResolvedValue({}),
+}));
+
 const {
   verifyTransaction,
   syncPaymentsForSchool,
@@ -67,8 +87,9 @@ jest.mock('../backend/src/config/stellarConfig', () => ({
 
 jest.mock('../backend/src/models/paymentModel', () => ({
   findOne: jest.fn(),
-  create: jest.fn().mockResolvedValue({}),
+  create: jest.fn().mockResolvedValue({ toObject: () => ({}) }),
   exists: jest.fn().mockResolvedValue(false),
+  aggregate: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('../backend/src/models/paymentIntentModel', () => ({
@@ -308,6 +329,7 @@ function makeSyncTx(amount, memo = 'STU001') {
     hash: `tx-${amount}`,
     successful: true,
     memo,
+    memo_type: 'text',
     created_at: new Date().toISOString(),
     ledger_attr: 90, // below CONFIRMATION_THRESHOLD of 2 from sequence 100 → confirmed
     operations: jest.fn().mockResolvedValue({
@@ -331,6 +353,13 @@ describe('syncPaymentsForSchool', () => {
     jest.clearAllMocks();
     Payment.findOne.mockResolvedValue(null); // tx not yet recorded
     Payment.exists.mockResolvedValue(false);
+    Payment.create.mockResolvedValue({ toObject: () => ({}) });
+    Payment.aggregate.mockResolvedValue([]);
+    mockWithTransaction.mockImplementation(async (cb) => cb());
+    mockStartSession.mockResolvedValue({
+      withTransaction: mockWithTransaction,
+      endSession: mockEndSession,
+    });
   });
 
   test('resolves without error when no transactions exist', async () => {
@@ -472,6 +501,84 @@ describe('syncPaymentsForSchool', () => {
     expect(studentUpdateSpy).not.toHaveBeenCalled();
 
     // Restore
+    stellarConfig.server.transactions = origTransactions;
+  });
+
+  test('records payment for memo matching a soft-deleted student instead of dropping it (flagged for manual review)', async () => {
+    const school = { schoolId: 'SCH001', stellarAddress: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5' };
+    const tx = makeSyncTx(100, 'STU_DEL');
+
+    const stellarConfig = require('../backend/src/config/stellarConfig');
+    const origTransactions = stellarConfig.server.transactions;
+    stellarConfig.server.transactions = () => ({
+      forAccount: () => ({
+        order: () => ({
+          limit: () => ({
+            call: async () => ({ records: [tx], next: async () => ({ records: [] }) }),
+          }),
+        }),
+      }),
+    });
+
+    // No pending intent for this memo — falls back to a direct studentId lookup.
+    const PaymentIntent = require('../backend/src/models/paymentIntentModel');
+    PaymentIntent.findOne.mockResolvedValue(null);
+
+    // Active lookup misses (the student is soft-deleted, excluded by the
+    // softDelete plugin); the explicit deletedAt-filtered lookup finds them.
+    Student.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ schoolId: 'SCH001', studentId: 'STU_DEL', feeAmount: 100, deletedAt: new Date() });
+
+    const summary = await syncPaymentsForSchool(school);
+
+    // Funds are recorded, not silently unmatched.
+    expect(Payment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ txHash: tx.hash, studentId: 'STU_DEL', studentDeleted: true }),
+      expect.anything(),
+    );
+    // The deleted student's stored balance is never mutated.
+    expect(Student.findOneAndUpdate).not.toHaveBeenCalled();
+    expect(summary.unmatched).toBe(0);
+
+    stellarConfig.server.transactions = origTransactions;
+  });
+
+  test('credits a transaction whose memo matches an already-completed payment intent (intent-decoupled fallback match)', async () => {
+    const school = { schoolId: 'SCH001', stellarAddress: 'GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5' };
+    const tx = makeSyncTx(100, 'STU001');
+
+    const stellarConfig = require('../backend/src/config/stellarConfig');
+    const origTransactions = stellarConfig.server.transactions;
+    stellarConfig.server.transactions = () => ({
+      forAccount: () => ({
+        order: () => ({
+          limit: () => ({
+            call: async () => ({ records: [tx], next: async () => ({ records: [] }) }),
+          }),
+        }),
+      }),
+    });
+
+    // The intent for this memo is already completed — the pending-only query finds nothing.
+    const PaymentIntent = require('../backend/src/models/paymentIntentModel');
+    PaymentIntent.findOne.mockResolvedValue(null);
+
+    // Fallback direct studentId lookup finds the (still-active) student.
+    Student.findOne.mockResolvedValueOnce({ schoolId: 'SCH001', studentId: 'STU001', feeAmount: 100 });
+
+    const summary = await syncPaymentsForSchool(school);
+
+    // The late/duplicate transaction is credited to the student, not dropped.
+    expect(Payment.create).toHaveBeenCalledWith(
+      expect.objectContaining({ txHash: tx.hash, studentId: 'STU001', studentDeleted: false }),
+      expect.anything(),
+    );
+    expect(Student.findOneAndUpdate).toHaveBeenCalled();
+    // No pending intent existed, so nothing is marked completed a second time.
+    expect(PaymentIntent.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(summary.unmatched).toBe(0);
+
     stellarConfig.server.transactions = origTransactions;
   });
 


### PR DESCRIPTION
## Summary

`docs/testing-sync-payments.md` explicitly listed two fraud-relevant memo-matching scenarios as untested: a transaction whose memo matches a **deleted student**, and one matching an **already-completed payment intent**. This PR determines and fixes/verifies the actual behavior of `syncPaymentsForSchool` for both, with real tests exercising the actual code path (mocked models, not the function itself).

### 1. Memo matches a soft-deleted student — was silently dropped, now recorded for review

Previously: `Student.findOne` (correctly) excludes soft-deleted students, so a transaction whose memo/intent resolved to a deleted student fell into the generic `unmatched` bucket — indistinguishable from a plain typo, with zero detail returned to admins, and no persisted record anywhere. The on-chain funds were real, but the app never tracked them.

The codebase already has infrastructure for exactly this situation: the `Payment.studentDeleted` flag and the `getDeletedStudentPayments` audit endpoint (used when an *existing* student with prior payments is deleted). `syncPaymentsForSchool` just never populated it for *new* transactions arriving after the deletion.

**Fix**: when the active student lookup misses, `syncPaymentsForSchool` now does a second, explicit lookup for a soft-deleted student with that ID. If found, the payment is recorded with `studentDeleted: true` (visible via the existing audit endpoint, excluded from active reports/balances by the existing `studentDeleted: { $ne: true }` filters used throughout the codebase), the deleted student's stored balance is never mutated, and a warning is logged. Funds are no longer silently lost track of.

### 2. Memo matches an already-completed payment intent — already handled correctly, now verified

Investigated whether a late/duplicate transaction whose memo matches a completed intent could lose or misapply funds. It does not: the `status: 'pending'` intent lookup finds nothing, so the sync falls back to the intent-decoupled direct-studentId match (#848) and credits the payment to the student normally (raising `totalPaid`, marked `overpaid` if it exceeds the fee). No code change was needed here — added a test that exercises this path and documented the verified behavior, closing the documented gap.

## Changes

- `backend/src/services/stellarService.js` — `syncPaymentsForSchool`: detect a soft-deleted-student memo match, record it with `studentDeleted: true`, skip balance mutation, log for visibility.
- `tests/stellar.test.js` — two new tests against the real function (mocked models), plus the mongoose/Outbox/aggregate mocking needed to exercise the previously-untested "matched" credit path; fixed `makeSyncTx` to set `memo_type: 'text'` (was missing, silently short-circuiting every non-bail-out test).
- `docs/testing-sync-payments.md` — documents the verified behavior for both scenarios and updates the acceptance criteria.

## Test plan

- [x] `npx jest tests/stellar.test.js` — 34/34 passing, including both new tests
- [x] Confirmed via `git stash` that pre-existing failures elsewhere in the suite (`transactionAtomicity.test.js`, `payment.test.js`, `auditCoverage.test.js`, `cross-tenant-access.test.js`, `e2e-payment-flow.test.js`) are present on `main` too — unrelated to this change

Closes #1119