### PR TITLE
ci: add lint gates, frontend build, CodeQL SAST, and version-drift check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,21 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # ── #1082 ──────────────────────────────────────────────────────────────────
+  # Fails the build if any shared dependency's declared major version differs
+  # between the root package.json and any workspace (backend / frontend).
+  version-drift:
+    name: Check dependency version drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+      - name: Detect major-version mismatches
+        run: node scripts/check-version-drift.js
+
+  # ── Dependency security audits ─────────────────────────────────────────────
   audit:
     name: Dependency security audit
     runs-on: ubuntu-latest
@@ -69,6 +84,89 @@ jobs:
       - uses: actions/checkout@v7
       - run: node scripts/validate-migrations.js
 
+  # ── #1083: Lint gate ────────────────────────────────────────────────────────
+  # Runs ESLint over backend source. A PR introducing a lint violation fails CI
+  # before merge. Requires branch protection to mark this job as required.
+  lint-backend:
+    name: Lint backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: actions/cache@v6
+        with:
+          path: backend/node_modules
+          key: ${{ runner.os }}-backend-node-${{ hashFiles('backend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-backend-node-
+
+      - name: Install backend dependencies
+        run: cd backend && npm ci
+
+      - name: Run ESLint (backend)
+        run: cd backend && npx eslint src/ --max-warnings=0
+
+  # ── #1083: Lint gate ────────────────────────────────────────────────────────
+  # Runs next lint over the frontend source. A PR introducing a lint violation
+  # fails CI before merge. Requires branch protection to mark this job as required.
+  lint-frontend:
+    name: Lint frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: actions/cache@v6
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-node-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-node-
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Run next lint (frontend)
+        run: cd frontend && npm run lint
+
+  # ── #1081: Frontend build gate ─────────────────────────────────────────────
+  # Runs next build so that any commit introducing a broken import, a JSX syntax
+  # error, or a Next.js build-time error fails CI rather than blocking a deploy.
+  build-frontend:
+    name: Build frontend
+    runs-on: ubuntu-latest
+    env:
+      # next build requires NEXT_PUBLIC_* vars to be present at build time even
+      # if they resolve to a placeholder value in CI.
+      NEXT_PUBLIC_API_URL: http://localhost:5000/api
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: actions/cache@v6
+        with:
+          path: frontend/node_modules
+          key: ${{ runner.os }}-frontend-node-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-frontend-node-
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Build frontend (next build)
+        run: cd frontend && npm run build
+
+  # ── Tests ──────────────────────────────────────────────────────────────────
   test:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,63 @@
+name: CodeQL SAST
+
+# Runs on every pull request and on a daily schedule for the default branch.
+# Free for public repositories via GitHub's native CodeQL analysis.
+#
+# Coverage: JavaScript/TypeScript query pack across the entire repo
+# (backend Express/Node source + frontend Next.js/React source).
+#
+# Findings triage: follow the same severity process documented for dependency
+# vulnerabilities in docs/dependency-triage.md — high/critical findings must be
+# addressed before merge; moderate findings should be triaged within 30 days.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Daily at 03:17 UTC — staggered to avoid peak-hour GitHub runner contention.
+    - cron: '17 3 * * *'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  analyze:
+    name: CodeQL analysis (JavaScript / TypeScript)
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Required to upload SARIF results to the Security tab.
+      security-events: write
+      # Required to fetch the repository contents.
+      contents: read
+      # Required for private repos; no-op for public repos.
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # Initialise the CodeQL tools and select the JavaScript/TypeScript query suite.
+      # The "security-and-quality" suite runs the full set of security queries plus
+      # quality queries (unused code, dead branches, etc.).
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript-typescript
+          queries: security-and-quality
+
+      # CodeQL's JavaScript/TypeScript extractor does not require a build step —
+      # it analyses source files directly. The autobuild step is included here
+      # as a no-op placeholder; it is safe to leave in place if build-time
+      # analysis is ever added for a compiled language.
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:javascript-typescript'
+          # Upload results to the Security → Code scanning tab.
+          upload: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,12 @@
         "@testing-library/react": "^14.3.1",
         "babel-jest": "^29.7.0",
         "cross-env": "^7.0.3",
-        "dotenv": "^17.3.1",
+        "dotenv": "^16.0.0",
         "jest": "^29.0.0",
         "jest-environment-jsdom": "^29.7.0",
         "js-yaml": "^4.1.0",
         "mongodb-memory-server": "^9.1.1",
-        "mongoose": "^9.3.1",
+        "mongoose": "^8.0.0",
         "prom-client": "^15.1.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -2734,9 +2734,9 @@
       "license": "MIT"
     },
     "node_modules/@types/whatwg-url": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-13.0.0.tgz",
-      "integrity": "sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3318,13 +3318,13 @@
       }
     },
     "node_modules/bson": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-7.2.0.tgz",
-      "integrity": "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==",
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=16.20.1"
       }
     },
     "node_modules/buffer-crc32": {
@@ -3998,9 +3998,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
-      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6080,13 +6080,13 @@
       }
     },
     "node_modules/kareem": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-3.2.0.tgz",
-      "integrity": "sha512-VS8MWZz/cT+SqBCpVfNN4zoVz5VskR3N4+sTmUXme55e9avQHntpwpNq0yjnosISXqwJ3AQVjlbI4Dyzv//JtA==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/kleur": {
@@ -6347,27 +6347,27 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.0.tgz",
-      "integrity": "sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.20.0.tgz",
+      "integrity": "sha512-Tl6MEIU3K4Rq3TSHd+sZQqRBoGlFsOgNrH5ltAcFBV62Re3Fd+FcaVf8uSEQFOJ51SDowDVttBTONMfoYWrWlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.3.0",
-        "bson": "^7.1.1",
-        "mongodb-connection-string-url": "^7.0.0"
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=16.20.1"
       },
       "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.806.0",
-        "@mongodb-js/zstd": "^7.0.0",
-        "gcp-metadata": "^7.0.1",
-        "kerberos": "^7.0.0",
-        "mongodb-client-encryption": ">=7.0.0 <7.1.0",
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
         "snappy": "^7.3.2",
-        "socks": "^2.8.6"
+        "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
@@ -6394,17 +6394,14 @@
       }
     },
     "node_modules/mongodb-connection-string-url": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-7.0.1.tgz",
-      "integrity": "sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@types/whatwg-url": "^13.0.0",
-        "whatwg-url": "^14.1.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
       }
     },
     "node_modules/mongodb-memory-server": {
@@ -6574,21 +6571,22 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.3.1.tgz",
-      "integrity": "sha512-58DuQti+LlRS74/UfWN4F3wZsC0Yr1dgTWZ2Wd3/TuSvm6rIdyAjDWbx2xGyuBooqJYdAWotVv4mQgVdivh+3Q==",
+      "version": "8.24.2",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.24.2.tgz",
+      "integrity": "sha512-5+H3MSHNJCcr9M+lVplekrZ4/Dyn3N1dOpvgn9gMwvHJhunc4G8SQcBVd/btBQoVdspVNPjx8Pw03YWBv6uTJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "kareem": "3.2.0",
-        "mongodb": "~7.1",
+        "bson": "^6.10.4",
+        "kareem": "2.6.3",
+        "mongodb": "~6.20.0",
         "mpath": "0.9.0",
-        "mquery": "6.0.0",
+        "mquery": "5.0.0",
         "ms": "2.1.3",
         "sift": "17.1.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=16.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -6606,13 +6604,16 @@
       }
     },
     "node_modules/mquery": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mquery/-/mquery-6.0.0.tgz",
-      "integrity": "sha512-b2KQNsmgtkscfeDgkYMcWGn9vZI9YoXh802VDEwE6qc50zxBFQ0Oo8ROkawbPAsXCY1/Z1yp0MagqsZStPWJjw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-5.0.0.tgz",
+      "integrity": "sha512-iQMncpmEK8R8ncT8HJGsGc9Dsp8xcgYMVSbs5jgnm1lFHTZqMJTUWTDx1LBO8+mK3tPNZWFLBghQEIOULSTHZg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "debug": "4.x"
+      },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "test:e2e": "jest tests/e2e/ --forceExit --runInBand --testPathIgnorePatterns=/node_modules/",
     "test:integration": "cross-env RUN_INTEGRATION_TESTS=true jest tests/stellar.integration.test.js --forceExit",
     "test:docker-healthcheck": "cross-env RUN_DOCKER_COMPOSE_HEALTHCHECK_TESTS=true jest tests/dockerComposeHealthCheck.test.js --forceExit",
-    "seed": "node scripts/seed-test-data.js"
+    "seed": "node scripts/seed-test-data.js",
+    "check-version-drift": "node scripts/check-version-drift.js"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",
@@ -16,12 +17,12 @@
     "@testing-library/react": "^14.3.1",
     "babel-jest": "^29.7.0",
     "cross-env": "^7.0.3",
-    "dotenv": "^17.3.1",
+    "dotenv": "^16.0.0",
     "jest": "^29.0.0",
     "jest-environment-jsdom": "^29.7.0",
     "js-yaml": "^4.1.0",
     "mongodb-memory-server": "^9.1.1",
-    "mongoose": "^9.3.1",
+    "mongoose": "^8.0.0",
     "prom-client": "^15.1.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/scripts/check-version-drift.js
+++ b/scripts/check-version-drift.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * check-version-drift.js
+ *
+ * Fails if any shared dependency's declared major version differs between the
+ * root package.json and any workspace package.json (backend, frontend).
+ *
+ * Usage:
+ *   node scripts/check-version-drift.js
+ *
+ * Exit codes:
+ *   0 — no major-version drift detected
+ *   1 — one or more drift violations found
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+
+/** Parse major version from a semver range string (e.g. "^8.0.0" → 8). */
+function parseMajor(range) {
+  if (!range) return null;
+  // Strip leading range specifiers: ^, ~, >=, <=, =, >, <, whitespace
+  const cleaned = range.replace(/^[~^>=<\s]+/, '').trim();
+  const match = cleaned.match(/^(\d+)/);
+  return match ? parseInt(match[1], 10) : null;
+}
+
+/** Read and parse a package.json file, returning its combined dependencies map. */
+function readDeps(pkgPath) {
+  const raw = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  return Object.assign(
+    {},
+    raw.dependencies || {},
+    raw.devDependencies || {},
+    raw.peerDependencies || {}
+  );
+}
+
+const workspaces = [
+  { label: 'backend', pkgPath: path.join(ROOT, 'backend', 'package.json') },
+  { label: 'frontend', pkgPath: path.join(ROOT, 'frontend', 'package.json') },
+];
+
+const rootDeps = readDeps(path.join(ROOT, 'package.json'));
+
+let violations = 0;
+
+for (const ws of workspaces) {
+  if (!fs.existsSync(ws.pkgPath)) {
+    continue;
+  }
+  const wsDeps = readDeps(ws.pkgPath);
+
+  for (const [pkg, wsRange] of Object.entries(wsDeps)) {
+    if (!(pkg in rootDeps)) continue; // package not in root — no drift to detect
+
+    const rootMajor = parseMajor(rootDeps[pkg]);
+    const wsMajor = parseMajor(wsRange);
+
+    if (rootMajor === null || wsMajor === null) continue; // non-semver range, skip
+
+    if (rootMajor !== wsMajor) {
+      console.error(
+        `[version-drift] MISMATCH: "${pkg}" — root declares major ${rootMajor} ` +
+          `(${rootDeps[pkg]}), ${ws.label} declares major ${wsMajor} (${wsRange})`
+      );
+      violations++;
+    }
+  }
+}
+
+if (violations > 0) {
+  console.error(
+    `\n${violations} major-version drift violation(s) found. ` +
+      'Align the version ranges in the affected package.json files and re-run.'
+  );
+  process.exit(1);
+} else {
+  console.log('check-version-drift: no major-version drift detected.');
+}


### PR DESCRIPTION
## Summary

Closes #1081
closes #1082
closes #1083
closes #1084 
 four CI pipeline gaps identified in the security/quality audit.

---

### #1082 — Mongoose version drift between root and backend

**Root cause:** `package.json` declared `mongoose: ^9.3.1` while `backend/package.json` runs `^8.0.0`, meaning the root-level test suite was exercising Mongoose 9 behaviour against a production stack that runs Mongoose 8.

**Fix:**
- Aligned root `mongoose` to `^8.0.0`
- Also aligned `dotenv` (`^17.3.1` → `^16.0.0`) which had the same class of drift
- Added `scripts/check-version-drift.js` — exits non-zero if any shared dependency's declared major version differs between root and any workspace `package.json`
- Added a `version-drift` CI job that runs this script on every PR and push

---

### #1081 — Frontend build never ran in CI

**Root cause:** CI installed frontend deps but never ran `next build`, so broken imports, JSX syntax errors, and Next.js build-time failures could merge to main undetected.

**Fix:** Added `build-frontend` CI job that runs `npm run build` (i.e. `next build`) in the `frontend/` workspace on every PR and push. A `NEXT_PUBLIC_API_URL` placeholder is injected at build time so the build doesn't error on missing env vars.

---

### #1083 — No lint gate in CI

**Root cause:** Both `backend/.eslintrc.json` and `frontend/`'s `next lint` script were fully configured but never called by CI.

**Fix:**
- Added `lint-backend` job: runs `npx eslint src/ --max-warnings=0` in `backend/`
- Added `lint-frontend` job: runs `npm run lint` (next lint) in `frontend/`

Both jobs must pass before merge; mark them required in branch protection settings.

---

### #1084 — No first-party SAST coverage

**Root cause:** The only security check in CI was `npm audit`, which covers third-party CVEs but not first-party code patterns (injection, missing-auth, tenant-scoping gaps, etc.).

**Fix:** Added `.github/workflows/codeql.yml`:
- Language: `javascript-typescript`
- Query suite: `security-and-quality`
- Triggers: every PR, every push to `main`, and daily at 03:17 UTC
- Results uploaded to the Security → Code scanning tab
- Findings triage follows the same process documented in `docs/dependency-triage.md`

---

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Added `version-drift`, `lint-backend`, `lint-frontend`, `build-frontend` jobs |
| `.github/workflows/codeql.yml` | New — CodeQL SAST workflow |
| `scripts/check-version-drift.js` | New — major-version drift detector |
| `package.json` | `mongoose ^9.3.1 → ^8.0.0`, `dotenv ^17.3.1 → ^16.0.0` |
| `package-lock.json` | Updated to reflect version changes |

## Testing

- `node scripts/check-version-drift.js` passes cleanly with the corrected versions
- CI jobs are structured identically to the existing `audit` and `test` jobs (same cache keys, same `setup-node` version)