### PR TITLE
fix: run verified backup.sh from compose backup service (closes #1106)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,29 +93,33 @@ services:
       start_period: 10s
     restart: unless-stopped
 
-  # Runs a mongodump every 24 hours and retains 7 days of backups.
+  # Runs scripts/backup.sh every 24 hours and retains RETAIN_DAYS of backups.
   # Backups are written to the host path defined by BACKUP_DIR (default: ./backups).
+  #
+  # This deliberately invokes the SAME verified scripts/backup.sh used for
+  # manual/CI backups rather than a raw mongodump call, so the compose-embedded
+  # path carries identical integrity guarantees (minimum-size check +
+  # mongorestore --dryRun verification + retention pruning). See issue #1106 —
+  # there is now a single, well-verified backup implementation, not two.
   backup:
     image: mongo:7
     entrypoint: >
-      /bin/sh -c '
+      /bin/bash -c '
         while true; do
           echo "[backup] $(date -u) — starting backup";
-          mongodump
-            --uri="$$MONGO_URI"
-            --archive="/backups/$$(date -u +%Y%m%dT%H%M%SZ).gz"
-            --gzip &&
-          echo "[backup] done" ||
-          echo "[backup] FAILED";
-          find /backups -name "*.gz" -mtime +$$RETAIN_DAYS -delete;
+          bash /scripts/backup.sh || echo "[backup] FAILED";
           sleep 86400;
         done
       '
     environment:
       - MONGO_URI=mongodb://${MONGO_ROOT_USERNAME:-root}:${MONGO_ROOT_PASSWORD:-password}@mongo:27017/stellaredupay?authSource=admin
+      - BACKUP_DIR=/backups
       - RETAIN_DAYS=${RETAIN_DAYS:-7}
+      - MIN_BACKUP_SIZE=${MIN_BACKUP_SIZE:-1024}
+      - WEBHOOK_URL=${WEBHOOK_URL:-}
     volumes:
       - ${BACKUP_DIR:-./backups}:/backups
+      - ./scripts:/scripts:ro
     depends_on:
       mongo:
         condition: service_healthy


### PR DESCRIPTION
## Summary
The scheduled backup loop embedded in `docker-compose.yml` ran a raw `mongodump` with **no minimum-size check** and **no `mongorestore --dryRun` verification** — strictly weaker guarantees than `scripts/backup.sh`, yet it is the backup path most compose-based deployments actually run. Operators could accumulate months of unverified, possibly-corrupt backups, only discovering the problem during an actual disaster-recovery attempt.

## Changes
The compose `backup` service now invokes the **same verified `scripts/backup.sh`** rather than a divergent inline `mongodump`:

- Mounts `./scripts` into the container read-only (`./scripts:/scripts:ro`).
- Loop entrypoint runs `bash /scripts/backup.sh` every 24h.
- Passes `BACKUP_DIR`, `RETAIN_DAYS`, `MIN_BACKUP_SIZE`, and `WEBHOOK_URL` through as env vars.

This inherits `backup.sh`'s minimum-size check, `mongorestore --dryRun` integrity verification, retention pruning, and webhook failure alerts. There is now a **single, well-verified backup implementation** used consistently by both the manual/CI and scheduled compose paths.

## Acceptance criteria
- ✅ The backup mechanism used by the default `docker-compose.yml` deployment now includes the same integrity verification as `scripts/backup.sh`.
- ✅ A single documented, verified backup implementation rather than two divergent ones.

`docker compose config` validates cleanly.

Closes #1106
