### PR TITLE
# Fix outbox retry head-of-line blocking

### DIFF
--- a/backend/src/models/outboxModel.js
+++ b/backend/src/models/outboxModel.js
@@ -15,13 +15,17 @@ const outboxSchema = new mongoose.Schema(
 
     retryCount:     { type: Number, default: 0 },
     lastError:      { type: String, default: null },
+
+    deadLettered:       { type: Boolean, default: false, index: true },
+    deadLetteredAt:     { type: Date, default: null },
+    deadLetterReason:   { type: String, default: null },
   },
   {
     timestamps: true,
   }
 );
 
-outboxSchema.index({ processed: 1, createdAt: 1 });
+outboxSchema.index({ processed: 1, deadLettered: 1, createdAt: 1 });
 outboxSchema.index({ eventType: 1, processed: 1 });
 
 module.exports = mongoose.model('Outbox', outboxSchema);

--- a/backend/src/services/outboxDispatcher.js
+++ b/backend/src/services/outboxDispatcher.js
@@ -5,15 +5,39 @@ const paymentEvents = require('../events/paymentEvents');
 const logger = require('../utils/logger').child('OutboxDispatcher');
 
 const BATCH_SIZE = 100;
+const MAX_RETRIES = parseInt(process.env.OUTBOX_MAX_RETRIES, 10) || 3;
 const DISPATCH_INTERVAL_MS = parseInt(process.env.OUTBOX_DISPATCH_INTERVAL_MS, 10) || 5000;
 let _dispatchTimer = null;
 
+async function deadLetterOutboxEvent(event, retryCount, errorMessage) {
+  logger.error('Outbox event exceeded max retries', {
+    eventId: event.eventId,
+    eventType: event.eventType,
+    error: errorMessage,
+    retryCount,
+    maxRetries: MAX_RETRIES,
+  });
+
+  await Outbox.findByIdAndUpdate(event._id, {
+    retryCount,
+    lastError: errorMessage,
+    deadLettered: true,
+    deadLetteredAt: new Date(),
+    deadLetterReason: 'max_retries_exhausted',
+  });
+}
+
 async function dispatchOutboxEvents() {
   try {
-    const batch = await Outbox.find({ processed: false }).limit(BATCH_SIZE).sort({ createdAt: 1 });
+    const batch = await Outbox.find({ processed: false, deadLettered: { $ne: true } }).limit(BATCH_SIZE).sort({ createdAt: 1 });
 
     for (const event of batch) {
       try {
+        if ((event.retryCount || 0) >= MAX_RETRIES) {
+          await deadLetterOutboxEvent(event, event.retryCount || 0, event.lastError || 'Retry budget exhausted');
+          continue;
+        }
+
         paymentEvents.emit(event.eventType, event.payload);
         await Outbox.findByIdAndUpdate(event._id, {
           processed: true,
@@ -21,18 +45,9 @@ async function dispatchOutboxEvents() {
         });
       } catch (err) {
         const retryCount = (event.retryCount || 0) + 1;
-        const maxRetries = 3;
 
-        if (retryCount >= maxRetries) {
-          logger.error('Outbox event exceeded max retries', {
-            eventId: event.eventId,
-            eventType: event.eventType,
-            error: err.message,
-          });
-          await Outbox.findByIdAndUpdate(event._id, {
-            retryCount,
-            lastError: err.message,
-          });
+        if (retryCount >= MAX_RETRIES) {
+          await deadLetterOutboxEvent(event, retryCount, err.message);
         } else {
           await Outbox.findByIdAndUpdate(event._id, {
             retryCount,

--- a/backend/tests/outboxDispatcherDeadLetter.test.js
+++ b/backend/tests/outboxDispatcherDeadLetter.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+const Outbox = require('../src/models/outboxModel');
+const paymentEvents = require('../src/events/paymentEvents');
+
+jest.mock('../src/models/outboxModel', () => ({
+  find: jest.fn(),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../src/events/paymentEvents', () => ({
+  emit: jest.fn(),
+}));
+
+const mockOutboxLogger = {
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+};
+
+jest.mock('../src/utils/logger', () => ({
+  child: jest.fn(() => mockOutboxLogger),
+}));
+
+const { dispatchOutboxEvents } = require('../src/services/outboxDispatcher');
+
+describe('outboxDispatcher dead-letter handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function mockOutboxBatch(batch) {
+    const sort = jest.fn().mockResolvedValue(batch);
+    const limit = jest.fn(() => ({ sort }));
+    Outbox.find.mockReturnValue({ limit });
+
+    return { limit, sort };
+  }
+
+  it('dead-letters exhausted events and still dispatches healthy events in the batch', async () => {
+    const exhaustedEvent = {
+      _id: 'outbox-dead',
+      eventId: 'dead-event',
+      eventType: 'payment.failed_permanently',
+      payload: { paymentId: 'dead' },
+      retryCount: 3,
+      lastError: 'listener no longer exists',
+    };
+    const healthyEvent = {
+      _id: 'outbox-healthy',
+      eventId: 'healthy-event',
+      eventType: 'payment.confirmed',
+      payload: { paymentId: 'healthy' },
+      retryCount: 0,
+    };
+
+    mockOutboxBatch([exhaustedEvent, healthyEvent]);
+
+    await dispatchOutboxEvents();
+
+    expect(Outbox.find).toHaveBeenCalledWith({
+      processed: false,
+      deadLettered: { $ne: true },
+    });
+    expect(paymentEvents.emit).toHaveBeenCalledTimes(1);
+    expect(paymentEvents.emit).toHaveBeenCalledWith('payment.confirmed', healthyEvent.payload);
+    expect(Outbox.findByIdAndUpdate).toHaveBeenCalledWith(
+      exhaustedEvent._id,
+      expect.objectContaining({
+        retryCount: 3,
+        lastError: 'listener no longer exists',
+        deadLettered: true,
+        deadLetterReason: 'max_retries_exhausted',
+      })
+    );
+    expect(Outbox.findByIdAndUpdate).toHaveBeenCalledWith(
+      healthyEvent._id,
+      expect.objectContaining({
+        processed: true,
+        processedAt: expect.any(Date),
+      })
+    );
+    expect(mockOutboxLogger.error).toHaveBeenCalledWith(
+      'Outbox event exceeded max retries',
+      expect.objectContaining({ eventId: 'dead-event', retryCount: 3 })
+    );
+  });
+
+  it('marks a permanently failing event dead-lettered when its final retry fails', async () => {
+    const failingEvent = {
+      _id: 'outbox-failing',
+      eventId: 'failing-event',
+      eventType: 'payment.confirmed',
+      payload: { paymentId: 'failing' },
+      retryCount: 2,
+    };
+    const failure = new Error('listener crashed');
+
+    mockOutboxBatch([failingEvent]);
+    paymentEvents.emit.mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    await dispatchOutboxEvents();
+
+    expect(Outbox.findByIdAndUpdate).toHaveBeenCalledWith(
+      failingEvent._id,
+      expect.objectContaining({
+        retryCount: 3,
+        lastError: failure.message,
+        deadLettered: true,
+        deadLetteredAt: expect.any(Date),
+        deadLetterReason: 'max_retries_exhausted',
+      })
+    );
+  });
+});


### PR DESCRIPTION
Closes #1051

## Summary
- Adds outbox dead-letter fields so exhausted events stop occupying dispatch batch slots.
- Excludes `deadLettered: true` events from the main outbox dispatch query.
- Marks already-exhausted events as dead-lettered before attempting another emit.
- Adds regression coverage proving exhausted events do not prevent healthy events in the same batch from being dispatched.

## Testing
- PASS `node_modules\.bin\jest.cmd backend/tests/outboxDispatcherDeadLetter.test.js backend/tests/outboxDispatcherUnhandledRejection.test.js --runInBand`
- Full `jest --testPathPattern=tests/ --runInBand --forceExit` Passed