### PR TITLE
Enforce machine-readable dependency exceptions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,17 +37,16 @@ jobs:
       - run: cd backend && npm ci && cd ..
       - run: cd frontend && npm ci && cd ..
 
-      # Fail the build on high or critical advisories.
-      # Triage process: file a GitHub issue, apply `npm audit fix`, or add an
-      # explicit `npm audit --omit` entry with a justification comment.
+      # Fails on any high/critical advisory that has no current, non-expired
+      # entry in security-exceptions.json. See docs/dependency-triage.md.
       - name: Audit root
-        run: npm audit --audit-level=high
+        run: node scripts/check-dependency-audit.js .
 
       - name: Audit backend
-        run: cd backend && npm audit --audit-level=high
+        run: node scripts/check-dependency-audit.js backend
 
       - name: Audit frontend
-        run: cd frontend && npm audit --audit-level=high
+        run: node scripts/check-dependency-audit.js frontend
 
   test:
     runs-on: ubuntu-latest

--- a/docs/dependency-triage.md
+++ b/docs/dependency-triage.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-CI runs `npm audit --audit-level=high` for all three packages (root, backend, frontend).
-Any **high** or **critical** advisory will fail the build. Dependabot opens weekly PRs for
-outdated dependencies.
+CI runs `node scripts/check-dependency-audit.js` for all three packages (root, backend,
+frontend). It runs `npm audit --json` and fails the build on any **high** or **critical**
+advisory that has no current, non-expired entry in [`security-exceptions.json`](../security-exceptions.json).
+Dependabot opens weekly PRs for outdated dependencies.
 
 ## When CI Fails with a Vulnerability
 
@@ -18,8 +19,26 @@ outdated dependencies.
 4. **If no fix is available** (zero-day / no upstream patch):
    - Open a GitHub issue tagged `security` with the advisory CVE/ID and affected paths.
    - Assess exploitability in context (e.g. a server-side-only dep used only in tests).
-   - If safe to defer, document the exception in `docs/security.md` with the issue link.
-   - Do **not** silence the audit without a written justification.
+   - If safe to defer, add an entry to `security-exceptions.json` (repo root):
+     ```json
+     {
+       "id": "GHSA-xxxx-xxxx-xxxx",
+       "package": "package-name",
+       "path": "backend",
+       "severity": "high",
+       "reason": "Why this is safe to defer, in context.",
+       "issue": "https://github.com/<org>/<repo>/issues/<n>",
+       "added": "2026-07-20",
+       "expires": "2026-10-20"
+     }
+     ```
+     `path` must match the package the CI audit step runs against (`.`, `backend`, or
+     `frontend`). `id` is the advisory's GHSA slug (the last path segment of its
+     `github.com/advisories/...` URL). `scripts/check-dependency-audit.js` treats an
+     exception whose `expires` date has passed as if it didn't exist, so the build
+     fails again until the entry is renewed (with a fresh look at whether a fix has
+     since landed) or the vulnerability is fixed.
+   - Do **not** silence the audit without a corresponding exception entry.
 
 ## Dependabot PRs
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,12 @@
 # Security
 
+## Dependency vulnerability exceptions
+
+Deferred high/critical `npm audit` findings are tracked as dated, expiring entries in
+[`security-exceptions.json`](../security-exceptions.json) at the repo root, not as prose here.
+CI (`scripts/check-dependency-audit.js`) fails the build if a high/critical advisory has no
+matching, non-expired entry in that file. See `docs/dependency-triage.md` for the process.
+
 ## Content Security Policy (CSP)
 
 StellarEduPay enforces a Content Security Policy on all HTTP responses to mitigate XSS attacks. The policy is applied at two layers: the Next.js frontend and the Express backend.

--- a/scripts/check-dependency-audit.js
+++ b/scripts/check-dependency-audit.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Fails if `npm audit` reports a high/critical advisory in <package-path> that
+ * has no matching, non-expired entry in security-exceptions.json.
+ *
+ * Usage: node scripts/check-dependency-audit.js <package-path>
+ *   e.g. node scripts/check-dependency-audit.js .
+ *        node scripts/check-dependency-audit.js backend
+ *        node scripts/check-dependency-audit.js frontend
+ *
+ * See docs/dependency-triage.md for the exception process.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const GATED_SEVERITIES = ['high', 'critical'];
+
+function findUnexceptedVulnerabilities(vulnerabilities, exceptions, packagePath, today) {
+  const failures = [];
+  for (const vuln of Object.values(vulnerabilities)) {
+    if (!GATED_SEVERITIES.includes(vuln.severity)) continue;
+
+    const advisoryIds = (vuln.via || [])
+      .filter((entry) => typeof entry === 'object' && entry.url)
+      .map((entry) => entry.url.split('/').pop());
+
+    // Entries whose `via` is only package names (no advisory objects) are
+    // transitive-only; the direct dependency carries its own advisory entry.
+    if (advisoryIds.length === 0) continue;
+
+    const hasCurrentException = advisoryIds.some((id) =>
+      exceptions.some(
+        (ex) =>
+          ex.path === packagePath &&
+          ex.package === vuln.name &&
+          ex.id === id &&
+          ex.expires >= today
+      )
+    );
+
+    if (!hasCurrentException) {
+      failures.push({ package: vuln.name, severity: vuln.severity, advisoryIds });
+    }
+  }
+  return failures;
+}
+
+function main() {
+  const packagePath = process.argv[2];
+  if (!packagePath) {
+    console.error('Usage: node scripts/check-dependency-audit.js <package-path>');
+    process.exit(1);
+  }
+
+  const repoRoot = path.resolve(__dirname, '..');
+  const exceptions = loadExceptions(repoRoot);
+  const vulnerabilities = runAudit(path.join(repoRoot, packagePath));
+  const today = new Date().toISOString().slice(0, 10);
+  const failures = findUnexceptedVulnerabilities(vulnerabilities, exceptions, packagePath, today);
+
+  if (failures.length > 0) {
+    console.error(
+      `\nDependency audit failed for "${packagePath}": ${failures.length} high/critical advisory(ies) with no current exception.\n`
+    );
+    for (const failure of failures) {
+      console.error(`  - ${failure.package} (${failure.severity}): ${failure.advisoryIds.join(', ')}`);
+    }
+    console.error(
+      '\nRun `npm audit fix` to patch, or add a dated, time-bound entry to security-exceptions.json ' +
+        '(existing exceptions expire and must be renewed). See docs/dependency-triage.md.\n'
+    );
+    process.exit(1);
+  }
+
+  console.log(`Dependency audit OK for "${packagePath}" (no unexcepted high/critical advisories).`);
+}
+
+function loadExceptions(repoRoot) {
+  const file = path.join(repoRoot, 'security-exceptions.json');
+  const { exceptions } = JSON.parse(fs.readFileSync(file, 'utf8'));
+  return exceptions;
+}
+
+function runAudit(cwd) {
+  let stdout;
+  try {
+    // npm audit exits non-zero as soon as any advisory is found, but still
+    // writes the full JSON report to stdout — capture it from the error too.
+    stdout = execSync('npm audit --json', { cwd, encoding: 'utf8', maxBuffer: 20 * 1024 * 1024 });
+  } catch (err) {
+    stdout = err.stdout;
+  }
+  const report = JSON.parse(stdout);
+  return report.vulnerabilities || {};
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { findUnexceptedVulnerabilities };

--- a/security-exceptions.json
+++ b/security-exceptions.json
@@ -1,0 +1,5 @@
+{
+  "description": "Machine-readable record of high/critical npm audit findings that are deferred rather than fixed. Read by scripts/check-dependency-audit.js in CI. See docs/dependency-triage.md for the process.",
+  "exceptions": [
+  ]
+}

--- a/tests/checkDependencyAudit.test.js
+++ b/tests/checkDependencyAudit.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+const { findUnexceptedVulnerabilities } = require('../scripts/check-dependency-audit');
+
+function vuln(name, severity, advisoryUrls) {
+  return {
+    name,
+    severity,
+    via: advisoryUrls.map((url) => ({ url })),
+  };
+}
+
+describe('findUnexceptedVulnerabilities', () => {
+  it('flags a high-severity advisory with no exception', () => {
+    const vulnerabilities = {
+      'form-data': vuln('form-data', 'high', ['https://github.com/advisories/GHSA-hmw2-7cc7-3qxx']),
+    };
+
+    const failures = findUnexceptedVulnerabilities(vulnerabilities, [], 'backend', '2026-07-20');
+
+    expect(failures).toEqual([
+      { package: 'form-data', severity: 'high', advisoryIds: ['GHSA-hmw2-7cc7-3qxx'] },
+    ]);
+  });
+
+  it('does not flag moderate/low severity advisories', () => {
+    const vulnerabilities = {
+      'js-yaml': vuln('js-yaml', 'moderate', ['https://github.com/advisories/GHSA-mh29-5h37-fv8m']),
+    };
+
+    expect(findUnexceptedVulnerabilities(vulnerabilities, [], 'backend', '2026-07-20')).toEqual([]);
+  });
+
+  it('is silenced by a current, matching exception', () => {
+    const vulnerabilities = {
+      'form-data': vuln('form-data', 'high', ['https://github.com/advisories/GHSA-hmw2-7cc7-3qxx']),
+    };
+    const exceptions = [
+      {
+        id: 'GHSA-hmw2-7cc7-3qxx',
+        package: 'form-data',
+        path: 'backend',
+        expires: '2026-12-31',
+      },
+    ];
+
+    expect(findUnexceptedVulnerabilities(vulnerabilities, exceptions, 'backend', '2026-07-20')).toEqual([]);
+  });
+
+  it('treats an expired exception as absent', () => {
+    const vulnerabilities = {
+      'form-data': vuln('form-data', 'high', ['https://github.com/advisories/GHSA-hmw2-7cc7-3qxx']),
+    };
+    const exceptions = [
+      {
+        id: 'GHSA-hmw2-7cc7-3qxx',
+        package: 'form-data',
+        path: 'backend',
+        expires: '2026-01-01',
+      },
+    ];
+
+    const failures = findUnexceptedVulnerabilities(vulnerabilities, exceptions, 'backend', '2026-07-20');
+
+    expect(failures).toHaveLength(1);
+  });
+
+  it('does not apply an exception scoped to a different package path', () => {
+    const vulnerabilities = {
+      'form-data': vuln('form-data', 'high', ['https://github.com/advisories/GHSA-hmw2-7cc7-3qxx']),
+    };
+    const exceptions = [
+      {
+        id: 'GHSA-hmw2-7cc7-3qxx',
+        package: 'form-data',
+        path: 'frontend',
+        expires: '2026-12-31',
+      },
+    ];
+
+    const failures = findUnexceptedVulnerabilities(vulnerabilities, exceptions, 'backend', '2026-07-20');
+
+    expect(failures).toHaveLength(1);
+  });
+
+  it('ignores transitive-only entries whose via list has no advisory objects', () => {
+    const vulnerabilities = {
+      bullmq: { name: 'bullmq', severity: 'high', via: ['uuid'] },
+    };
+
+    expect(findUnexceptedVulnerabilities(vulnerabilities, [], 'backend', '2026-07-20')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`docs/dependency-triage.md` sanctioned deferring an unpatched high/critical `npm audit` finding by writing free-text prose into `docs/security.md`, but nothing checked that the documentation step ever actually happened before the deferral took effect — CI just ran `npm audit --audit-level=high` directly, with no awareness of any "exception." This PR replaces that with an enforced, machine-readable exception mechanism.

## What changed

- **`security-exceptions.json`** (new, repo root) — a machine-readable list of deferred advisories. Each entry has `id` (GHSA slug), `package`, `path` (which of `.`/`backend`/`frontend` it applies to), `severity`, `reason`, `issue` link, `added`, and `expires`. Starts empty — no exceptions currently exist.
- **`scripts/check-dependency-audit.js`** (new) — runs `npm audit --json` for a given package path and fails if any `high`/`critical` advisory has no matching entry in `security-exceptions.json` whose `expires` date hasn't passed. An expired exception is treated as if it never existed, so the build goes red again until it's renewed (forcing a fresh look at whether a fix has since landed) or the vulnerability is actually fixed.
- **`.github/workflows/ci.yml`** — the three `npm audit --audit-level=high` steps (root, backend, frontend) now call the new script instead.
- **`docs/dependency-triage.md`** — the "When CI Fails with a Vulnerability" section now documents the `security-exceptions.json` entry format instead of pointing at free-text `docs/security.md` prose.
- **`docs/security.md`** — added a short section pointing at `security-exceptions.json` as the source of truth for deferred vulnerabilities, replacing the (never-used) prose-based process.
- **`tests/checkDependencyAudit.test.js`** (new) — unit tests for the exception-matching logic: flags unexcepted high/critical advisories, ignores moderate/low, honors a current exception, treats an expired exception as absent, scopes exceptions to the correct package path, and ignores transitive-only `via` entries with no advisory URL.

## Why this shape

- Exceptions are matched on `(path, package, advisory id, expires)` rather than just package name, so an exception for one CVE doesn't silently cover a *different*, later CVE in the same package.
- Expiration is enforced by the script itself (not just documented as a convention), so a deferred vulnerability can't persist indefinitely without periodic re-review, per the issue's acceptance criteria.

## Note on pre-existing audit failures

Running the new script locally against `.`, `backend`, and `frontend` on `main` surfaces multiple already-present high/critical advisories (e.g. `axios`, `next`, `nodemailer`, `tmp`, `picomatch`) with fix-avoidance requiring breaking upgrades. These are **pre-existing** and unrelated to this issue — CI on `main` is already red for these before this change (see recent failed runs on `main`). This PR doesn't fix them; that's separate dependency-upgrade work. I deliberately did not add exception entries for them either, since I can't make the "safe to defer" exploitability call documented in `docs/dependency-triage.md` step 4 — that requires per-advisory judgment from whoever owns the fix.

## Test plan

- [x] `node scripts/check-dependency-audit.js .` / `backend` / `frontend` run against real `npm audit --json` output and correctly report unexcepted high/critical findings.
- [x] `npx jest tests/checkDependencyAudit.test.js` — all 6 cases pass.
- [x] `node -c scripts/check-dependency-audit.js` — no syntax errors.
- [x] `security-exceptions.json` validated as well-formed JSON.

Closes #1120