### PR TITLE
test: verify indexes and field content in backup-recovery test (closes #1107)

### DIFF
--- a/scripts/test-backup-recovery.sh
+++ b/scripts/test-backup-recovery.sh
@@ -4,6 +4,15 @@
 # Requires: mongodump, mongorestore, mongosh (or mongo) on PATH.
 # Spins up nothing — runs against an already-running MongoDB instance.
 #
+# What this verifies (a matching document count alone is NOT enough for a
+# financial application — see issue #1107):
+#   1. Document count per the whole database matches before vs after.
+#   2. Every index present before the backup is present after the restore
+#      (name + key spec), so uniqueness/performance guarantees survive.
+#   3. A full field-level content fingerprint matches before vs after, so a
+#      dropped/garbled/swapped field or a corrupted subset of documents is
+#      caught even when the total count is unchanged.
+#
 # Usage:
 #   MONGO_URI=mongodb://localhost:27017/stellaredupay \
 #   ./scripts/test-backup-recovery.sh
@@ -11,18 +20,58 @@
 set -euo pipefail
 
 MONGO_URI="${MONGO_URI:?MONGO_URI is required}"
+DB_NAME="${DB_NAME:-stellaredupay}"
 TEST_BACKUP_DIR="$(mktemp -d)"
 BACKUP_FILE="${TEST_BACKUP_DIR}/test-backup.gz"
 
 cleanup() { rm -rf "${TEST_BACKUP_DIR}"; }
 trap cleanup EXIT
 
-echo "=== [1/4] Counting documents before backup ==="
-BEFORE=$(mongosh --quiet --eval \
-  "db.getSiblingDB('stellaredupay').getCollectionNames()
-     .reduce((n,c) => n + db.getSiblingDB('stellaredupay').getCollection(c).countDocuments(), 0)" \
-  "${MONGO_URI}" 2>/dev/null || echo "0")
-echo "    Documents before: ${BEFORE}"
+# Total document count across every collection in the database.
+count_documents() {
+  mongosh --quiet --eval \
+    "db.getSiblingDB('${DB_NAME}').getCollectionNames()
+       .reduce((n,c) => n + db.getSiblingDB('${DB_NAME}').getCollection(c).countDocuments(), 0)" \
+    "${MONGO_URI}" 2>/dev/null || echo "0"
+}
+
+# Emit one stable line per index as "collection|indexName|keySpec", sorted.
+# Used to detect any index that fails to come back after a restore.
+index_manifest() {
+  mongosh --quiet --eval "
+    const database = db.getSiblingDB('${DB_NAME}');
+    const lines = [];
+    database.getCollectionNames().forEach(function (name) {
+      database.getCollection(name).getIndexes().forEach(function (idx) {
+        lines.push(name + '|' + idx.name + '|' + EJSON.stringify(idx.key));
+      });
+    });
+    lines.sort().forEach(function (l) { print(l); });
+  " "${MONGO_URI}" 2>/dev/null
+}
+
+# Full field-level content fingerprint: canonical extended JSON of every
+# document (sorted by _id, within collections sorted by name), hashed. Any
+# changed/dropped/swapped field value flips the hash — no sampling gaps.
+content_fingerprint() {
+  mongosh --quiet --eval "
+    const database = db.getSiblingDB('${DB_NAME}');
+    database.getCollectionNames().sort().forEach(function (name) {
+      print('### ' + name);
+      database.getCollection(name).find().sort({ _id: 1 }).forEach(function (doc) {
+        print(EJSON.stringify(doc, { relaxed: false }));
+      });
+    });
+  " "${MONGO_URI}" 2>/dev/null | sha256sum | cut -d' ' -f1
+}
+
+echo "=== [1/4] Fingerprinting database before backup ==="
+BEFORE_COUNT="$(count_documents)"
+index_manifest > "${TEST_BACKUP_DIR}/indexes-before.txt"
+BEFORE_CONTENT="$(content_fingerprint)"
+echo "    Documents:   ${BEFORE_COUNT}"
+echo "    Indexes:     $(wc -l < "${TEST_BACKUP_DIR}/indexes-before.txt")"
+echo "    Content sha: ${BEFORE_CONTENT}"
 
 echo "=== [2/4] Running backup ==="
 MONGO_URI="${MONGO_URI}" BACKUP_DIR="${TEST_BACKUP_DIR}" \
@@ -38,19 +87,46 @@ echo "=== [3/4] Running restore (drop + reimport) ==="
 MONGO_URI="${MONGO_URI}" BACKUP_FILE="${BACKUP_FILE}" DROP="true" \
   bash "$(dirname "$0")/restore.sh"
 
-echo "=== [4/4] Verifying document count after restore ==="
-AFTER=$(mongosh --quiet --eval \
-  "db.getSiblingDB('stellaredupay').getCollectionNames()
-     .reduce((n,c) => n + db.getSiblingDB('stellaredupay').getCollection(c).countDocuments(), 0)" \
-  "${MONGO_URI}" 2>/dev/null || echo "0")
-echo "    Documents after:  ${AFTER}"
+echo "=== [4/4] Verifying restored database against pre-backup fingerprint ==="
+AFTER_COUNT="$(count_documents)"
+index_manifest > "${TEST_BACKUP_DIR}/indexes-after.txt"
+AFTER_CONTENT="$(content_fingerprint)"
+echo "    Documents:   ${AFTER_COUNT}"
+echo "    Indexes:     $(wc -l < "${TEST_BACKUP_DIR}/indexes-after.txt")"
+echo "    Content sha: ${AFTER_CONTENT}"
 
-if [[ "${BEFORE}" == "${AFTER}" ]]; then
-  echo ""
-  echo "✅  PASS — document count matches (${AFTER}). Data can be restored successfully."
+FAILED=0
+
+# Check 1 — document count.
+if [[ "${BEFORE_COUNT}" != "${AFTER_COUNT}" ]]; then
+  echo "❌  Document count mismatch: before=${BEFORE_COUNT}, after=${AFTER_COUNT}." >&2
+  FAILED=1
+fi
+
+# Check 2 — every index present before must be present after. Lines in the
+# before-manifest that are absent from the after-manifest are missing indexes.
+MISSING_INDEXES="$(comm -23 \
+  "${TEST_BACKUP_DIR}/indexes-before.txt" \
+  "${TEST_BACKUP_DIR}/indexes-after.txt")"
+if [[ -n "${MISSING_INDEXES}" ]]; then
+  echo "❌  Restore is missing indexes present in the source:" >&2
+  echo "${MISSING_INDEXES}" | sed 's/^/      - /' >&2
+  FAILED=1
+fi
+
+# Check 3 — field-level content fingerprint.
+if [[ "${BEFORE_CONTENT}" != "${AFTER_CONTENT}" ]]; then
+  echo "❌  Field-level content mismatch: a document field was dropped, garbled," >&2
+  echo "    or swapped during the round trip (content hash differs)." >&2
+  FAILED=1
+fi
+
+echo ""
+if [[ "${FAILED}" -eq 0 ]]; then
+  echo "✅  PASS — document count, indexes, and field-level content all match."
+  echo "    The backup is safely restorable."
   exit 0
 else
-  echo ""
-  echo "❌  FAIL — before=${BEFORE}, after=${AFTER}. Counts do not match." >&2
+  echo "❌  FAIL — the restored database does not faithfully match the source." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary
`scripts/test-backup-recovery.sh` reported **PASS** on a matching total document count alone. A restore that dropped an index, or dropped/garbled/swapped a field across documents while leaving the total count unchanged, still passed — dangerously weak for a financial application's data integrity.

## Changes
The round-trip verification now captures a fingerprint **before** the backup and re-checks it **after** the restore, across three dimensions:

1. **Document count** — total across all collections (as before).
2. **Index manifest** — per-collection `name + key spec`; the test **fails if any index present in the source is missing** after the restore (uniqueness/performance guarantees).
3. **Field-level content fingerprint** — canonical extended JSON (`EJSON.stringify({ relaxed: false })`) of every document, sorted by `_id` within name-sorted collections, hashed with `sha256sum`. Any dropped, garbled, or swapped field flips the hash — a full comparison, not a sampled one.

Each check reports independently and the script exits non-zero if any fails.

## Acceptance criteria
- ✅ Fails if the restored DB is missing any index present in the source (`comm -23` of the before/after index manifests).
- ✅ Fails if a field-level comparison detects any discrepancy beyond document count (content hash mismatch).
- ✅ A deliberately corrupted restore (e.g. a dropped index or a mutated field) flips the corresponding manifest/hash and the script correctly reports failure.

`bash -n` clean.

Closes #1107
