### PR TITLE
Fix soft-delete consistency, insecure RNG, script output labeling, and missing sparse index

### DIFF
--- a/backend/src/controllers/feeController.js
+++ b/backend/src/controllers/feeController.js
@@ -113,7 +113,7 @@ async function updateFeeStructure(req, res, next) {
 
             // Aggregate confirmed payment totals per student from authoritative source
             const paymentTotals = await Payment.aggregate([
-              { $match: { schoolId: req.schoolId, studentId: { $in: studentIds }, status: 'SUCCESS' } },
+              { $match: Payment.activeFilter({ schoolId: req.schoolId, studentId: { $in: studentIds }, status: 'SUCCESS' }) },
               { $group: { _id: '$studentId', amountPaid: { $sum: '$amount' } } },
             ]).session(session);
 

--- a/backend/src/controllers/studentController.js
+++ b/backend/src/controllers/studentController.js
@@ -945,7 +945,9 @@ async function exportStudents(req, res, next) {
 
     res.write(columns.join(',') + '\n');
 
-    const cursor = Student.find(filter).sort({ createdAt: -1 }).cursor();
+    const query = Student.find(filter).sort({ createdAt: -1 });
+    if (includeDeleted) query.includeDeleted();
+    const cursor = query.cursor();
 
     cursor.on('data', (doc) => {
       const row = columns.map((col) => {

--- a/backend/src/services/reportService.js
+++ b/backend/src/services/reportService.js
@@ -292,7 +292,7 @@ async function getDashboardMetrics({ schoolId, timezone = 'UTC' } = {}) {
 
     // Per-class breakdown (from Student collection — these are small)
     Student.aggregate([
-      { $match: { schoolId } },
+      { $match: Student.activeFilter({ schoolId }) },
       {
         $group: {
           _id: '$class',
@@ -325,7 +325,7 @@ async function getDashboardMetrics({ schoolId, timezone = 'UTC' } = {}) {
       .lean(),
 
     Student.aggregate([
-      { $match: { schoolId } },
+      { $match: Student.activeFilter({ schoolId }) },
       { $group: { _id: null, totalExpected: { $sum: '$feeAmount' }, totalPaid: { $sum: '$totalPaid' } } },
     ]),
   ]);

--- a/backend/src/utils/generateReferenceCode.js
+++ b/backend/src/utils/generateReferenceCode.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const Payment = require('../models/paymentModel');
 
 /**
@@ -7,7 +8,7 @@ const Payment = require('../models/paymentModel');
 async function generateReferenceCode(maxAttempts = 5) {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
   for (let i = 0; i < maxAttempts; i++) {
-    const suffix = Array.from({ length: 10 }, () => chars[Math.floor(Math.random() * chars.length)]).join('');
+    const suffix = Array.from({ length: 10 }, () => chars[crypto.randomInt(0, chars.length)]).join('');
     const code = `PAY-${suffix}`;
     const exists = await Payment.exists({ referenceCode: code });
     if (!exists) return code;

--- a/scripts/migrate-payment-index.js
+++ b/scripts/migrate-payment-index.js
@@ -6,10 +6,13 @@
  *
  * Replaces the single-field unique index on txHash with a compound unique
  * index on { schoolId, txHash }, enabling per-school uniqueness enforcement
- * and faster school-scoped payment queries.
+ * and faster school-scoped payment queries. Also (re)creates the sparse
+ * unique index on txHash alone, used for fast cross-school duplicate
+ * detection while excluding manually created records with a null txHash —
+ * see backend/src/models/paymentModel.js.
  *
  * Safe to re-run — drops the old index only if it exists, then creates the
- * new one with createIndex (no-op if it already exists).
+ * new ones with createIndex (no-op if they already exist).
  *
  * Usage:
  *   MONGO_URI=mongodb://... node scripts/migrate-payment-index.js
@@ -47,6 +50,12 @@ async function run() {
   // Create the new compound unique index
   await col.createIndex({ schoolId: 1, txHash: 1 }, { unique: true, background: true });
   console.log('Created compound unique index { schoolId: 1, txHash: 1 }');
+
+  // Create the sparse unique index on txHash alone for fast cross-school
+  // duplicate detection. sparse: true excludes documents where txHash is
+  // null (manually created records), matching backend/src/models/paymentModel.js.
+  await col.createIndex({ txHash: 1 }, { unique: true, sparse: true, background: true });
+  console.log('Created sparse unique index { txHash: 1 }');
 
   await client.close();
   console.log('Migration complete.');

--- a/scripts/rotate-signer-master-key.js
+++ b/scripts/rotate-signer-master-key.js
@@ -68,13 +68,20 @@ async function main() {
   const failed = results.filter((r) => r.status === 'error');
 
   console.log(`${results.length} school(s) with a stored signing key found.`);
+  results
+    .filter((r) => r.status === 'ok')
+    .forEach((r) =>
+      console.log(
+        `Rotated signer key for school: ${r.schoolId}` + (apply ? '' : ' (dry run — not persisted)')
+      )
+    );
   console.log(
     `${results.length - failed.length} re-encrypted successfully` +
       (apply ? '.' : ' (dry run — no writes made; re-run with --apply to persist).')
   );
   if (failed.length > 0) {
     console.error(`${failed.length} failed:`);
-    failed.forEach((f) => console.error(`  - ${f.schoolId}: ${f.error}`));
+    failed.forEach((f) => console.error(`  - Failed to rotate signer key for school: ${f.schoolId}: ${f.error}`));
   }
 
   await mongoose.disconnect();


### PR DESCRIPTION
## Summary

Fixes four issues:

**#1208 — soft-delete middleware not applied consistently**
- `reportService.js` `getDashboardMetrics`: two `Student.aggregate()` calls (per-class breakdown, fee rollup) were missing `deletedAt: null` in their `$match` stage. `softDelete.js`'s query middleware only hooks `find`/`findOne`/`findOneAndUpdate`/`countDocuments` — not `aggregate` — so these needed the existing `Model.activeFilter()` helper. Soft-deleted students were skewing dashboard totals.
- `feeController.js` `updateFeeStructure` cascade: `Payment.aggregate()` summing per-student paid totals was missing `deletedAt: null`, letting soft-deleted payments corrupt recomputed student balances.
- `studentController.js` `exportStudents`: `includeDeleted=true` was silently a no-op — the query never called `.includeDeleted()`, and the pre-hook injects `deletedAt: null` whenever the key is absent from the filter, so deleted students never appeared even when explicitly requested via the flag.

**#1209 — non-cryptographic RNG for payment reference codes**
- `generateReferenceCode.js` now uses `crypto.randomInt()` instead of `Math.random()`, matching the pattern already used in `signerKeyManager.js`. `randomInt` avoids the modulo bias `randomBytes() % chars.length` would introduce. Format/length (`PAY-XXXXXXXXXX`) unchanged.

**#1210 — unlabeled schoolId in rotate-signer-master-key.js output**
- Both success and failure lines now read `...for school: <schoolId>`, so an operator running the script across multiple schools can unambiguously tell which school each rotation result belongs to.

**#1211 — missing sparse index in migrate-payment-index.js**
- `paymentModel.js` declares a unique **sparse** index on `{ txHash: 1 }` (for fast cross-school duplicate detection, excluding manually created records with a null `txHash`), separate from the compound `{ schoolId, txHash }` uniqueness index. The migration script only ever created the compound index — this documented index was never actually applied to the collection. Added it to the script.

## Test plan
- [ ] Verify a soft-deleted student is excluded from the admin dashboard per-class breakdown and fee rollup
- [ ] Verify `exportStudents?includeDeleted=true` now returns soft-deleted students in the CSV
- [ ] Verify `updateFeeStructure` cascade recompute excludes soft-deleted payments from `totalPaid`
- [ ] Verify generated payment reference codes still match `PAY-` + 10 uppercase alphanumeric chars
- [ ] Run `rotate-signer-master-key.js` against multiple schools and confirm output clearly labels each
- [ ] Run `migrate-payment-index.js` and confirm `db.payments.getIndexes()` includes the sparse `{ txHash: 1 }` unique index

Closes #1208
Closes #1209
Closes #1210
Closes #1211

🤖 Generated with [Claude Code](https://claude.com/claude-code)