### PR TITLE
docs: verify IMPLEMENTATION_SUMMARY.md fix claims against current code

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,7 @@
 # Implementation Summary: Issues #559, #560, #561, #562
 
+> **Status check (2026-07-24):** In some forks of this repo, later backlog documents (`issues.md`, `GITHUB_ISSUES.md`, `PROJECT_ISSUES.md`) listed what looked like the same three problems as still open, appearing to contradict this document. Those documents don't exist in this repository's history — see `SECURITY_STATUS_RECONCILIATION.md` for why, and for direct re-verification of this document's claims against current code.
+
 ## Overview
 This document summarizes the fixes implemented for four critical security and bug issues in the StellarEduPay backend.
 

--- a/SECURITY_STATUS_RECONCILIATION.md
+++ b/SECURITY_STATUS_RECONCILIATION.md
@@ -1,0 +1,36 @@
+# Reconciliation: IMPLEMENTATION_SUMMARY.md vs. historical issue backlogs
+
+**Verified against live code on:** 2026-07-24
+
+## Context
+
+`IMPLEMENTATION_SUMMARY.md` (branch `fix/559-560-561-562`, 2026-05-27) claims three problems were fixed:
+
+1. `syncAllPayments` calling `syncPaymentsForSchool` twice / sending two responses (#559, #560)
+2. Cross-school data isolation gaps in payment queries (#561)
+3. Missing authentication on write endpoints (#562)
+
+In some forks of this repository, later static backlog documents (`issues.md`, `GITHUB_ISSUES.md`, `PROJECT_ISSUES.md`) listed what read as the same three problems as still open, with full problem/fix/acceptance-criteria writeups — appearing to contradict this summary.
+
+Those three files don't exist in this repository. They were deliberately removed here in `99a414e` ("docs: remove three redundant, contradictory issue-backlog files", closing #1110), on the grounds that three overlapping, audit-generated markdown backlogs with no canonical status are unreliable and that the live GitHub Issues tracker is this project's single source of truth. That removal resolves the *documentation* contradiction directly — there's no still-open static claim left to reconcile against `IMPLEMENTATION_SUMMARY.md` in this repo.
+
+What that removal doesn't establish on its own is whether the underlying **code claims** in `IMPLEMENTATION_SUMMARY.md` still hold. This document verifies that directly against current code, so a reader doesn't have to take either the summary or a deleted backlog's word for it.
+
+## Verified current state
+
+### 1. Duplicate `syncAllPayments` call — still fixed
+`backend/src/controllers/paymentAdminController.js:33-79`: `syncPaymentsForSchool(req.school)` is called exactly once (line 52), `res.json()` exactly once on the success path. The function has since gained a distributed Redis lock (`Issue #69`) on top of the original fix, and the duplicate-call bug has not reappeared.
+
+### 2. Cross-school data isolation — still fixed
+`backend/src/controllers/paymentQueryController.js`: `getStudentPayments` scopes the student lookup and payment find/count by `schoolId` (lines 63, 71-73). `getStudentBalance` scopes the student lookup, the main balance aggregation, and the category-breakdown sub-aggregation all by `schoolId` (lines 190, 195, 220).
+
+### 3. Missing write-endpoint authentication — still fixed
+Every endpoint named in the original fix carries `requireAdminAuth` today: student routes (`studentRoutes.js`), fee routes (`feeRoutes.js`), school routes (`schoolRoutes.js`), and `POST /api/payments/sync` / `PATCH /api/payments/:txHash/status` (`paymentRoutes.js`).
+
+## A related, still-open gap (do not confuse with the above)
+
+Most payment **read** endpoints trust the `X-School-ID`/`X-School-Slug` header alone — `resolveSchool` (`backend/src/middleware/schoolContext.js`) only validates tenant binding against a JWT when one happens to be present on the request. That's a header-trust gap specific to reads, distinct from the write-endpoint `requireAdminAuth` gap fixed in #562. It should be tracked as its own GitHub issue, not folded into this reconciliation.
+
+## Disposition
+
+`IMPLEMENTATION_SUMMARY.md` is accurate and current; no change needed there beyond a pointer to this document. No other repository markdown currently contradicts it. If a future static backlog is reintroduced and drifts out of sync again, prefer filing/updating a GitHub issue over trusting either document at face value — see the rationale in `99a414e`.


### PR DESCRIPTION
## Summary
- `IMPLEMENTATION_SUMMARY.md` claims three fixes (duplicate `syncAllPayments` call, cross-school data isolation, missing write-endpoint auth — issues #559-562). In some forks, later static backlogs (`issues.md`/`GITHUB_ISSUES.md`/`PROJECT_ISSUES.md`) listed the same three problems as still open, reading as a contradiction.
- Those three files are already removed in this repo (`99a414e`, closes #1110) for exactly that reason — no still-open static claim remains to reconcile against the summary here.
- What wasn't independently confirmed is whether the underlying **code** claims in `IMPLEMENTATION_SUMMARY.md` still hold today. This PR re-verifies them directly against current code and adds `SECURITY_STATUS_RECONCILIATION.md` documenting the result, so the summary's claims don't rest on a deleted document's word alone.
- All three fixes hold: `paymentAdminController.js:33-79` (single sync call/response), `paymentQueryController.js` (schoolId scoping in `getStudentPayments`/`getStudentBalance`), and `requireAdminAuth` on all the named write routes.
- Also flags one related but distinct, still-open gap for future tracking: `resolveSchool` trusts the `X-School-ID`/`X-School-Slug` header alone on reads when no JWT is present — not the same issue as #562, not addressed by this PR.

Note: I recognize this repo's stated preference (per `99a414e`) is GitHub Issues as the single source of truth over static root-level docs. Opening this anyway since it's a one-time verification note rather than an ongoing backlog, and it's scoped to resolve lingering doubt about `IMPLEMENTATION_SUMMARY.md` specifically — happy to close if maintainers would rather this go as an issue comment instead.

## Test plan
- [x] Re-verified `syncAllPayments` calls `syncPaymentsForSchool`/`res.json` exactly once
- [x] Re-verified `schoolId` scoping in `getStudentPayments`/`getStudentBalance`
- [x] Re-verified `requireAdminAuth` on every write endpoint named in the original fix
- Documentation-only change — no code paths touched