### PR TITLE
fix(monitoring): auto-provision Grafana dashboards from repository

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -41,6 +41,7 @@ services:
     volumes:
       - grafana_data:/var/lib/grafana
       - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
       - "3001:3000"
     depends_on:

--- a/monitoring/grafana/provisioning/dashboards/default.yml
+++ b/monitoring/grafana/provisioning/dashboards/default.yml
@@ -1,0 +1,14 @@
+apiVersion: 1
+
+providers:
+  - name: "StellarEduPay Dashboards"
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: false
+    options:
+      # Path inside the Grafana container where dashboards are mounted.
+      # Matches the volume mount added in docker-compose.monitoring.yml.
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false


### PR DESCRIPTION
- Add monitoring/grafana/provisioning/dashboards/default.yml so Grafana's provisioning system knows to load JSON files from the dashboards/ directory.
- Mount ./monitoring/grafana/dashboards into the Grafana container at /var/lib/grafana/dashboards (read-only) alongside the existing provisioning mount.

Previously the webhooks.json dashboard checked into version control was never loaded automatically — every new deployment required a manual import. With this change, any dashboard JSON placed in monitoring/grafana/dashboards/ will appear in Grafana automatically on first start, satisfying the acceptance criterion: a fresh monitoring stack shows the webhooks dashboard with no manual import step required.

Closes #1100 