### PR TITLE
docs: reconcile IMPLEMENTATION_SUMMARY.md vs later issue backlogs

### DIFF
--- a/GITHUB_ISSUES.md
+++ b/GITHUB_ISSUES.md
@@ -4,6 +4,8 @@
 
 ## Issue #1: `syncAllPayments` calls `syncPaymentsForSchool` twice and sends two HTTP responses
 
+> **STATUS: RESOLVED (fixed before this document was compiled).** This entry derives from the `issues.md` audit dated 2026-05-26, one day before the fix landed in `fix/559-560-561-562` (see `IMPLEMENTATION_SUMMARY.md`, 2026-05-27). Current code (`backend/src/controllers/paymentAdminController.js`) calls `syncPaymentsForSchool` and `res.json` exactly once. Independently re-confirmed by `CHANGELOG.md` issue #731. See `SECURITY_STATUS_RECONCILIATION.md`.
+
 **Labels:** `bug`, `critical`, `backend`
 
 ### Problem
@@ -48,6 +50,8 @@ async function syncAllPayments(req, res, next) {
 ---
 
 ## Issue #2: `GET /api/payments/:studentId` lacks cross-school isolation tests
+
+> **STATUS: RESOLVED (fixed before this document was compiled).** This entry derives from the `issues.md` audit dated 2026-05-26, before the fix in `IMPLEMENTATION_SUMMARY.md` (2026-05-27, issue #561) landed. Current code (`backend/src/controllers/paymentQueryController.js`) scopes the student lookup, payment find/count, and both balance aggregations by `schoolId`. `tests/cross-school-isolation.test.js` and `backend/tests/cross-school-isolation.test.js` exist and are substantial. Note: the separate, still-open issue is that `resolveSchool` trusts the `X-School-ID`/`X-School-Slug` header alone on read endpoints when no JWT is present — a different problem from this one. See `SECURITY_STATUS_RECONCILIATION.md`.
 
 **Labels:** `bug`, `security`, `multi-school`
 
@@ -129,6 +133,8 @@ res.json({
 ---
 
 ## Issue #5: Write endpoints for students, fees, and schools have no authentication
+
+> **STATUS: RESOLVED (fixed before this document was compiled).** This entry derives from the `issues.md` audit dated 2026-05-26, before the fix in `IMPLEMENTATION_SUMMARY.md` (2026-05-27, issue #562) landed. Every endpoint listed below now has `requireAdminAuth` applied in its route file. `tests/authentication-enforcement.test.js` exists and is substantial. See `SECURITY_STATUS_RECONCILIATION.md`.
 
 **Labels:** `security`, `critical`, `backend`
 

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,7 @@
 # Implementation Summary: Issues #559, #560, #561, #562
 
+> **Status check (2026-07-24):** Later backlog documents (`issues.md`, `GITHUB_ISSUES.md`, `PROJECT_ISSUES.md`) list what looks like the same three problems as still open. They don't contradict this document — their source audit predates this fix by one day and was never re-verified against it. This summary's claims were re-checked against current code and confirmed still accurate; see `SECURITY_STATUS_RECONCILIATION.md` for the full analysis.
+
 ## Overview
 This document summarizes the fixes implemented for four critical security and bug issues in the StellarEduPay backend.
 

--- a/PROJECT_ISSUES.md
+++ b/PROJECT_ISSUES.md
@@ -31,6 +31,8 @@
 
 ## Issue #1: `syncAllPayments` calls `syncPaymentsForSchool` twice and sends two HTTP responses
 
+> **STATUS: RESOLVED (fixed before this backlog was compiled).** This is one of the "#1-25 previously-tracked items... de-duplicated from `GITHUB_ISSUES.md`/`issues.md`" per this document's own header — carried forward from the 2026-05-26 pre-fix audit without re-verification, not independently re-checked on 2026-06-24. Current code has moved to `backend/src/controllers/paymentAdminController.js` and calls `syncPaymentsForSchool`/`res.json` exactly once. Independently re-confirmed by `CHANGELOG.md` issue #731. See `SECURITY_STATUS_RECONCILIATION.md`.
+
 **Labels:** `bug`, `critical`, `backend`
 
 ### Problem
@@ -55,6 +57,8 @@ Call the service once, log the audit, and send one response inside a `try/finall
 ---
 
 ## Issue #2: `GET /api/payments/:studentId` lacks cross-school isolation tests
+
+> **STATUS: RESOLVED (fixed before this backlog was compiled).** Carried forward from the 2026-05-26 pre-fix audit without re-verification (see this document's header note on issues #1-25). Current code (`backend/src/controllers/paymentQueryController.js`) scopes the student lookup, payment find/count, and both balance aggregations by `schoolId`. `tests/cross-school-isolation.test.js` and `backend/tests/cross-school-isolation.test.js` exist and are substantial. Note: the separate, still-open issue is that `resolveSchool` trusts the `X-School-ID`/`X-School-Slug` header alone on read endpoints when no JWT is present — a different problem from this one. See `SECURITY_STATUS_RECONCILIATION.md`.
 
 **Labels:** `bug`, `security`, `multi-school`, `testing`
 
@@ -117,6 +121,8 @@ Guarantee `getPaymentInstructions` returns the plaintext student ID as the memo.
 ---
 
 ## Issue #5: Write endpoints for students, fees, and schools have no authentication
+
+> **STATUS: RESOLVED (fixed before this backlog was compiled).** Carried forward from the 2026-05-26 pre-fix audit without re-verification (see this document's header note on issues #1-25). Every endpoint listed below now has `requireAdminAuth` applied in its route file. `tests/authentication-enforcement.test.js` exists and is substantial. See `SECURITY_STATUS_RECONCILIATION.md`.
 
 **Labels:** `security`, `critical`, `backend`
 

--- a/SECURITY_STATUS_RECONCILIATION.md
+++ b/SECURITY_STATUS_RECONCILIATION.md
@@ -1,0 +1,75 @@
+# Reconciliation: IMPLEMENTATION_SUMMARY.md vs. later issue backlogs (issues.md / GITHUB_ISSUES.md / PROJECT_ISSUES.md)
+
+**Verified against live code on:** 2026-07-24
+**Verified by:** Code inspection (file/line references below) + existing test suites + `CHANGELOG.md` history.
+
+## The contradiction
+
+`IMPLEMENTATION_SUMMARY.md` (added 2026-05-27, branch `fix/559-560-561-562`) claims three problems were fixed:
+
+1. `syncAllPayments` calling `syncPaymentsForSchool` twice / sending two responses (#559, #560)
+2. Cross-school data isolation gaps in payment queries (#561)
+3. Missing authentication on write endpoints (#562)
+
+`issues.md` / `GITHUB_ISSUES.md` (added 2026-06-11) and `PROJECT_ISSUES.md` (added 2026-06-30) — all dated *after* the summary — list what reads as the same three problems (their Issue #1, #2, #5) as open, with full problem/fix/acceptance-criteria writeups, as if unaddressed.
+
+## Verdict: the fixes are real and hold today. The later backlogs are stale for these three items.
+
+This is the counter-intuitive part: the *later* documents are the *less* accurate ones here. Chronology is not a reliable tiebreaker in this repo — the code is.
+
+### 1. Duplicate `syncAllPayments` call — FIXED, not regressed
+
+Current code: [backend/src/controllers/paymentAdminController.js:33-79](backend/src/controllers/paymentAdminController.js#L33-L79). `syncPaymentsForSchool(req.school)` is called exactly once (line 52), `res.json()` is called exactly once (line 68) inside the success path, with a separate single `res.json`/`next` on the error path. This function has since moved out of `paymentController.js` entirely (split into `paymentAdminController.js`) and gained a distributed Redis lock (`Issue #69`, see line 36-44) on top of the original fix — i.e. it has been touched and re-verified *again* since the original fix, and the duplicate-call bug did not reappear.
+
+Independent corroboration: `CHANGELOG.md` (Unreleased section, line 12) records a *second*, independent audit — **"Investigated duplicate sync bug (#731)"** — which re-checked this exact code path and concluded: *"Confirmed the code already calls `syncPaymentsForSchool` exactly once... No code change required."* That audit happened after the original fix and reached the same conclusion this reconciliation does.
+
+### 2. Cross-school data isolation — FIXED, not regressed
+
+Current code (now in `paymentQueryController.js` after the controller split):
+- `getStudentPayments`: student existence check scoped by `schoolId` ([paymentQueryController.js:63](backend/src/controllers/paymentQueryController.js#L63)), payment count/find both scoped by `schoolId` ([:71-73](backend/src/controllers/paymentQueryController.js#L71-L73)).
+- `getStudentBalance`: student lookup scoped by `schoolId` ([:190](backend/src/controllers/paymentQueryController.js#L190)), main balance aggregation `$match` includes `schoolId` ([:195](backend/src/controllers/paymentQueryController.js#L195)), category-breakdown sub-aggregation `$match` also includes `schoolId` ([:220](backend/src/controllers/paymentQueryController.js#L220)).
+
+`issues.md`'s version of this issue (its Issue 2, uniquely titled "is not scoped to the requesting school" rather than "lacks isolation tests") specifically alleged the category aggregation and top-level balance aggregation might drop the `schoolId` filter — that specific claim does not match current code; both aggregations include it.
+
+Both test suites named in the summary's acceptance criteria exist and are substantial (not stubs): `tests/cross-school-isolation.test.js` (282 lines) and `backend/tests/cross-school-isolation.test.js` (259 lines).
+
+### 3. Missing authentication on write endpoints — FIXED, not regressed
+
+Every endpoint the summary and the backlogs both named carries `requireAdminAuth` today:
+
+| Endpoint | Current state |
+|---|---|
+| `POST /api/students` | `requireAdminAuth` ([studentRoutes.js:33](backend/src/routes/studentRoutes.js#L33)) |
+| `PUT/DELETE /api/students/:studentId` | `requireAdminAuth` ([:43-44](backend/src/routes/studentRoutes.js#L43-L44)) |
+| `POST/PUT/DELETE /api/fees...` | `requireAdminAuth` ([feeRoutes.js:21,24,25](backend/src/routes/feeRoutes.js#L21)) |
+| `POST/PATCH/DELETE /api/schools...` | `requireAdminAuth` ([schoolRoutes.js:26-28](backend/src/routes/schoolRoutes.js#L26-L28)) |
+| `POST /api/payments/sync` | `requireAdminAuth` ([paymentRoutes.js:185](backend/src/routes/paymentRoutes.js#L185)) |
+| `PATCH /api/payments/:txHash/status` | `requireAdminAuth` ([paymentRoutes.js:202](backend/src/routes/paymentRoutes.js#L202)) |
+
+`tests/authentication-enforcement.test.js` (326 lines) exists and covers these paths.
+
+## Why the numbering differs (#559-562 vs #1/#2/#5)
+
+Confirmed as a renumbering across tracking eras, not evidence of a second, different problem: the titles, code snippets, and acceptance criteria in the backlog entries are near-verbatim restatements of the same three problems the summary describes as fixed. `PROJECT_ISSUES.md` and `GITHUB_ISSUES.md` even reuse "#1"/"#2"/"#5" as a fresh, standalone numbering scheme unrelated to the original GitHub issue numbers.
+
+## Root cause, confirmed from the documents' own self-reported metadata
+
+This isn't a guess — each backlog document states its own audit date, and those dates resolve the contradiction cleanly:
+
+- `issues.md` header: *"Generated from a full codebase audit on **2026-05-26**."* — **one day before** the fix landed (`IMPLEMENTATION_SUMMARY.md` / branch `fix/559-560-561-562`, 2026-05-27). The audit simply predates the fix. It was committed to git later (2026-06-11 per `git log`), which is what made it *look* like a later, more-authoritative document — it isn't; its content is older than the fix it appears to contradict.
+- `GITHUB_ISSUES.md`: same three issues, no audit date of its own, added to git the same commit as `issues.md` (2026-06-11) — evidently derived from the same 2026-05-26 pre-fix audit.
+- `PROJECT_ISSUES.md` header: *"Consolidated, de-duplicated issue backlog generated from a full codebase audit on **2026-06-24**... Issues #1–25 are the previously-tracked items (cleaned and de-duplicated from `GITHUB_ISSUES.md` / `issues.md`)."* — by its own admission, its Issue #1/#2/#5 are **carried forward from the same stale 2026-05-26 source**, not independently re-verified against code. The 2026-06-24 date describes when issues #26-150 (new findings) were audited, not when #1-25 were re-checked.
+
+So there is no regression and no mystery: one pre-fix audit produced the three "open" issues, and it was copied forward twice (into `GITHUB_ISSUES.md`, then consolidated into `PROJECT_ISSUES.md`) without ever being diffed against the fix that had already landed. Git history corroborates that the fixed code kept evolving correctly afterward — controller split into `paymentAdminController.js`/`paymentQueryController.js`, the Redis distributed lock work on top of the sync fix, and the independent #731 re-audit recorded in `CHANGELOG.md` — and the fixed behavior held through all of it.
+
+## Do not confuse this with the real, currently-open, related issues
+
+This audit independently confirmed two *different* problems that are real and open today — do not treat their existence as evidence the three issues above are also still open:
+
+- Most payment **read** endpoints trust the `X-School-ID`/`X-School-Slug` header alone, with JWT-based tenant binding only enforced when a token happens to be present (see `resolveSchool`, [backend/src/middleware/schoolContext.js:26-40](backend/src/middleware/schoolContext.js#L26-L40)). This is a header-trust gap on **reads**, distinct from the write-endpoint `requireAdminAuth` gap fixed in #562 — the two should not be conflated.
+- `concurrentPaymentProcessor` omitting `schoolId` scoping in one of its queries.
+
+## Disposition of the four documents
+
+- **`IMPLEMENTATION_SUMMARY.md`**: Accurate and current. Keep as-is; it documents a real fix that has held.
+- **`issues.md`, `GITHUB_ISSUES.md`, `PROJECT_ISSUES.md`**: Each contains many issues unrelated to this contradiction that are still legitimate (e.g. the header-trust and `concurrentPaymentProcessor` gaps above) — not archived wholesale. Instead, their Issue #1/#2/#5 entries have been annotated in place with a `RESOLVED` status note pointing back to this document, so a reader hitting those sections directly sees the correction without needing to find this file first.

--- a/issues.md
+++ b/issues.md
@@ -6,6 +6,8 @@
 
 ## Issue 1: `syncAllPayments` calls `syncPaymentsForSchool` twice and sends two responses
 
+> **STATUS: RESOLVED (fixed before this audit was committed).** This audit was generated 2026-05-26, one day before the fix landed in `fix/559-560-561-562` (see `IMPLEMENTATION_SUMMARY.md`, 2026-05-27), but was committed to git on 2026-06-11, making it look newer than the fix. Current code (`backend/src/controllers/paymentAdminController.js`) calls `syncPaymentsForSchool` and `res.json` exactly once. Independently re-confirmed by `CHANGELOG.md` issue #731. See `SECURITY_STATUS_RECONCILIATION.md`.
+
 **Labels:** `bug`, `critical`, `backend`
 
 ### Problem
@@ -69,6 +71,8 @@ async function syncAllPayments(req, res, next) {
 ---
 
 ## Issue 2: `GET /api/payments/:studentId` is not scoped to the requesting school
+
+> **STATUS: RESOLVED (fixed before this audit was committed).** This audit was generated 2026-05-26, before the fix in `IMPLEMENTATION_SUMMARY.md` (2026-05-27, issue #561) landed. Current code (`backend/src/controllers/paymentQueryController.js`) includes `schoolId` in the student lookup, the payment find/count, and both the top-level and category-breakdown balance aggregations. `tests/cross-school-isolation.test.js` and `backend/tests/cross-school-isolation.test.js` exist and are substantial. Note: the separate, still-open issue is that `resolveSchool` trusts the `X-School-ID`/`X-School-Slug` header alone on read endpoints when no JWT is present — that's a different problem from this one. See `SECURITY_STATUS_RECONCILIATION.md`.
 
 **Labels:** `bug`, `security`, `multi-school`
 
@@ -246,6 +250,8 @@ Remove `encryptMemo` from `getPaymentInstructions` and `createPaymentIntent`. Th
 ---
 
 ## Issue 5: No authentication on student registration, fee structure creation, and school management endpoints
+
+> **STATUS: RESOLVED (fixed before this audit was committed).** This audit was generated 2026-05-26, before the fix in `IMPLEMENTATION_SUMMARY.md` (2026-05-27, issue #562) landed. Every endpoint listed below now has `requireAdminAuth` applied in its route file (`studentRoutes.js`, `feeRoutes.js`, `schoolRoutes.js`, `paymentRoutes.js`). `tests/authentication-enforcement.test.js` exists and is substantial. See `SECURITY_STATUS_RECONCILIATION.md`.
 
 **Labels:** `security`, `critical`, `backend`
 


### PR DESCRIPTION
issues.md/GITHUB_ISSUES.md/PROJECT_ISSUES.md list the same three problems (duplicate syncAllPayments call, cross-school isolation, missing write-endpoint auth) as still open, contradicting IMPLEMENTATION_SUMMARY.md's fix claims. Verified against current code: the fixes hold. The backlog entries derive from a 2026-05-26 audit, one day before the fix landed (2026-05-27), and were never re-verified against it as they were copied forward into later docs.

Adds SECURITY_STATUS_RECONCILIATION.md as the authoritative current state, with code references, and annotates the three stale backlog entries in place rather than deleting files that contain other still valid issues.


closes #1113 