### PR TITLE
fix: move favicon link to _app.jsx for site-wide coverage (#1220)

### DIFF
--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import Head from "next/head";
 import "../styles/globals.css";
 import "../styles/redesign.css";
 import Navbar from "../components/Navbar";
@@ -47,6 +48,9 @@ export default function MyApp({ Component, pageProps }) {
 
   return (
     <ThemeContext.Provider value={{ dark, toggle: () => setDark((d) => !d) }}>
+      <Head>
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      </Head>
       <Navbar />
       <ErrorBoundary>
         {useAppLayout ? (

--- a/frontend/src/pages/reports.jsx
+++ b/frontend/src/pages/reports.jsx
@@ -6,7 +6,6 @@ export default function ReportsPage() {
     <>
       <Head>
         <title>Reports | StellarEduPay</title>
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
       </Head>
       <ReportDownload />
     </>


### PR DESCRIPTION
## Summary

Closes #1220

The favicon `<link>` tag was only present in `frontend/src/pages/reports.jsx`, meaning every other page in the app silently requested the browser-default `/favicon.ico`, which does not exist in `frontend/public/`, producing a 404 on every navigation.

## Problem

- `reports.jsx` was the only page with an explicit `<link rel=icon ...>` tag.
- No `_document.jsx` exists in this project.
- `frontend/public/` contains `favicon.svg` but no `favicon.ico`.
- Every page except Reports showed a broken/missing favicon and generated a console 404 for `/favicon.ico`.

## Changes

- **`frontend/src/pages/_app.jsx`**: Added `import Head from next/head` and rendered a `<Head>` block containing `<link rel=icon type=image/svg+xml href=/favicon.svg />` inside the root provider â€” this applies the favicon site-wide across every page.
- **`frontend/src/pages/reports.jsx`**: Removed the now-redundant `<link rel=icon ...>` from the page-level `<Head>`; the `<title>` tag is kept since page titles remain page-specific.

## Verification

- Confirmed `favicon.svg` exists in `frontend/public/`.
- Confirmed no other page had its own favicon link that would conflict.
- The `<Head>` in `_app.jsx` wraps every page render, so the favicon tag is injected consistently on all routes.

## Acceptance Criteria (from issue)

- [x] Every page requests `/favicon.svg` consistently via the shared `_app.jsx` layout.
- [x] No page generates a 404 for `/favicon.ico`.
- [x] The page-specific favicon link is removed from `reports.jsx`.