### PR TITLE
fix: serialize student balance updates in verifyPayment and sync

### DIFF
--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -32,6 +32,12 @@ const logger = require('../utils/logger');
 // round-trip; 30 s is more than enough while still auto-expiring on crash.
 const VERIFY_LOCK_TTL_MS = parseInt(process.env.VERIFY_LOCK_TTL_MS || '30000', 10);
 
+// TTL for the per-student balance lock (#1026). Guards the read-aggregate-then-write
+// sequence that computes cumulativeTotal and writes it as an absolute Student.$set,
+// which is not safe to run concurrently for the same student — whether the second
+// writer is another verifyPayment call or syncPaymentsForSchool.
+const STUDENT_BALANCE_LOCK_TTL_MS = parseInt(process.env.STUDENT_BALANCE_LOCK_TTL_MS || '15000', 10);
+
 // Permanent error codes that should NOT be retried
 const PERMANENT_FAIL_CODES = [
   'TX_FAILED',
@@ -349,80 +355,100 @@ async function verifyPayment(req, res, next) {
         await PaymentIntent.findByIdAndUpdate(intent._id, { status: 'expired' });
       }
 
-      // Determine cumulative feeValidationStatus (#846).
-      // Partial payments (amount < fee) are accepted — money is already on-chain.
-      // The cumulative total drives the status; per-payment underpaid rejection
-      // is not applied here because a parent may be paying in installments.
-      const prevAgg = await Payment.aggregate([
-        { $match: { schoolId, studentId: studentStrId, deletedAt: null, status: 'SUCCESS' } },
-        { $group: { _id: null, total: { $sum: '$amount' } } },
-      ]);
-      const prevTotal = prevAgg.length ? prevAgg[0].total : 0;
-      const cumulativeTotal = parseFloat((prevTotal + result.amount).toFixed(7));
-      let feeValidationStatus;
-      if (cumulativeTotal < studentObj.feeAmount) feeValidationStatus = 'partial';
-      else if (cumulativeTotal > studentObj.feeAmount) feeValidationStatus = 'overpaid';
-      else feeValidationStatus = 'valid';
-      const computedExcessAmount = feeValidationStatus === 'overpaid'
-        ? parseFloat((cumulativeTotal - studentObj.feeAmount).toFixed(7))
-        : 0;
-
-      const now = new Date();
-      try {
-        await recordPayment({
-          schoolId,
-          studentId: studentStrId,
-          txHash: result.hash,
-          amount: result.amount,
-          feeAmount: result.feeAmount || studentObj.feeAmount,
-          feeValidationStatus,
-          excessAmount: computedExcessAmount,
-          networkFee: result.networkFee,
-          status: 'SUCCESS',
-          memo: result.memo,
-          senderAddress: result.senderAddress || null,
-          ledgerSequence: result.ledger || null,
-          confirmationStatus: 'confirmed',
-          confirmedAt: result.date ? new Date(result.date) : now,
-          verifiedAt: now,
-        });
-      } catch (dupErr) {
-        if (dupErr.code === 'DUPLICATE_TX') {
-          // Concurrent path (poller or another verify call) already recorded this tx.
-          // Fetch and return the existing record as a cache hit.
-          const cached = await Payment.findOne({ schoolId, txHash: normalizedHash });
-          if (cached) {
-            await audit.success({ txHash: normalizedHash, cached: true, studentId: studentStrId, amount: cached.amount });
-            const targetCurrency = req.school.localCurrency || 'USD';
-            const cachedConv = await convertToLocalCurrency(cached.amount, cached.assetCode || 'XLM', targetCurrency);
-            return res.json({
-              verified: true, cached: true, hash: cached.txHash,
-              stellarExplorerUrl: getExplorerUrl(cached.txHash), explorerUrl: getExplorerUrl(cached.txHash),
-              memo: cached.memo, studentId: cached.studentId, amount: cached.amount,
-              assetCode: cached.assetCode, feeAmount: cached.feeAmount,
-              feeValidation: { status: cached.feeValidationStatus, excessAmount: cached.excessAmount },
-              date: cached.confirmedAt || cached.createdAt, status: cached.status,
-              localCurrency: {
-                amount: cachedConv.available ? cachedConv.localAmount : null,
-                currency: cachedConv.currency, rate: cachedConv.rate,
-                rateTimestamp: cachedConv.rateTimestamp, available: cachedConv.available,
-              },
-            });
-          }
-        }
-        throw dupErr;
+      // Issue #1026 — the tx-hash lock above only prevents two calls for the SAME
+      // transaction from racing; two DIFFERENT transactions for the same student
+      // can still verify concurrently. The balance write below is a non-atomic
+      // read-aggregate-then-absolute-write, so it also needs a lock scoped to the
+      // student, shared with syncPaymentsForSchool's equivalent section so the two
+      // code paths serialize against each other too.
+      const studentLockKey = lock.studentBalanceLockKey(schoolId, studentStrId);
+      const studentLockInfo = await lock.acquire(studentLockKey, STUDENT_BALANCE_LOCK_TTL_MS);
+      if (!studentLockInfo) {
+        return res.status(409).json({ error: 'Sync already in progress', code: 'SYNC_IN_PROGRESS' });
       }
+      const studentLockToken = studentLockInfo.token;
 
-      // Update student record immediately after recording (#846) — sync path also does
-      // this, but the verify path never did, leaving totalPaid/remainingBalance stale.
-      await Student.findOneAndUpdate(
-        { schoolId, studentId: studentStrId },
-        {
-          totalPaid: cumulativeTotal,
-          remainingBalance: parseFloat(Math.max(0, studentObj.feeAmount - cumulativeTotal).toFixed(7)),
-          feePaid: cumulativeTotal >= studentObj.feeAmount,
-        },
-      );
+      let cumulativeTotal;
+      let feeValidationStatus;
+      let computedExcessAmount;
+      let now;
+      try {
+        // Determine cumulative feeValidationStatus (#846).
+        // Partial payments (amount < fee) are accepted — money is already on-chain.
+        // The cumulative total drives the status; per-payment underpaid rejection
+        // is not applied here because a parent may be paying in installments.
+        const prevAgg = await Payment.aggregate([
+          { $match: { schoolId, studentId: studentStrId, deletedAt: null, status: 'SUCCESS' } },
+          { $group: { _id: null, total: { $sum: '$amount' } } },
+        ]);
+        const prevTotal = prevAgg.length ? prevAgg[0].total : 0;
+        cumulativeTotal = parseFloat((prevTotal + result.amount).toFixed(7));
+        if (cumulativeTotal < studentObj.feeAmount) feeValidationStatus = 'partial';
+        else if (cumulativeTotal > studentObj.feeAmount) feeValidationStatus = 'overpaid';
+        else feeValidationStatus = 'valid';
+        computedExcessAmount = feeValidationStatus === 'overpaid'
+          ? parseFloat((cumulativeTotal - studentObj.feeAmount).toFixed(7))
+          : 0;
+
+        now = new Date();
+        try {
+          await recordPayment({
+            schoolId,
+            studentId: studentStrId,
+            txHash: result.hash,
+            amount: result.amount,
+            feeAmount: result.feeAmount || studentObj.feeAmount,
+            feeValidationStatus,
+            excessAmount: computedExcessAmount,
+            networkFee: result.networkFee,
+            status: 'SUCCESS',
+            memo: result.memo,
+            senderAddress: result.senderAddress || null,
+            ledgerSequence: result.ledger || null,
+            confirmationStatus: 'confirmed',
+            confirmedAt: result.date ? new Date(result.date) : now,
+            verifiedAt: now,
+          });
+        } catch (dupErr) {
+          if (dupErr.code === 'DUPLICATE_TX') {
+            // Concurrent path (poller or another verify call) already recorded this tx.
+            // Fetch and return the existing record as a cache hit.
+            const cached = await Payment.findOne({ schoolId, txHash: normalizedHash });
+            if (cached) {
+              await audit.success({ txHash: normalizedHash, cached: true, studentId: studentStrId, amount: cached.amount });
+              const targetCurrency = req.school.localCurrency || 'USD';
+              const cachedConv = await convertToLocalCurrency(cached.amount, cached.assetCode || 'XLM', targetCurrency);
+              return res.json({
+                verified: true, cached: true, hash: cached.txHash,
+                stellarExplorerUrl: getExplorerUrl(cached.txHash), explorerUrl: getExplorerUrl(cached.txHash),
+                memo: cached.memo, studentId: cached.studentId, amount: cached.amount,
+                assetCode: cached.assetCode, feeAmount: cached.feeAmount,
+                feeValidation: { status: cached.feeValidationStatus, excessAmount: cached.excessAmount },
+                date: cached.confirmedAt || cached.createdAt, status: cached.status,
+                localCurrency: {
+                  amount: cachedConv.available ? cachedConv.localAmount : null,
+                  currency: cachedConv.currency, rate: cachedConv.rate,
+                  rateTimestamp: cachedConv.rateTimestamp, available: cachedConv.available,
+                },
+              });
+            }
+          }
+          throw dupErr;
+        }
+
+        // Update student record immediately after recording (#846) — sync path also does
+        // this, but the verify path never did, leaving totalPaid/remainingBalance stale.
+        await Student.findOneAndUpdate(
+          { schoolId, studentId: studentStrId },
+          {
+            totalPaid: cumulativeTotal,
+            remainingBalance: parseFloat(Math.max(0, studentObj.feeAmount - cumulativeTotal).toFixed(7)),
+            feePaid: cumulativeTotal >= studentObj.feeAmount,
+          },
+        );
+      } finally {
+        await lock.release(studentLockKey, studentLockToken);
+      }
 
       await audit.success({
         txHash: normalizedHash,

--- a/backend/src/services/distributedLock.js
+++ b/backend/src/services/distributedLock.js
@@ -98,6 +98,19 @@ function newToken() {
 }
 
 /**
+ * Canonical lock key for the read-aggregate-then-write balance section that
+ * both verifyPayment (paymentController) and syncPaymentsForSchool
+ * (stellarService) run for a given student. Shared here so the two call
+ * sites can never drift into different key formats and silently stop
+ * contending with each other (#1026).
+ * @param {string} schoolId
+ * @param {string} studentId
+ */
+function studentBalanceLockKey(schoolId, studentId) {
+  return `sync:lock:${schoolId}:student:${studentId}`;
+}
+
+/**
  * Get fencing token counter key for a lock key.
  */
 function getFenceKey(key) {
@@ -294,6 +307,7 @@ module.exports = {
   withLock,
   getCurrentFence,
   startWatchdog,
+  studentBalanceLockKey,
   close,
   _isRedisEnabled: () => Boolean(client),
   _getFenceKey: getFenceKey,

--- a/backend/src/services/stellarService.js
+++ b/backend/src/services/stellarService.js
@@ -21,6 +21,7 @@ const {
 const { withStellarRetry } = require("../utils/withStellarRetry");
 const { savePayment } = require("./transactionService");
 const { deriveCorrelationId } = require("../utils/correlationId");
+const lock = require("./distributedLock");
 const {
   CONFIRMATION_STATES,
   computeTargetState,
@@ -29,6 +30,13 @@ const {
   isConfirmedOrAbove,
 } = require("./paymentConfirmationStateMachine");
 const logger = require("../utils/logger").child("StellarService");
+
+// TTL for the per-student balance lock (#1026), shared with paymentController's
+// verifyPayment. Guards the read-aggregate-then-write sequence that computes
+// cumulativeTotal and writes it as an absolute Student.$set — unsafe to run
+// concurrently for the same student, whether the other writer is verifyPayment
+// or another syncPaymentsForSchool run.
+const STUDENT_BALANCE_LOCK_TTL_MS = parseInt(process.env.STUDENT_BALANCE_LOCK_TTL_MS || "15000", 10);
 
 function detectAsset(payOp) {
   const assetType = payOp.asset_type;
@@ -741,6 +749,22 @@ async function syncPaymentsForSchool(school) {
       const feeAmountForRecord = intent ? intent.amount : student.feeAmount;
       const feeCategory = intent ? (intent.feeCategory || null) : null;
 
+      // Issue #1026 — the balance write below is a non-atomic read-aggregate-then-
+      // absolute-write. It races against another sync pass touching the same
+      // student, and against verifyPayment's equivalent section, unless both hold
+      // this shared per-student lock around it.
+      const studentLockKey = lock.studentBalanceLockKey(schoolId, studentId);
+      const studentLockInfo = await lock.acquire(studentLockKey, STUDENT_BALANCE_LOCK_TTL_MS);
+      if (!studentLockInfo) {
+        // A concurrent verify/sync is updating this student's balance right now.
+        // Skip this transaction for this pass — it will be picked up on the next
+        // sync run once the in-flight update releases the lock.
+        summary.failed++;
+        summary.failedDetails.push({ txHash: tx.hash, reason: 'STUDENT_BALANCE_LOCK_CONTENDED' });
+        continue;
+      }
+      const studentLockToken = studentLockInfo.token;
+
       const previousPayments = await Payment.aggregate([
         { $match: { schoolId, studentId, deletedAt: null } },
         { $group: { _id: null, total: { $sum: "$amount" } } },
@@ -860,6 +884,7 @@ async function syncPaymentsForSchool(school) {
         throw saveErr;
       } finally {
         if (session) await session.endSession();
+        await lock.release(studentLockKey, studentLockToken);
       }
       newPayments++;
 


### PR DESCRIPTION
## Summary
- Two different transactions for the same student could verify concurrently in `verifyPayment` because the existing lock is keyed by `(schoolId, txHash)`, not by student. Each call independently read the same pre-write `Payment.aggregate` total and wrote it back as an absolute `$set`, so the last writer silently discarded the other transaction's contribution to `totalPaid`/`remainingBalance`/`feePaid`.
- `syncPaymentsForSchool` had the same non-atomic read-aggregate-then-write shape and no protection against racing a concurrent `verifyPayment` (or another sync run) for the same student.
- Added `distributedLock.studentBalanceLockKey(schoolId, studentId)` and acquire/release the lock around the read-aggregate-then-write section in both `verifyPayment` (`backend/src/controllers/paymentController.js`) and `syncPaymentsForSchool` (`backend/src/services/stellarService.js`), so both code paths now serialize against each other and against themselves for the same student.

Closes #1026

## Test plan
- [x] `backend/tests/paymentDistributedLock.test.js` — passes
- [x] `backend/tests/issue69-syncDistributedLock.test.js` — passes
- [x] `tests/payment.test.js` (59 tests, exercises the real `verifyPayment` lock path against the in-process lock fallback) — passes
- [ ] New regression tests for this issue were intentionally skipped per task instructions

