### PR TITLE
fix: k8s hardening — Redis, NetworkPolicy, Kustomize overlays, secret provisioning

### DIFF
--- a/deploy/k8s/backend-deployment.yaml
+++ b/deploy/k8s/backend-deployment.yaml
@@ -51,11 +51,10 @@ spec:
           ports:
             - containerPort: 5000
           env:
-            # Inject sensitive values from a Kubernetes Secret, not plain ConfigMaps.
-            # Create the secret with:
-            #   kubectl create secret generic stellaredupay \
-            #     --from-literal=JWT_SECRET=<value> \
-            #     --from-literal=MONGO_URI=<value>
+            # Sensitive values are injected from a Kubernetes Secret.
+            # To provision the secret, run scripts/provision-k8s-secrets.sh
+            # (see docs/operator-runbooks.md § Secret Provisioning for the
+            # full checklist, rotation procedure, and audit requirements).
             - name: JWT_SECRET
               valueFrom:
                 secretKeyRef:
@@ -66,8 +65,11 @@ spec:
                 secretKeyRef:
                   name: stellaredupay
                   key: MONGO_URI
-            - name: STELLAR_NETWORK
-              value: "mainnet"
+            # STELLAR_NETWORK is not set here — it must be provided by the
+            # environment-specific Kustomize overlay (overlays/mainnet or
+            # overlays/testnet). Applying this base manifest directly without
+            # an overlay will intentionally omit the value, preventing
+            # accidental cross-environment deployments.
             - name: REDIS_HOST
               value: "redis"
           readinessProbe:

--- a/deploy/k8s/backend-networkpolicy.yaml
+++ b/deploy/k8s/backend-networkpolicy.yaml
@@ -1,0 +1,77 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: backend-network-policy
+  labels:
+    app: backend
+spec:
+  podSelector:
+    matchLabels:
+      app: backend
+  policyTypes:
+    - Ingress
+    - Egress
+
+  ingress:
+    # Allow inbound traffic from the ingress controller only.
+    # Both selectors are in the same list entry (AND semantics): the source
+    # pod must be in the ingress-nginx namespace AND carry the ingress-nginx
+    # pod label. Update the namespaceSelector label if your ingress
+    # controller runs in a different namespace.
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: ingress-nginx
+      ports:
+        - protocol: TCP
+          port: 5000
+    # Allow inbound traffic from the frontend pod when deployed in the
+    # same namespace.
+    - from:
+        - podSelector:
+            matchLabels:
+              app: frontend
+      ports:
+        - protocol: TCP
+          port: 5000
+
+  egress:
+    # DNS — required for all service-name resolution (MongoDB Atlas,
+    # Horizon, Redis service name, etc.).
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+
+    # Redis — distributed locking and leader election (distributedLock.js /
+    # leaderElection.js). Restricted to pods labelled app=redis so that no
+    # other pod in the namespace can be targeted by this rule.
+    - to:
+        - podSelector:
+            matchLabels:
+              app: redis
+      ports:
+        - protocol: TCP
+          port: 6379
+
+    # MongoDB — database connection (Atlas or in-cluster).
+    - ports:
+        - protocol: TCP
+          port: 27017
+
+    # HTTPS — Stellar Horizon API, external webhook deliveries, price feeds,
+    # and any other TLS-secured external service.
+    - ports:
+        - protocol: TCP
+          port: 443
+
+    # SMTP — transactional email (STARTTLS on 587, implicit TLS on 465).
+    - ports:
+        - protocol: TCP
+          port: 587
+        - protocol: TCP
+          port: 465

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Base manifest set — not intended to be applied directly.
+# Select an environment overlay instead:
+#
+#   kubectl apply -k deploy/k8s/overlays/mainnet   # production
+#   kubectl apply -k deploy/k8s/overlays/testnet   # staging / testnet
+
+resources:
+  - backend-deployment.yaml
+  - backend-pdb.yaml
+  - backend-networkpolicy.yaml
+  - redis.yaml

--- a/deploy/k8s/overlays/mainnet/kustomization.yaml
+++ b/deploy/k8s/overlays/mainnet/kustomization.yaml
@@ -1,0 +1,31 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Production / mainnet overlay.
+# Apply with: kubectl apply -k deploy/k8s/overlays/mainnet
+#
+# This overlay sets STELLAR_NETWORK=mainnet, enabling real irreversible
+# transactions. Ensure all secrets are provisioned (see
+# docs/operator-runbooks.md § Secret Provisioning) and that you are
+# targeting the correct cluster context before applying.
+
+resources:
+  - ../../
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: backend
+      spec:
+        template:
+          spec:
+            containers:
+              - name: backend
+                env:
+                  - name: STELLAR_NETWORK
+                    value: "mainnet"
+    target:
+      kind: Deployment
+      name: backend

--- a/deploy/k8s/overlays/testnet/kustomization.yaml
+++ b/deploy/k8s/overlays/testnet/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Staging / testnet overlay.
+# Apply with: kubectl apply -k deploy/k8s/overlays/testnet
+#
+# This overlay sets STELLAR_NETWORK=testnet — all transactions are
+# reversible test transactions with no real funds at risk.
+
+resources:
+  - ../../
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: backend
+      spec:
+        template:
+          spec:
+            containers:
+              - name: backend
+                env:
+                  - name: STELLAR_NETWORK
+                    value: "testnet"
+    target:
+      kind: Deployment
+      name: backend

--- a/deploy/k8s/redis.yaml
+++ b/deploy/k8s/redis.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          # Persistence is intentionally disabled — Redis is used solely for
+          # distributed locking and leader election (distributedLock.js /
+          # leaderElection.js). Locks are short-lived and must not survive a
+          # Redis restart; enabling AOF/RDB would persist stale lock keys and
+          # could block all replicas from acquiring locks after a restore.
+          args: ["--save", ""]
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "250m"
+              memory: "128Mi"
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 30
+            timeoutSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+      protocol: TCP
+  type: ClusterIP

--- a/docs/operator-runbooks.md
+++ b/docs/operator-runbooks.md
@@ -36,6 +36,38 @@ Triage payment ID, tenant ID, user ID, idempotency key, amount, asset, destinati
 
 Procedure: if a transaction hash exists, query Stellar/Horizon directly. If confirmed, update payment state with an audit reason. If failed, mark failed with the failure reason. If no hash exists and no transfer occurred, retry from queued state. If state is ambiguous, keep manual-review and do not retry automatically.
 
+## Secret Provisioning
+
+Before deploying the backend for the first time in any environment, provision
+the `stellaredupay` Kubernetes Secret using the scripted process below. Never
+use a hand-typed `kubectl create secret` command — the script validates inputs,
+is idempotent, and emits an audit trail for your change-management log.
+
+**Checklist — run before every new environment or after a credential reset:**
+
+1. Generate values for all required secrets (see script header for generation
+   commands): `JWT_SECRET`, `MONGO_URI`, and (for production) `SIGNER_MASTER_KEY`.
+2. Verify you are targeting the correct cluster context:
+   `kubectl config current-context`
+3. Run the provisioning script:
+   ```sh
+   JWT_SECRET=<value> MONGO_URI=<value> SIGNER_MASTER_KEY=<value> \
+     NAMESPACE=<namespace> \
+     ./scripts/provision-k8s-secrets.sh
+   ```
+4. Record the script's audit output (context, operator, timestamp) in your
+   incident or change-management log.
+5. Deploy via the environment overlay — not the base manifest directly:
+   ```sh
+   kubectl apply -k deploy/k8s/overlays/mainnet   # production
+   kubectl apply -k deploy/k8s/overlays/testnet   # staging
+   ```
+6. Verify the backend pods reach `Running` state and the `/health` endpoint
+   returns `{"status":"healthy"}`.
+
+The script (`scripts/provision-k8s-secrets.sh`) uses `--dry-run=client | apply`
+so it is safe to re-run; it patches an existing secret without error.
+
 ## Key Rotation
 
 Rotate JWT secrets, webhook secrets, database credentials, queue credentials, deployment tokens, and Stellar signing credentials when compromise is suspected, operator membership changes, or the scheduled interval expires.

--- a/scripts/provision-k8s-secrets.sh
+++ b/scripts/provision-k8s-secrets.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# provision-k8s-secrets.sh — Initial provisioning for the stellaredupay
+# Kubernetes Secret used by the backend deployment.
+#
+# Usage:
+#   JWT_SECRET=<value> MONGO_URI=<value> \
+#     [SIGNER_MASTER_KEY=<value>] \
+#     [NAMESPACE=default] \
+#     [SECRET_NAME=stellaredupay] \
+#     [DRY_RUN=1] \
+#     ./scripts/provision-k8s-secrets.sh
+#
+# The script is idempotent — running it again with updated values patches
+# the existing secret in place without downtime.
+#
+# Required env vars:
+#   JWT_SECRET        — HS256 signing key for session JWTs.
+#                       Generate: node -e "console.log(require('crypto').randomBytes(64).toString('hex'))"
+#   MONGO_URI         — MongoDB connection string (including credentials).
+#
+# Optional env vars:
+#   SIGNER_MASTER_KEY — AES-256 key that encrypts stored Stellar signing
+#                       secret keys at rest (signerKeyManager.js). Required
+#                       for a production deployment; if omitted the backend
+#                       will start but Stellar signing operations will fail.
+#                       Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+#   NAMESPACE         — Kubernetes namespace (default: default).
+#   SECRET_NAME       — Name of the Secret resource (default: stellaredupay).
+#   DRY_RUN           — Set to 1 to print the kubectl command without running it.
+#
+# Audit trail:
+#   The script echoes the cluster context, namespace, secret name, operator,
+#   and UTC timestamp on success. Capture this output in your incident or
+#   change-management log.
+#
+# See also: docs/operator-runbooks.md § Secret Provisioning
+
+set -euo pipefail
+
+NAMESPACE="${NAMESPACE:-default}"
+SECRET_NAME="${SECRET_NAME:-stellaredupay}"
+DRY_RUN="${DRY_RUN:-0}"
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+missing=()
+
+if [[ -z "${JWT_SECRET:-}" ]]; then
+  missing+=("JWT_SECRET")
+fi
+
+if [[ -z "${MONGO_URI:-}" ]]; then
+  missing+=("MONGO_URI")
+fi
+
+if [[ "${#missing[@]}" -gt 0 ]]; then
+  echo "ERROR: the following required environment variables are not set:" >&2
+  for var in "${missing[@]}"; do
+    echo "  - $var" >&2
+  done
+  echo "" >&2
+  echo "See the script header comment for usage and generation instructions." >&2
+  exit 1
+fi
+
+if [[ -z "${SIGNER_MASTER_KEY:-}" ]]; then
+  echo "WARNING: SIGNER_MASTER_KEY is not set. The backend will start but" >&2
+  echo "         Stellar signing operations will fail until it is provisioned." >&2
+  echo "         For production deployments, set SIGNER_MASTER_KEY." >&2
+fi
+
+# ---------------------------------------------------------------------------
+# Build the kubectl command
+# ---------------------------------------------------------------------------
+
+CLUSTER_CONTEXT="$(kubectl config current-context 2>/dev/null || echo 'unknown')"
+
+echo "Provisioning secret '${SECRET_NAME}' in namespace '${NAMESPACE}'"
+echo "  Cluster context : ${CLUSTER_CONTEXT}"
+echo "  Operator        : ${USER:-unknown}"
+echo "  Timestamp (UTC) : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+echo ""
+
+KUBECTL_ARGS=(
+  create secret generic "${SECRET_NAME}"
+  "--from-literal=JWT_SECRET=${JWT_SECRET}"
+  "--from-literal=MONGO_URI=${MONGO_URI}"
+)
+
+if [[ -n "${SIGNER_MASTER_KEY:-}" ]]; then
+  KUBECTL_ARGS+=("--from-literal=SIGNER_MASTER_KEY=${SIGNER_MASTER_KEY}")
+fi
+
+KUBECTL_ARGS+=(
+  "--namespace=${NAMESPACE}"
+  "--dry-run=client"
+  "-o" "yaml"
+)
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  echo "[DRY RUN] Would run:"
+  echo "  kubectl ${KUBECTL_ARGS[*]} | kubectl apply -f -"
+  exit 0
+fi
+
+# Use --dry-run=client | apply so the command is idempotent: it creates the
+# secret on first run and patches it on subsequent runs without error.
+kubectl "${KUBECTL_ARGS[@]}" | kubectl apply --namespace="${NAMESPACE}" -f -
+
+echo ""
+echo "Secret provisioned successfully."
+echo "Record this run in your change-management or incident log:"
+echo "  Secret   : ${SECRET_NAME}"
+echo "  Namespace: ${NAMESPACE}"
+echo "  Context  : ${CLUSTER_CONTEXT}"
+echo "  Operator : ${USER:-unknown}"
+echo "  Time     : $(date -u +%Y-%m-%dT%H:%M:%SZ)"


### PR DESCRIPTION
## Summary

- **#1089** — Added `deploy/k8s/redis.yaml` (Redis Deployment + ClusterIP Service) so `REDIS_HOST=redis` resolves to a real pod; persistence intentionally disabled since Redis is used solely for short-lived distributed locks and leader election.
- **#1090** — Removed hardcoded `STELLAR_NETWORK=mainnet` from the base manifest; introduced a Kustomize base (`deploy/k8s/kustomization.yaml`) and per-environment overlays (`overlays/mainnet`, `overlays/testnet`) so the network is selected explicitly via `kubectl apply -k` rather than hand-editing YAML.
- **#1092** — Added `deploy/k8s/backend-networkpolicy.yaml` restricting the backend pod's ingress (ingress-nginx + frontend only) and egress (DNS, Redis, MongoDB, HTTPS, SMTP) — all other traffic denied.
- **#1093** — Replaced the ad-hoc `kubectl create secret` comment in the deployment with `scripts/provision-k8s-secrets.sh` (validated inputs, idempotent via `--dry-run=client | apply`, structured audit trail) and a new "Secret Provisioning" section with a pre-deploy checklist in `docs/operator-runbooks.md`.

## Test plan

- [ ] `kubectl apply -k deploy/k8s/overlays/mainnet` renders without errors (`--dry-run=server`)
- [ ] `kubectl apply -k deploy/k8s/overlays/testnet` renders without errors
- [ ] Backend pod reaches `Running`; `/health` returns `{"status":"healthy"}` with Redis check passing
- [ ] `DRY_RUN=1 JWT_SECRET=x MONGO_URI=x ./scripts/provision-k8s-secrets.sh` prints the command without applying
- [ ] A pod without `app=backend` label cannot reach port 5000 on the backend pod (manual `kubectl exec` + curl test)
- [ ] Applying the base manifest directly (`kubectl apply -k deploy/k8s/`) deploys without `STELLAR_NETWORK`, causing the app to fail loudly rather than silently use the wrong network

closes #1089
closes #1090
closes #1092
closes #1093