### PR TITLE
fix(outbox): await async listeners before marking events processed

### DIFF
--- a/backend/src/events/paymentEvents.js
+++ b/backend/src/events/paymentEvents.js
@@ -15,4 +15,40 @@ const paymentEvents = new EventEmitter();
 // Prevent silent event-loop leaks when many subscribers are registered.
 paymentEvents.setMaxListeners(20);
 
+/**
+ * Emit an event and await all listener results via Promise.allSettled.
+ *
+ * Unlike EventEmitter.prototype.emit, which invokes listeners synchronously
+ * and ignores any promises they return, this method collects every listener's
+ * return value — whether a plain value or a promise — and waits for all of
+ * them to settle. This is essential for the outbox dispatcher, which must
+ * confirm that every async side-effect (webhook delivery, receipt generation,
+ * etc.) completed before marking an outbox event as processed.
+ *
+ * @param {string} eventType
+ * @param {...*} args — arguments forwarded to each listener
+ * @returns {Promise<PromiseSettledResult[]>} settled results from every listener
+ */
+paymentEvents.asyncEmit = async function asyncEmit(eventType, ...args) {
+  const listeners = paymentEvents.rawListeners(eventType);
+  if (listeners.length === 0) return [];
+
+  const results = await Promise.allSettled(
+    listeners.map((listener) => {
+      try {
+        const result = listener(...args);
+        // If the listener returned a promise, wait for it to settle;
+        // otherwise wrap the plain value as a fulfilled promise.
+        return (result != null && typeof result.then === 'function')
+          ? result
+          : Promise.resolve(result);
+      } catch (err) {
+        return Promise.reject(err);
+      }
+    }),
+  );
+
+  return results;
+};
+
 module.exports = paymentEvents;

--- a/backend/src/services/outboxDispatcher.js
+++ b/backend/src/services/outboxDispatcher.js
@@ -38,7 +38,17 @@ async function dispatchOutboxEvents() {
           continue;
         }
 
-        paymentEvents.emit(event.eventType, event.payload);
+        const results = await paymentEvents.asyncEmit(event.eventType, event.payload);
+
+        // If any listener failed (rejected), treat the whole dispatch as
+        // failed so the event gets retried or dead-lettered rather than
+        // being permanently marked processed with unprocessed side-effects.
+        const rejected = results.filter((r) => r.status === 'rejected');
+        if (rejected.length > 0) {
+          const messages = rejected.map((r) => r.reason?.message || String(r.reason));
+          throw new Error(`Listener(s) rejected: ${messages.join('; ')}`);
+        }
+
         await Outbox.findByIdAndUpdate(event._id, {
           processed: true,
           processedAt: new Date(),

--- a/backend/tests/outboxDispatcherAsyncRejection.test.js
+++ b/backend/tests/outboxDispatcherAsyncRejection.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+/**
+ * Tests that the outbox dispatcher does NOT mark an event as processed when
+ * an async listener rejects — the event must instead be retried or
+ * dead-lettered, preserving the at-least-once delivery guarantee.
+ *
+ * Acceptance criteria (issue #1050):
+ *   "An outbox event whose listener's async portion throws is not marked
+ *    processed: true, and is instead retried or routed to the existing
+ *    dead-letter/retry mechanism; a test simulates an async listener
+ *    rejection and asserts the outbox row remains unprocessed (or is
+ *    retried) rather than being marked complete."
+ */
+
+const Outbox = require('../src/models/outboxModel');
+const paymentEvents = require('../src/events/paymentEvents');
+
+jest.mock('../src/models/outboxModel', () => ({
+  find: jest.fn(),
+  findByIdAndUpdate: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../src/events/paymentEvents', () => ({
+  emit: jest.fn(),
+  asyncEmit: jest.fn(),
+}));
+
+const mockOutboxLogger = {
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+};
+
+jest.mock('../src/utils/logger', () => ({
+  child: jest.fn(() => mockOutboxLogger),
+}));
+
+const { dispatchOutboxEvents } = require('../src/services/outboxDispatcher');
+
+describe('outboxDispatcher — async listener rejection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function mockOutboxBatch(batch) {
+    const sort = jest.fn().mockResolvedValue(batch);
+    const limit = jest.fn(() => ({ sort }));
+    Outbox.find.mockReturnValue({ limit });
+    return { limit, sort };
+  }
+
+  it('retries an event whose async listener rejects', async () => {
+    const event = {
+      _id: 'outbox-retry',
+      eventId: 'retry-event',
+      eventType: 'payment.saved',
+      payload: { paymentId: 'p1' },
+      retryCount: 0,
+    };
+
+    mockOutboxBatch([event]);
+
+    // Simulate asyncEmit returning one rejected and one fulfilled result
+    paymentEvents.asyncEmit.mockResolvedValue([
+      { status: 'rejected', reason: new Error('webhook timeout') },
+    ]);
+
+    await dispatchOutboxEvents();
+
+    // The event should NOT be marked processed
+    expect(Outbox.findByIdAndUpdate).not.toHaveBeenCalledWith(
+      event._id,
+      expect.objectContaining({ processed: true }),
+    );
+
+    // Instead, retryCount should be incremented with the error message
+    expect(Outbox.findByIdAndUpdate).toHaveBeenCalledWith(
+      event._id,
+      expect.objectContaining({
+        retryCount: 1,
+        lastError: 'Listener(s) rejected: webhook timeout',
+      }),
+    );
+
+    // Dead-letter should NOT have been called (retry budget not exhausted)
+    expect(Outbox.findByIdAndUpdate).not.toHaveBeenCalledWith(
+      event._id,
+      expect.objectContaining({ deadLettered: true }),
+    );
+
+    expect(mockOutboxLogger.error).not.toHaveBeenCalledWith(
+      'Outbox event exceeded max retries',
+      expect.anything(),
+    );
+  });
+
+  it('dead-letters after max retries when async listener keeps rejecting', async () => {
+    const event = {
+      _id: 'outbox-deadletter-async',
+      eventId: 'deadletter-async',
+      eventType: 'payment.saved',
+      payload: { paymentId: 'p2' },
+      retryCount: 2,
+    };
+
+    mockOutboxBatch([event]);
+
+    paymentEvents.asyncEmit.mockResolvedValue([
+      { status: 'rejected', reason: new Error('persistent webhook failure') },
+    ]);
+
+    await dispatchOutboxEvents();
+
+    // Should be dead-lettered (retryCount 2 + 1 = 3 >= MAX_RETRIES)
+    expect(Outbox.findByIdAndUpdate).toHaveBeenCalledWith(
+      event._id,
+      expect.objectContaining({
+        retryCount: 3,
+        lastError: 'Listener(s) rejected: persistent webhook failure',
+        deadLettered: true,
+        deadLetteredAt: expect.any(Date),
+        deadLetterReason: 'max_retries_exhausted',
+      }),
+    );
+
+    expect(mockOutboxLogger.error).toHaveBeenCalledWith(
+      'Outbox event exceeded max retries',
+      expect.objectContaining({ eventId: 'deadletter-async', retryCount: 3 }),
+    );
+  });
+
+  it('marks event processed when all async listeners resolve', async () => {
+    const event = {
+      _id: 'outbox-success',
+      eventId: 'success-event',
+      eventType: 'payment.saved',
+      payload: { paymentId: 'p3' },
+      retryCount: 0,
+    };
+
+    mockOutboxBatch([event]);
+
+    // All listeners succeeded
+    paymentEvents.asyncEmit.mockResolvedValue([
+      { status: 'fulfilled', value: undefined },
+      { status: 'fulfilled', value: { receiptId: 'r1' } },
+    ]);
+
+    await dispatchOutboxEvents();
+
+    // Event should be marked processed
+    expect(Outbox.findByIdAndUpdate).toHaveBeenCalledWith(
+      event._id,
+      expect.objectContaining({
+        processed: true,
+        processedAt: expect.any(Date),
+      }),
+    );
+  });
+});

--- a/backend/tests/outboxDispatcherDeadLetter.test.js
+++ b/backend/tests/outboxDispatcherDeadLetter.test.js
@@ -10,6 +10,7 @@ jest.mock('../src/models/outboxModel', () => ({
 
 jest.mock('../src/events/paymentEvents', () => ({
   emit: jest.fn(),
+  asyncEmit: jest.fn().mockResolvedValue([]),
 }));
 
 const mockOutboxLogger = {
@@ -62,8 +63,8 @@ describe('outboxDispatcher dead-letter handling', () => {
       processed: false,
       deadLettered: { $ne: true },
     });
-    expect(paymentEvents.emit).toHaveBeenCalledTimes(1);
-    expect(paymentEvents.emit).toHaveBeenCalledWith('payment.confirmed', healthyEvent.payload);
+    expect(paymentEvents.asyncEmit).toHaveBeenCalledTimes(1);
+    expect(paymentEvents.asyncEmit).toHaveBeenCalledWith('payment.confirmed', healthyEvent.payload);
     expect(Outbox.findByIdAndUpdate).toHaveBeenCalledWith(
       exhaustedEvent._id,
       expect.objectContaining({
@@ -97,9 +98,9 @@ describe('outboxDispatcher dead-letter handling', () => {
     const failure = new Error('listener crashed');
 
     mockOutboxBatch([failingEvent]);
-    paymentEvents.emit.mockImplementationOnce(() => {
-      throw failure;
-    });
+    paymentEvents.asyncEmit.mockResolvedValueOnce([
+      { status: 'rejected', reason: failure },
+    ]);
 
     await dispatchOutboxEvents();
 
@@ -107,7 +108,7 @@ describe('outboxDispatcher dead-letter handling', () => {
       failingEvent._id,
       expect.objectContaining({
         retryCount: 3,
-        lastError: failure.message,
+        lastError: 'Listener(s) rejected: listener crashed',
         deadLettered: true,
         deadLetteredAt: expect.any(Date),
         deadLetterReason: 'max_retries_exhausted',

--- a/backend/tests/outboxDispatcherUnhandledRejection.test.js
+++ b/backend/tests/outboxDispatcherUnhandledRejection.test.js
@@ -21,6 +21,7 @@ jest.mock('../src/models/outboxModel', () => ({
 
 jest.mock('../src/events/paymentEvents', () => ({
   emit: jest.fn(),
+  asyncEmit: jest.fn().mockResolvedValue([]),
 }));
 
 // Simulates a log-transport failure specifically on dispatchOutboxEvents' own


### PR DESCRIPTION
## Overview

The outbox dispatcher called `EventEmitter.emit()` synchronously and then immediately marked the outbox row `processed: true`. Since Node's `EventEmitter` does not await async listeners — it returns after invoking them, not after they complete — any async side-effect (webhook delivery, receipt generation, etc.) that later rejected would be silently lost, with the event already permanently recorded as successfully dispatched. This directly undermined the at-least-once delivery guarantee the outbox pattern is designed to provide.

## Related Issue

Closes #1050

## Changes

### Async Event Emission

- **[MODIFY]** `backend/src/events/paymentEvents.js`
  - Added `asyncEmit` method that collects every listener's return value via `Promise.allSettled` and awaits all promises before returning.

- **[MODIFY]** `backend/src/services/outboxDispatcher.js`
  - Replaced `paymentEvents.emit()` with `await paymentEvents.asyncEmit()`.
  - If any listener rejected, the event is **not** marked processed — it goes through the existing retry/dead-letter mechanism instead.

- **[ADD]** `backend/tests/outboxDispatcherAsyncRejection.test.js`
  - Verifies an async listener rejection causes the event to be retried (not marked processed).
  - Verifies dead-lettering after max retries when async listener keeps rejecting.
  - Verifies all listeners resolving leads to event being marked processed.

- **[MODIFY]** `backend/tests/outboxDispatcherDeadLetter.test.js` / `outboxDispatcherUnhandledRejection.test.js`
  - Updated mocks to reflect the new `asyncEmit` dispatch path.

## Verification Results

All 6 outbox dispatcher tests pass (3 test suites), and all 6 transaction service tests pass.

| Acceptance Criteria | Status |
| --- | --- |
| Async listener rejection is not marked `processed: true` | Event is retried with incremented retryCount |
| Event is routed to dead-letter mechanism after retries exhausted | deadLettered: true with appropriate reason |
| All listeners succeeding marks event as processed | processed: true only when all fulfilled |
| Existing retry/dead-letter flow preserved | Tests updated, all pass |

Made with [Cursor](https://cursor.com)