### PR TITLE
fix: add PodDisruptionBudget for backend deployment

### DIFF
--- a/deploy/k8s/backend-pdb.yaml
+++ b/deploy/k8s/backend-pdb.yaml
@@ -1,0 +1,15 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: backend
+  labels:
+    app: backend
+spec:
+  # backend-deployment.yaml runs replicas: 2 — require at least one pod to stay
+  # available during any voluntary disruption (node drain, cluster autoscaler
+  # scale-down, managed-cluster upgrade) so routine maintenance can never take
+  # the payment backend fully offline.
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: backend

--- a/tests/issue1091-backendPodDisruptionBudget.test.js
+++ b/tests/issue1091-backendPodDisruptionBudget.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+/**
+ * Tests for Issue #1091 — no PodDisruptionBudget for the backend deployment.
+ *
+ * Acceptance criteria:
+ *   1. A PodDisruptionBudget exists for the backend deployment.
+ *   2. It constrains voluntary disruption so at least one of the 2 replicas
+ *      stays available (minAvailable >= 1, or an equivalent maxUnavailable).
+ *
+ * The actual "simulated node drain against a test cluster" half of the
+ * acceptance criteria requires a live cluster and is out of scope for this
+ * Jest suite; this validates the manifest statically instead.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const K8S_DIR = path.join(__dirname, '..', 'deploy', 'k8s');
+
+function loadYaml(filename) {
+  const raw = fs.readFileSync(path.join(K8S_DIR, filename), 'utf8');
+  return yaml.load(raw);
+}
+
+describe('Issue #1091 — backend PodDisruptionBudget', () => {
+  const deployment = loadYaml('backend-deployment.yaml');
+  const pdb = loadYaml('backend-pdb.yaml');
+
+  it('the backend Deployment still runs 2 replicas', () => {
+    expect(deployment.kind).toBe('Deployment');
+    expect(deployment.spec.replicas).toBe(2);
+  });
+
+  it('a PodDisruptionBudget resource exists', () => {
+    expect(pdb.kind).toBe('PodDisruptionBudget');
+    expect(pdb.apiVersion).toBe('policy/v1');
+  });
+
+  it('selects the backend deployment pods', () => {
+    expect(pdb.spec.selector.matchLabels).toEqual(deployment.spec.selector.matchLabels);
+  });
+
+  it('guarantees at least one pod survives a voluntary disruption', () => {
+    const { minAvailable, maxUnavailable } = pdb.spec;
+
+    if (minAvailable !== undefined) {
+      expect(minAvailable).toBeGreaterThanOrEqual(1);
+    } else if (maxUnavailable !== undefined) {
+      expect(maxUnavailable).toBeLessThan(deployment.spec.replicas);
+    } else {
+      throw new Error('PodDisruptionBudget must define minAvailable or maxUnavailable');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `backend-deployment.yaml` runs `replicas: 2` but no `PodDisruptionBudget` existed anywhere in `deploy/k8s/`, so a routine voluntary disruption (node drain, cluster autoscaler scale-down, managed-cluster upgrade) could legally evict both replicas at once — a full outage of the payment backend during otherwise routine maintenance.
- Adds `deploy/k8s/backend-pdb.yaml`: a `PodDisruptionBudget` (`policy/v1`) with `minAvailable: 1`, scoped to the same `app: backend` selector as the Deployment, so at least one pod always stays available during voluntary disruptions.

Closes #1091

## Test plan
- [x] `tests/issue1091-backendPodDisruptionBudget.test.js` — statically validates the manifest: the PDB exists, targets the backend deployment's pods, and guarantees `minAvailable`/`maxUnavailable` leaves at least one of the 2 replicas up.
- [ ] Acceptance criteria also calls for a simulated node drain against a live test cluster — out of scope for this repo's Jest suite; recommend validating with `kubectl drain` against a staging cluster before merge.

Closes #1091