### PR TITLE
Fix sync-lock spec drift, tenant-scoped memo index, partial-credit race, inactive-school rollups

### DIFF
--- a/.kiro/specs/sync-idempotency-lock/design.md
+++ b/.kiro/specs/sync-idempotency-lock/design.md
@@ -1,6 +1,33 @@
 # Design Document: sync-idempotency-lock
 
-## Overview
+## Implementation Status
+
+**Not implemented as specified.** This document describes a proposed per-transaction
+`SyncLock` Mongoose model that was never built — no such model exists in
+`backend/src/models/`, and every task in `tasks.md` is unchecked.
+
+The idempotency problem this spec addresses is instead handled by the existing
+**`distributedLock.js`** service (Redis-backed, in-process fallback when Redis is
+unconfigured), via two locks:
+
+- A **per-school sync lock** (`sync:lock:<schoolId>`), acquired in
+  `paymentAdminController.js` (`syncAllPayments`) and `transactionPollingService.js`
+  before either one calls `syncPaymentsForSchool()`. A contended acquisition
+  returns/skips rather than running a concurrent sync for the same school.
+- A **per-student balance lock** (`sync:lock:<schoolId>:student:<studentId>`, see
+  `distributedLock.studentBalanceLockKey`), acquired inside `syncPaymentsForSchool()`
+  (`stellarService.js`) around the balance read-update-write section, and shared with
+  `verifyPayment` (`paymentController.js`) so a manual verification and a sync run
+  can't race on the same student's balance.
+
+The `Payment.txHash` unique index remains as the defence-in-depth guard described in
+Requirement 3 below, which is the one part of this spec that did ship.
+
+The rest of this document is kept for historical/reference purposes only and does not
+describe the current system. Do not use it to reason about how sync idempotency
+actually works today — see `distributedLock.js` and the call sites above instead.
+
+## Overview (original proposal, not built)
 
 `POST /api/payments/sync` (and the background poller) both call `syncPayments()` in `stellarService.js`. Because the function fetches a batch of transactions and processes each one sequentially, two concurrent invocations can race: both read the same `txHash` from Horizon before either has written a `Payment` document, so both proceed through fee validation and student-status updates before the second one hits the `txHash` unique-index error.
 

--- a/backend/migrations/025_scope_payment_intent_memo_index.js
+++ b/backend/migrations/025_scope_payment_intent_memo_index.js
@@ -1,0 +1,50 @@
+'use strict';
+
+/**
+ * Migration 025 — Scope the paymentIntents.memo unique index to schoolId
+ *
+ * paymentIntentModel.js previously declared `memo` with a global unique:true
+ * index. Memos are only guaranteed unique within a school, so two different
+ * schools producing the same memo hit a raw duplicate-key error (#1202).
+ * Replace the global unique index with a compound { schoolId: 1, memo: 1 }
+ * unique index.
+ */
+
+const mongoose = require('mongoose');
+
+const VERSION = '025_scope_payment_intent_memo_index';
+
+async function up() {
+  const collection = mongoose.connection.collection('paymentintents');
+
+  const indexes = await collection.indexes();
+  const globalMemoIndex = indexes.find(
+    (idx) => idx.unique && idx.key && Object.keys(idx.key).length === 1 && idx.key.memo !== undefined
+  );
+  if (globalMemoIndex) {
+    await collection.dropIndex(globalMemoIndex.name);
+    console.log(`[025] Dropped global unique memo index: ${globalMemoIndex.name}`);
+  }
+
+  await collection.createIndex(
+    { schoolId: 1, memo: 1 },
+    { unique: true, background: true, name: 'schoolId_1_memo_1_unique' }
+  );
+  console.log('[025] Created compound unique index on paymentintents: { schoolId: 1, memo: 1 }');
+}
+
+async function down() {
+  const collection = mongoose.connection.collection('paymentintents');
+
+  const indexes = await collection.indexes();
+  const compoundIndex = indexes.find((idx) => idx.name === 'schoolId_1_memo_1_unique');
+  if (compoundIndex) {
+    await collection.dropIndex(compoundIndex.name);
+    console.log('[025] Dropped compound unique memo index');
+  }
+
+  await collection.createIndex({ memo: 1 }, { unique: true, background: true });
+  console.log('[025] Recreated global unique index on paymentintents.memo');
+}
+
+module.exports = { version: VERSION, up, down };

--- a/backend/src/controllers/paymentController.js
+++ b/backend/src/controllers/paymentController.js
@@ -175,6 +175,9 @@ async function createPaymentIntent(req, res, next) {
       categoryInfo,
     });
   } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ error: 'A payment intent with that memo already exists for this school', code: 'DUPLICATE_PAYMENT_INTENT' });
+    }
     next(err);
   }
 }

--- a/backend/src/models/paymentIntentModel.js
+++ b/backend/src/models/paymentIntentModel.js
@@ -9,7 +9,7 @@ const paymentIntentSchema = new mongoose.Schema(
     studentId: { type: String, required: true },
     amount: { type: Number, required: true },
     feeCategory: { type: String, default: null },
-    memo: { type: String, required: true, unique: true },
+    memo: { type: String, required: true },
     status: {
       type: String,
       enum: ["pending", "completed", "expired"],
@@ -24,6 +24,9 @@ paymentIntentSchema.index({ schoolId: 1, studentId: 1 });
 paymentIntentSchema.index({ schoolId: 1, status: 1 });
 // Lookup intent by memo during payment sync
 paymentIntentSchema.index({ schoolId: 1, memo: 1, status: 1 });
+// Memos are only required to be unique within a school, not globally — two
+// schools can legitimately produce the same memo (#1202).
+paymentIntentSchema.index({ schoolId: 1, memo: 1 }, { unique: true });
 // Cleanup / TTL queries on expired intents
 paymentIntentSchema.index({ status: 1, expiresAt: 1 });
 // Compound index for active intent lookup: { studentId, schoolId, expiresAt }

--- a/backend/src/services/metricsRollupService.js
+++ b/backend/src/services/metricsRollupService.js
@@ -174,7 +174,7 @@ let _timer = null;
 
 async function _runScheduledReconciliation() {
   const School = require('../models/schoolModel');
-  const schools = await School.find({}, 'schoolId').lean();
+  const schools = await School.find({ isActive: true }, 'schoolId').lean();
   const endDate   = _dayKey(new Date());
   const startDate = _dayKey(new Date(Date.now() - 32 * 86400000));
   for (const school of schools) {

--- a/backend/src/services/underpaidReconciliationService.js
+++ b/backend/src/services/underpaidReconciliationService.js
@@ -12,6 +12,11 @@
 const Payment = require('../models/paymentModel');
 const Student = require('../models/studentModel');
 const logger = require('../utils/logger');
+const lock = require('./distributedLock');
+
+// Shares the same TTL convention as the other callers of the per-student
+// balance lock (paymentController.verifyPayment, stellarService.syncPaymentsForSchool).
+const STUDENT_BALANCE_LOCK_TTL_MS = parseInt(process.env.STUDENT_BALANCE_LOCK_TTL_MS || '15000', 10);
 
 /**
  * Apply partial credit to an underpaid payment
@@ -45,47 +50,66 @@ async function applyPartialCredit(paymentId, creditAmount, creditAppliedBy, scho
     );
   }
 
-  // Ensure credit doesn't exceed the shortfall
-  const student = await Student.findOne({
-    schoolId: payment.schoolId,
-    studentId: payment.studentId,
-  });
-
-  if (!student) {
+  // Guard the read-modify-write of the student's balance with the same
+  // per-student distributed lock used by verifyPayment/syncPaymentsForSchool
+  // (#1201), so a concurrent payment confirmation for this student can't
+  // race this read-modify-write and silently lose one of the two updates.
+  const studentLockKey = lock.studentBalanceLockKey(payment.schoolId, payment.studentId);
+  const studentLockInfo = await lock.acquire(studentLockKey, STUDENT_BALANCE_LOCK_TTL_MS);
+  if (!studentLockInfo) {
     throw new Error(
-      `Student ${payment.studentId} not found in school ${payment.schoolId}`
+      `Could not acquire balance lock for student ${payment.studentId} — another update is in progress. Please retry.`
     );
   }
+  const { token: studentLockToken } = studentLockInfo;
 
-  const shortfall = Math.max(0, student.feeAmount - (student.totalPaid || 0));
-  if (creditAmount > shortfall) {
-    throw new Error(
-      `Credit amount (${creditAmount}) exceeds shortfall (${shortfall}). ` +
-      'Partial credit cannot exceed the remaining fee balance.'
+  let now;
+  try {
+    // Re-read the student's balance now that the lock is held, so the shortfall
+    // check and the write below are both based on up-to-date data.
+    const student = await Student.findOne({
+      schoolId: payment.schoolId,
+      studentId: payment.studentId,
+    });
+
+    if (!student) {
+      throw new Error(
+        `Student ${payment.studentId} not found in school ${payment.schoolId}`
+      );
+    }
+
+    const shortfall = Math.max(0, student.feeAmount - (student.totalPaid || 0));
+    if (creditAmount > shortfall) {
+      throw new Error(
+        `Credit amount (${creditAmount}) exceeds shortfall (${shortfall}). ` +
+        'Partial credit cannot exceed the remaining fee balance.'
+      );
+    }
+
+    now = new Date();
+
+    // Update payment with credit information
+    payment.underpaidReconciliation.status = 'partial_credited';
+    payment.underpaidReconciliation.appliedCredit = creditAmount;
+    payment.underpaidReconciliation.creditAppliedAt = now;
+    payment.underpaidReconciliation.creditAppliedBy = creditAppliedBy;
+    await payment.save();
+
+    // Update student's cumulative balance
+    const newTotalPaid = (student.totalPaid || 0) + creditAmount;
+    const newRemainingBalance = Math.max(0, student.feeAmount - newTotalPaid);
+    await Student.findOneAndUpdate(
+      { schoolId: payment.schoolId, studentId: payment.studentId },
+      {
+        totalPaid: parseFloat(newTotalPaid.toFixed(7)),
+        remainingBalance: parseFloat(newRemainingBalance.toFixed(7)),
+        feePaid: newTotalPaid >= student.feeAmount,
+      },
+      { new: true }
     );
+  } finally {
+    await lock.release(studentLockKey, studentLockToken);
   }
-
-  const now = new Date();
-
-  // Update payment with credit information
-  payment.underpaidReconciliation.status = 'partial_credited';
-  payment.underpaidReconciliation.appliedCredit = creditAmount;
-  payment.underpaidReconciliation.creditAppliedAt = now;
-  payment.underpaidReconciliation.creditAppliedBy = creditAppliedBy;
-  await payment.save();
-
-  // Update student's cumulative balance
-  const newTotalPaid = (student.totalPaid || 0) + creditAmount;
-  const newRemainingBalance = Math.max(0, student.feeAmount - newTotalPaid);
-  await Student.findOneAndUpdate(
-    { schoolId: payment.schoolId, studentId: payment.studentId },
-    {
-      totalPaid: parseFloat(newTotalPaid.toFixed(7)),
-      remainingBalance: parseFloat(newRemainingBalance.toFixed(7)),
-      feePaid: newTotalPaid >= student.feeAmount,
-    },
-    { new: true }
-  );
 
   logger.info('[UnderpaidReconciliation] Partial credit applied', {
     paymentId: payment._id,


### PR DESCRIPTION
## Summary

Four independent fixes bundled into one PR:

### #1203 — sync-idempotency-lock spec no longer matches implementation
`.kiro/specs/sync-idempotency-lock/design.md` described a per-transaction `SyncLock` Mongoose model that was never built (no such model exists, every task in `tasks.md` is unchecked). The doc is now labeled with an "Implementation Status" section explaining it was never implemented as designed, and pointing to the actual mechanism in production: `distributedLock.js`, via a per-school sync lock (`sync:lock:<schoolId>`) in `paymentAdminController.js` / `transactionPollingService.js`, and a per-student balance lock (`distributedLock.studentBalanceLockKey`) shared between `syncPaymentsForSchool` and `verifyPayment`. The original proposal is preserved below that section for historical reference only.

### #1202 — PaymentIntent.memo had a globally-unique index
`paymentIntentModel.js` declared `memo` with a global `unique: true` index, but memos are only guaranteed unique per school. Two schools producing the same memo triggered a raw MongoDB `E11000` error (500) instead of a handled error.
- Removed the global unique constraint on `memo`; added a compound `{ schoolId: 1, memo: 1 }` unique index instead.
- Added migration `025_scope_payment_intent_memo_index.js` to drop the old global unique index and create the compound one on existing collections (with a `down()` to revert).
- Added a duplicate-key (`11000`) catch in `createPaymentIntent` (`paymentController.js`) that returns a clean `409 DUPLICATE_PAYMENT_INTENT` instead of letting the error bubble up as a 500.

### #1201 — applyPartialCredit raced with concurrent payment confirmations
`underpaidReconciliationService.js`'s `applyPartialCredit` read a student's balance and wrote back an absolute value with no locking — a classic lost-update race against a concurrent `verifyPayment` or `syncPaymentsForSchool` run touching the same student.
- Wrapped the read-modify-write in the same per-student distributed lock (`distributedLock.studentBalanceLockKey`) already used by `verifyPayment` and `syncPaymentsForSchool`, so the three call sites now properly contend with each other.
- The student balance is re-read after the lock is acquired so the shortfall check and the write both use fresh data.

### #1200 — metrics-rollup scheduler included deactivated schools
`metricsRollupService.js`'s `_runScheduledReconciliation` looped over every `School` with no `isActive` filter, unlike its sibling schedulers (`consistencyService`, `reconciliationService`, `reminderService`, `transactionPollingService`), doing unnecessary rollup work for every deactivated school on every run.
- Added `{ isActive: true }` to the school-selection query, matching the established convention.

## Test plan
Not run for this PR — implementation only, per explicit instruction to skip testing.

Closes #1203
Closes #1202
Closes #1201
Closes #1200