### PR TITLE
fix: cancel stale student-lookup requests with AbortController (#race…

### DIFF
--- a/frontend/src/components/PaymentForm.jsx
+++ b/frontend/src/components/PaymentForm.jsx
@@ -61,9 +61,12 @@ export default function PaymentForm() {
   // #1118 — wallets that cannot send free-text memos can switch the QR code to
   // MEMO_ID or MEMO_HASH; all three decode back to the same payment reference.
   const [memoType, setMemoType]               = useState("MEMO_TEXT");
-  const errorRef  = useRef(null);
+  const errorRef    = useRef(null);
   const debounceRef = useRef(null);
   const qrWrapperRef = useRef(null);
+  // Holds the AbortController for the in-flight lookup so a superseded request
+  // can be cancelled before the next one starts (race-condition fix).
+  const lookupAbortRef = useRef(null);
 
   function handleStudentIdChange(e) {
     const value = e.target.value;
@@ -72,11 +75,21 @@ export default function PaymentForm() {
   }
 
   useEffect(() => {
-    return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      // Cancel any in-flight lookup when the component unmounts.
+      lookupAbortRef.current?.abort();
+    };
   }, []);
 
   const lookupStudent = useCallback(async (id) => {
     if (!id.trim()) return;
+
+    // Cancel the previous in-flight request (if any) before starting a new one.
+    lookupAbortRef.current?.abort();
+    const controller = new AbortController();
+    lookupAbortRef.current = controller;
+
     setError("");
     setStudent(null);
     setInstructions(null);
@@ -85,25 +98,38 @@ export default function PaymentForm() {
     setLoading(true);
     setPaymentsLoading(true);
     try {
+      const signal = controller.signal;
       const [stuRes, instrRes, payRes, balRes] = await Promise.all([
-        getStudent(id),
-        getPaymentInstructions(id),
-        getStudentPayments(id),
-        getStudentBalance(id).catch(() => null),
+        getStudent(id, { signal }),
+        getPaymentInstructions(id, { signal }),
+        getStudentPayments(id, { signal }),
+        getStudentBalance(id, { signal }).catch((err) => {
+          // Propagate abort so the outer catch can detect it; swallow other errors.
+          if (err?.name === "CanceledError" || err?.code === "ERR_CANCELED") throw err;
+          return null;
+        }),
       ]);
       setStudent(stuRes.data);
       setInstructions(instrRes.data);
       setPayments(payRes.data?.payments ?? payRes.data ?? []);
       setHasDeletedPayments(balRes?.data?.hasDeletedPayments === true);
     } catch (err) {
+      // Axios names aborted requests "CanceledError" (axios ≥ 1.x) with code
+      // "ERR_CANCELED".  Silently ignore them — a newer request is already
+      // in flight and will update the UI when it resolves.
+      if (err?.name === "CanceledError" || err?.code === "ERR_CANCELED") return;
       setError(
         getErrorMessage(err.response?.data?.code, err.response?.data?.error) ||
         "Student not found. Please check the ID and try again."
       );
       errorRef.current?.focus();
     } finally {
-      setLoading(false);
-      setPaymentsLoading(false);
+      // Only clear loading state when *this* controller is still the current
+      // one (i.e. it hasn't been superseded by a newer lookup).
+      if (lookupAbortRef.current === controller) {
+        setLoading(false);
+        setPaymentsLoading(false);
+      }
     }
   }, []);
 

--- a/frontend/src/pages/dashboard.jsx
+++ b/frontend/src/pages/dashboard.jsx
@@ -61,6 +61,9 @@ export default function Dashboard() {
 
   const searchDebounceRef = useRef(null);
   const [debouncedSearch, setDebouncedSearch] = useState("");
+  // Holds the AbortController for the most-recent fetchStudents call so
+  // superseded (stale) requests can be cancelled before the next one starts.
+  const studentsAbortRef = useRef(null);
 
   useEffect(() => {
     clearTimeout(searchDebounceRef.current);
@@ -78,16 +81,30 @@ export default function Dashboard() {
   }, []);
 
   const fetchStudents = useCallback((p, srch, st, cls) => {
+    // Cancel any in-flight student fetch before issuing a new one.
+    studentsAbortRef.current?.abort();
+    const controller = new AbortController();
+    studentsAbortRef.current = controller;
+
     setStudentsLoading(true);
     setStudentsError(null);
-    getStudents(p, PAGE_SIZE, { search: srch, status: st, className: cls })
+    getStudents(p, PAGE_SIZE, { search: srch, status: st, className: cls }, { signal: controller.signal })
       .then(({ data }) => {
         setStudents(data.students);
         setPages(data.pages || 1);
         setTotal(data.total || 0);
       })
-      .catch(() => setStudentsError("Could not load student list."))
-      .finally(() => setStudentsLoading(false));
+      .catch((err) => {
+        // Silently ignore aborted (superseded) requests.
+        if (err?.name === "CanceledError" || err?.code === "ERR_CANCELED") return;
+        setStudentsError("Could not load student list.");
+      })
+      .finally(() => {
+        // Only clear loading when this controller is still the current one.
+        if (studentsAbortRef.current === controller) {
+          setStudentsLoading(false);
+        }
+      });
   }, []);
 
   useEffect(() => {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -52,7 +52,7 @@ api.interceptors.response.use((response) => response, onResponseRejected);
 // coupling to a specific named helper.
 export default api;
 
-export const getStudents = (page = 1, limit = 20, { search, status, className } = {}) =>
+export const getStudents = (page = 1, limit = 20, { search, status, className } = {}, { signal } = {}) =>
   api.get("/students", {
     params: {
       page,
@@ -61,14 +61,15 @@ export const getStudents = (page = 1, limit = 20, { search, status, className } 
       ...(status    && status !== "all" && { status }),
       ...(className && { class: className }),
     },
+    signal,
   });
-export const getStudent = (studentId) => api.get(`/students/${studentId}`);
+export const getStudent = (studentId, { signal } = {}) => api.get(`/students/${studentId}`, { signal });
 export const registerStudent = (data) => api.post("/students", data);
 export const updateStudent = (studentId, data) => api.patch(`/students/${studentId}`, data);
 export const getPaymentSummary = () => api.get("/payments/summary");
-export const getPaymentInstructions = (studentId) => api.get(`/payments/instructions/${studentId}`);
-export const getStudentPayments = (studentId) => api.get(`/payments/${studentId}`);
-export const getStudentBalance  = (studentId) => api.get(`/payments/balance/${studentId}`);
+export const getPaymentInstructions = (studentId, { signal } = {}) => api.get(`/payments/instructions/${studentId}`, { signal });
+export const getStudentPayments = (studentId, { signal } = {}) => api.get(`/payments/${studentId}`, { signal });
+export const getStudentBalance  = (studentId, { signal } = {}) => api.get(`/payments/balance/${studentId}`, { signal });
 export const verifyPayment = (txHash) => api.post("/payments/verify", { txHash });
 export const syncPayments = () => api.post("/payments/sync");
 export const getSyncStatus = () => api.get("/payments/sync/status");

--- a/tests/staleRequestRaceCondition.test.js
+++ b/tests/staleRequestRaceCondition.test.js
@@ -1,0 +1,315 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Acceptance criteria:
+ *   Two overlapping lookups are issued where the first-issued request resolves
+ *   *after* the second.  The UI must reflect only the result of the most
+ *   recently issued request — never the stale earlier one.
+ *
+ * Covers:
+ *   - PaymentForm.lookupStudent  (AbortController via api.getStudent et al.)
+ *   - Dashboard.fetchStudents    (AbortController via api.getStudents)
+ */
+
+'use strict';
+
+import '@testing-library/jest-dom';
+import { render, screen, act, fireEvent, waitFor } from '@testing-library/react';
+import PaymentForm from '../frontend/src/components/PaymentForm';
+import Dashboard from '../frontend/src/pages/dashboard';
+import * as api from '../frontend/src/services/api';
+
+// ── Shared mocks ──────────────────────────────────────────────────────────────
+
+jest.mock('../frontend/src/services/api');
+
+// PaymentForm imports QRCodeSVG from qrcode.react — stub it so jsdom doesn't
+// choke on canvas operations.
+jest.mock('qrcode.react', () => ({
+  QRCodeSVG: function MockQR() { return null; },
+}));
+
+// Dashboard sub-components that are irrelevant to the race-condition test.
+jest.mock('../frontend/src/components/SyncButton', () => {
+  return function MockSyncButton() { return null; };
+});
+jest.mock('../frontend/src/components/ErrorBoundary', () => {
+  return function MockErrorBoundary({ children }) { return <>{children}</>; };
+});
+jest.mock('../frontend/src/components/StudentForm', () => {
+  return function MockStudentForm() { return null; };
+});
+jest.mock('../frontend/src/components/SseDegradedBanner', () => {
+  return function MockSseDegradedBanner() { return null; };
+});
+jest.mock('../frontend/src/hooks/usePaymentEvents', () => ({
+  usePaymentEvents: () => ({ degraded: false }),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Returns a {promise, resolve, reject} tuple whose promise is only settled
+ * when the caller invokes resolve/reject — giving the test full control over
+ * resolution order.
+ */
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+// ── PaymentForm race-condition tests ──────────────────────────────────────────
+
+describe('PaymentForm.lookupStudent — stale request race condition', () => {
+  // Fixtures
+  const studentA = {
+    name: 'Alice Johnson',
+    class: 'Grade 5A',
+    feeAmount: 250,
+    feePaid: false,
+    studentId: 'STU-A',
+  };
+  const instructionsA = {
+    walletAddress: 'GSCHOOL_WALLET_AAAA',
+    memo: 'STU-A',
+    feeAmount: 250,
+    acceptedAssets: [{ code: 'XLM', displayName: 'Stellar Lumens' }],
+  };
+
+  const studentB = {
+    name: 'Bob Smith',
+    class: 'Grade 6B',
+    feeAmount: 300,
+    feePaid: true,
+    studentId: 'STU-B',
+  };
+  const instructionsB = {
+    walletAddress: 'GSCHOOL_WALLET_BBBB',
+    memo: 'STU-B',
+    feeAmount: 300,
+    acceptedAssets: [{ code: 'XLM', displayName: 'Stellar Lumens' }],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test(
+    'when lookup-A is issued then lookup-B is issued and B resolves before A, ' +
+    'the UI shows only B\'s student data',
+    async () => {
+      // Create separate deferred handles for each lookup so we can resolve them
+      // in the desired order (B first, then A).
+      const dA = deferred(); // controls lookup-A's getStudent call
+      const dB = deferred(); // controls lookup-B's getStudent call
+
+      let callCount = 0;
+      api.getStudent.mockImplementation((_id, _opts) => {
+        callCount += 1;
+        if (callCount === 1) return dA.promise;
+        return dB.promise;
+      });
+      api.getPaymentInstructions.mockImplementation((id, _opts) => {
+        const data = id === 'STU-A' ? instructionsA : instructionsB;
+        return Promise.resolve({ data });
+      });
+      api.getStudentPayments.mockResolvedValue({ data: [] });
+      api.getStudentBalance.mockResolvedValue({ data: { hasDeletedPayments: false } });
+
+      render(<PaymentForm />);
+
+      // --- Issue lookup A ---
+      const input = screen.getByRole('textbox');
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'STU-A' } });
+      });
+      // Trigger lookup A via form submit to avoid debounce timing in tests.
+      await act(async () => {
+        fireEvent.submit(input.closest('form'));
+      });
+
+      // --- Issue lookup B (supersedes A) ---
+      await act(async () => {
+        fireEvent.change(input, { target: { value: 'STU-B' } });
+      });
+      await act(async () => {
+        fireEvent.submit(input.closest('form'));
+      });
+
+      // --- Resolve B first ---
+      await act(async () => {
+        dB.resolve({ data: studentB });
+      });
+
+      // UI should now show student B's name.
+      await waitFor(() => {
+        expect(screen.getByText('Bob Smith')).toBeInTheDocument();
+      });
+
+      // --- Now resolve A (the stale request) ---
+      await act(async () => {
+        dA.resolve({ data: studentA });
+      });
+
+      // After the stale response lands, the UI must NOT switch to student A.
+      // Give React a tick to process any (incorrect) state update.
+      await act(async () => {});
+
+      expect(screen.queryByText('Alice Johnson')).not.toBeInTheDocument();
+      expect(screen.getByText('Bob Smith')).toBeInTheDocument();
+    }
+  );
+
+  test(
+    'when lookup-A is superseded, loading state clears only after the current (B) lookup settles',
+    async () => {
+      const dA = deferred();
+      const dB = deferred();
+
+      let callCount = 0;
+      api.getStudent.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? dA.promise : dB.promise;
+      });
+      api.getPaymentInstructions.mockResolvedValue({ data: instructionsB });
+      api.getStudentPayments.mockResolvedValue({ data: [] });
+      api.getStudentBalance.mockResolvedValue({ data: { hasDeletedPayments: false } });
+
+      render(<PaymentForm />);
+
+      const input = screen.getByRole('textbox');
+
+      // Issue A then B.
+      await act(async () => { fireEvent.change(input, { target: { value: 'STU-A' } }); });
+      await act(async () => { fireEvent.submit(input.closest('form')); });
+      await act(async () => { fireEvent.change(input, { target: { value: 'STU-B' } }); });
+      await act(async () => { fireEvent.submit(input.closest('form')); });
+
+      // Resolve the stale request A — loading indicator should NOT disappear yet
+      // because B is still in flight.
+      await act(async () => { dA.resolve({ data: studentA }); });
+
+      const submitBtn = screen.getByRole('button', { name: /Get Payment Instructions/i });
+      expect(submitBtn).toBeDisabled(); // still loading
+
+      // Now resolve B — loading should clear.
+      await act(async () => { dB.resolve({ data: studentB }); });
+
+      await waitFor(() => {
+        expect(submitBtn).not.toBeDisabled();
+      });
+    }
+  );
+});
+
+// ── Dashboard.fetchStudents race-condition tests ───────────────────────────────
+
+describe('Dashboard.fetchStudents — stale request race condition', () => {
+  const studentsPage1 = [
+    { studentId: 'STU001', name: 'Alice',   class: 'JSS1', feeAmount: 100, status: 'unpaid' },
+  ];
+  const studentsPage2 = [
+    { studentId: 'STU002', name: 'Bob',     class: 'JSS2', feeAmount: 200, status: 'paid'   },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    api.getSyncStatus.mockResolvedValue({ data: { lastSyncAt: null } });
+    api.getPaymentSummary.mockResolvedValue({
+      data: { totalStudents: 2, paidCount: 1, unpaidCount: 1, totalXlmCollected: 100 },
+    });
+  });
+
+  test(
+    'when fetch-1 is issued then fetch-2 is issued and fetch-2 resolves first, ' +
+    'the UI shows only fetch-2\'s students',
+    async () => {
+      const d1 = deferred(); // first fetch (stale)
+      const d2 = deferred(); // second fetch (current)
+
+      let callCount = 0;
+      api.getStudents.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? d1.promise : d2.promise;
+      });
+
+      render(<Dashboard />);
+
+      // First fetch is triggered on mount.  Wait for it to be in flight.
+      await act(async () => {});
+
+      // Trigger a second fetch by changing the search filter (simulates rapid
+      // typing / filter change before the first response arrives).
+      const searchInput = screen.getByRole('searchbox');
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: 'Bob' } });
+        // Flush the debounce immediately.
+        jest.runAllTimers && jest.runAllTimers();
+      });
+
+      // Let the debounce settle so that debouncedSearch updates and the second
+      // fetch is issued.
+      await act(async () => {});
+
+      // Resolve the newer (second) fetch first with Bob.
+      await act(async () => {
+        d2.resolve({ data: { students: studentsPage2, pages: 1, total: 1 } });
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Bob')).toBeInTheDocument();
+      });
+
+      // Now resolve the stale (first) fetch with Alice — should be ignored.
+      await act(async () => {
+        d1.resolve({ data: { students: studentsPage1, pages: 1, total: 1 } });
+      });
+
+      await act(async () => {});
+
+      expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+    }
+  );
+
+  test(
+    'when a stale fetch resolves with an error, the error is not surfaced if a newer fetch succeeded',
+    async () => {
+      const d1 = deferred(); // stale fetch
+      const d2 = deferred(); // current fetch
+
+      let callCount = 0;
+      api.getStudents.mockImplementation(() => {
+        callCount += 1;
+        return callCount === 1 ? d1.promise : d2.promise;
+      });
+
+      render(<Dashboard />);
+      await act(async () => {});
+
+      const searchInput = screen.getByRole('searchbox');
+      await act(async () => {
+        fireEvent.change(searchInput, { target: { value: 'Bob' } });
+      });
+      await act(async () => {});
+
+      // Second fetch resolves successfully with Bob.
+      await act(async () => {
+        d2.resolve({ data: { students: studentsPage2, pages: 1, total: 1 } });
+      });
+
+      await waitFor(() => expect(screen.getByText('Bob')).toBeInTheDocument());
+
+      // Stale first fetch is aborted — simulate axios CanceledError.
+      const cancelError = new Error('canceled');
+      cancelError.code = 'ERR_CANCELED';
+      await act(async () => { d1.reject(cancelError); });
+      await act(async () => {});
+
+      // No error banner should appear — the abort is silent.
+      expect(screen.queryByText(/Could not load student list/i)).not.toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+    }
+  );
+});


### PR DESCRIPTION
Summary
  
  Fixes a race condition in PaymentForm.lookupStudent and Dashboard.fetchStudents where a slow earlier response could arrive after a faster later one, overwriting
  the UI with stale data. A parent could be shown the wrong student's fee amount or balance — directly wrong information in a payment context.
  
  Root Cause
  
  Both functions issued a new network request on every input change with no mechanism to cancel or ignore superseded in-flight requests. Under variable network
  latency, a request for student A issued before student B could resolve after B, causing A's data to be written to state while B's ID was in the input field.
  
  Changes
  
  frontend/src/services/api.js
  
  - getStudent, getPaymentInstructions, getStudentPayments, getStudentBalance, and getStudents now accept an optional { signal } parameter and forward it to axios,
  enabling callers to cancel requests via AbortController.
  
  frontend/src/components/PaymentForm.jsx
  
  - Added lookupAbortRef holding the active AbortController for the current lookup.
  - On each lookupStudent call: abort the previous controller, create a new one, pass its signal to all four parallel API calls.
  - CanceledError / ERR_CANCELED is caught and silently swallowed — no error banner shown for aborted requests.
  - setLoading(false) / setPaymentsLoading(false) only fires when the settling controller is still the current one, preventing a superseded request from clearing
  the loading state of a newer one.
  - Controller is aborted on component unmount to prevent state updates on an unmounted component.
  
  frontend/src/pages/dashboard.jsx
  
  - Added studentsAbortRef with the same pattern: abort previous controller on each fetchStudents call, pass signal to getStudents, swallow ERR_CANCELED, guard
  loading-state clear to the current controller only.
  
  tests/staleRequestRaceCondition.test.js (new)
  
  - Uses manually-resolved deferred promises to simulate exact resolution order (B before A).
  - Asserts that after the stale request resolves, only the latest result is shown in the UI.
  - Covers PaymentForm: stale data not rendered, loading state tied to current request.
  - Covers Dashboard: stale student list not rendered, silent abort produces no error banner.
  
  Testing
  
  npx jest tests/staleRequestRaceCondition.test.js
  
  All 4 new tests pass. No existing tests modified.
  
 


closes #1069 