### PR TITLE
feat(csp): define CSP allow-list as single source of truth

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -95,7 +95,22 @@ npm test -- tests/csp.test.js
 
 ### Adding new external origins
 
-If a new external service needs to be reachable from the frontend (e.g. a currency conversion API), add its origin to the `connect-src` directive in `frontend/next.config.js` and update the test in `tests/csp.test.js` accordingly.
+The CSP allow-list is defined in a **single source of truth**:
+
+```
+frontend/src/config/cspSources.js
+```
+
+Both `frontend/next.config.js` (runtime policy) and `tests/csp.test.js` (assertions) import from this module. Adding or removing an origin requires editing exactly one file — the change is automatically reflected in the deployed CSP header and in the test suite.
+
+**To add a new external origin:**
+
+1. Open `frontend/src/config/cspSources.js`.
+2. Add the full origin (scheme + host, no trailing slash) to the appropriate array:
+   - `CONNECT_SRC_ORIGINS` — fetch/XHR targets (APIs, WebSockets)
+   - `STYLE_SRC_ORIGINS` — external stylesheets
+   - `FONT_SRC_ORIGINS` — external font files
+3. That's it. Run `npm test -- tests/csp.test.js` to confirm.
 
 Do **not** add `'unsafe-inline'` or `'unsafe-eval'` to `script-src`. If a third-party library requires inline scripts, use a nonce-based approach instead.
 

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,5 +1,14 @@
 /** @type {import('next').NextConfig} */
 
+// External-origin allow-lists are defined in a single shared module so that
+// both this file (runtime policy) and tests/csp.test.js (assertions) stay in
+// sync automatically. To add a new origin, edit only cspSources.js.
+const {
+  CONNECT_SRC_ORIGINS,
+  STYLE_SRC_ORIGINS,
+  FONT_SRC_ORIGINS,
+} = require('./src/config/cspSources');
+
 const isDev = process.env.NODE_ENV !== 'production';
 
 // Origin of the backend API (scheme://host:port), derived from the public API
@@ -31,13 +40,13 @@ const scriptSrc = isDev ? "script-src 'self' 'unsafe-eval'" : "script-src 'self'
 const CSP = [
   "default-src 'self'",
   scriptSrc,
-  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  `style-src 'self' 'unsafe-inline' ${STYLE_SRC_ORIGINS.join(' ')}`,
   "img-src 'self' data:",
-  "font-src 'self' https://fonts.gstatic.com data:",
+  `font-src 'self' ${FONT_SRC_ORIGINS.join(' ')} data:`,
   // Allow fetch/XHR to the backend API and Stellar Horizon (testnet + mainnet).
   // The backend API origin is included so the browser can reach it cross-origin
   // in split-port deployments (e.g. localhost:3000 UI → localhost:5000 API).
-  `connect-src 'self' ${API_ORIGIN} https://horizon-testnet.stellar.org https://horizon.stellar.org`,
+  `connect-src 'self' ${API_ORIGIN} ${CONNECT_SRC_ORIGINS.join(' ')}`,
   "object-src 'none'",
   "frame-ancestors 'none'",
   "base-uri 'self'",

--- a/frontend/src/config/cspSources.js
+++ b/frontend/src/config/cspSources.js
@@ -1,0 +1,35 @@
+/**
+ * CSP external-origin allow-list — single source of truth.
+ *
+ * Both `frontend/next.config.js` (runtime policy) and `tests/csp.test.js`
+ * (assertions) import from here, so adding or removing an origin requires
+ * editing exactly one file and is automatically reflected in both the deployed
+ * CSP header and the test suite.
+ *
+ * HOW TO ADD A NEW ORIGIN
+ * -----------------------
+ * 1. Add the full origin (scheme + host, no trailing slash) to the appropriate
+ *    array below.
+ * 2. That's it — next.config.js and csp.test.js pick it up automatically.
+ *
+ * Do NOT add 'unsafe-inline' or 'unsafe-eval' to script-src origins.
+ * Use a nonce-based approach if a third-party library requires inline scripts.
+ */
+
+/** Origins permitted in `connect-src` (fetch / XHR / WebSocket targets). */
+const CONNECT_SRC_ORIGINS = [
+  'https://horizon-testnet.stellar.org',
+  'https://horizon.stellar.org',
+];
+
+/** Origins permitted in `style-src` (external stylesheets). */
+const STYLE_SRC_ORIGINS = [
+  'https://fonts.googleapis.com',
+];
+
+/** Origins permitted in `font-src` (external font files). */
+const FONT_SRC_ORIGINS = [
+  'https://fonts.gstatic.com',
+];
+
+module.exports = { CONNECT_SRC_ORIGINS, STYLE_SRC_ORIGINS, FONT_SRC_ORIGINS };

--- a/tests/csp.test.js
+++ b/tests/csp.test.js
@@ -67,6 +67,15 @@ describe('Issue #396 — Backend Helmet CSP config (JSON API)', () => {
 // ── Frontend next.config.js CSP tests ────────────────────────────────────────
 
 describe('Issue #396 — Frontend CSP (next.config.js)', () => {
+  // The allow-list is the single source of truth: the same arrays that
+  // next.config.js uses to build the CSP header are imported here so the
+  // assertions automatically stay in sync with the deployed policy.
+  const {
+    CONNECT_SRC_ORIGINS,
+    STYLE_SRC_ORIGINS,
+    FONT_SRC_ORIGINS,
+  } = require('../frontend/src/config/cspSources');
+
   let headers;
   let cspValue;
 
@@ -131,8 +140,21 @@ describe('Issue #396 — Frontend CSP (next.config.js)', () => {
   });
 
   test('frontend CSP includes connect-src with Stellar Horizon endpoints', () => {
-    expect(cspValue).toContain('horizon-testnet.stellar.org');
-    expect(cspValue).toContain('horizon.stellar.org');
+    for (const origin of CONNECT_SRC_ORIGINS) {
+      expect(cspValue).toContain(origin);
+    }
+  });
+
+  test('frontend CSP includes style-src external origins', () => {
+    for (const origin of STYLE_SRC_ORIGINS) {
+      expect(cspValue).toContain(origin);
+    }
+  });
+
+  test('frontend CSP includes font-src external origins', () => {
+    for (const origin of FONT_SRC_ORIGINS) {
+      expect(cspValue).toContain(origin);
+    }
   });
 
   test("frontend CSP includes object-src 'none'", () => {


### PR DESCRIPTION
Description
  
  Eliminates the two-file manual synchronization requirement for CSP external origins. Previously, adding a new origin required editing both frontend/next.config.js
   and tests/csp.test.js in lockstep — a fragile process for a security-critical configuration.
  
  Changes Made
  
  - New: frontend/src/config/cspSources.js — single source of truth exporting CONNECT_SRC_ORIGINS, STYLE_SRC_ORIGINS, and FONT_SRC_ORIGINS arrays
  - Updated: frontend/next.config.js — imports origin arrays from cspSources.js instead of hardcoding them inline
  - Updated: tests/csp.test.js — imports the same arrays and iterates over them for assertions; added coverage for style-src and font-src external origins
  (previously untested)
  - Updated: docs/security.md — "Adding new external origins" section now documents the single-file process
  
  Before / After
  
  Before: Adding an origin required editing two files, with no enforcement that both stayed in sync.
  
  After: Edit only frontend/src/config/cspSources.js. Both the deployed header and the test assertions derive from the same arrays automatically.
  
  Testing
  
  - [ ] npm test -- tests/csp.test.js passes
  - [ ] No change to the CSP policy itself — only where the allow-list is defined
  - [ ] Verified next.config.js still produces the same header values as before
  
  Breaking Changes
  
  None. The deployed CSP header is identical to before; this is a refactor of where the values are defined.
  
  Checklist
  
  - [x] Tests passing
  - [x] Documentation updated (docs/security.md)
  - [x] No merge conflicts
  - [x] Follows coding standards
  - [x] No sensitive data

closes #1066 