### PR TITLE
refac: login use api client

### DIFF
--- a/frontend/src/pages/login.jsx
+++ b/frontend/src/pages/login.jsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { useAdminAuth } from '../hooks/useAdminAuth';
 import { getErrorMessage } from '../utils/errorMessages';
+import api from '../services/api';
 
 // Only honour same-origin, absolute internal paths as a post-login destination.
 // Anything else (external URLs, protocol-relative "//evil.com", missing) falls
@@ -26,18 +27,18 @@ export default function LoginPage() {
     setError('');
     setLoading(true);
     try {
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ username, password }),
-      });
-      const data = await res.json();
-      if (!res.ok) { setError(getErrorMessage(data.code, data.error)); return; }
+      await api.post('/auth/login', { username, password });
       login();
       router.push(safeReturnTo(router.query.returnTo));
-    } catch {
-      setError('Network error. Please try again.');
+    } catch (err) {
+      if (err.response) {
+        // HTTP error response from the server (4xx, 5xx)
+        const { code, error } = err.response.data || {};
+        setError(getErrorMessage(code, error));
+      } else {
+        // Network failure, timeout, or no response at all
+        setError('Network error. Please try again.');
+      }
     } finally {
       setLoading(false);
     }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -47,6 +47,11 @@ const onResponseRejected = createRefreshHandler({
 
 api.interceptors.response.use((response) => response, onResponseRejected);
 
+// Export the bare axios instance as the default so callers that need ad-hoc
+// requests (e.g. login.jsx) can use api.post('/auth/login', data) without
+// coupling to a specific named helper.
+export default api;
+
 export const getStudents = (page = 1, limit = 20, { search, status, className } = {}) =>
   api.get("/students", {
     params: {


### PR DESCRIPTION
frontend/src/services/api.js — Added export default api just before the named exports. The axios instance was already fully configured (baseURL, withCredentials,
  timeout, request/response interceptors) but wasn't exported, making it unavailable to callers that don't want a named wrapper function.
  
  frontend/src/pages/login.jsx — Replaced the fetch block with await api.post('/auth/login', { username, password }). Error handling maps directly to the previous
  behavior:
  
  - HTTP errors (4xx/5xx): err.response.data.code + err.response.data.error → getErrorMessage(), same as before
  - Network/timeout failures: !err.response → 'Network error. Please try again.', same as before
  
  The login flow now automatically inherits any future interceptor additions (CSRF tokens, improved error normalization, etc.) without any additional changes.


closes #1068 