### PR TITLE
fix: surface balance-fetch errors in PaymentForm with retry affordance (#1222)

### DIFF
--- a/frontend/src/components/PaymentForm.jsx
+++ b/frontend/src/components/PaymentForm.jsx
@@ -56,7 +56,8 @@ export default function PaymentForm() {
   const [loading, setLoading]                 = useState(false);
   const [copied, setCopied]                   = useState(null);
   const [hasDeletedPayments, setHasDeletedPayments] = useState(false);
-  const [disputingTx, setDisputingTx]         = useState(null);
+  const [balanceError, setBalanceError]         = useState(false);
+  const [disputingTx, setDisputingTx]           = useState(null);
   const [disputedTxs, setDisputedTxs]         = useState(new Set());
   // #1118 — wallets that cannot send free-text memos can switch the QR code to
   // MEMO_ID or MEMO_HASH; all three decode back to the same payment reference.
@@ -95,6 +96,7 @@ export default function PaymentForm() {
     setInstructions(null);
     setPayments(null);
     setHasDeletedPayments(false);
+    setBalanceError(false);
     setLoading(true);
     setPaymentsLoading(true);
     try {
@@ -104,8 +106,9 @@ export default function PaymentForm() {
         getPaymentInstructions(id, { signal }),
         getStudentPayments(id, { signal }),
         getStudentBalance(id, { signal }).catch((err) => {
-          // Propagate abort so the outer catch can detect it; swallow other errors.
+          // Propagate abort so the outer catch can detect it; surface other errors.
           if (err?.name === "CanceledError" || err?.code === "ERR_CANCELED") throw err;
+          setBalanceError(true);
           return null;
         }),
       ]);
@@ -132,6 +135,17 @@ export default function PaymentForm() {
       }
     }
   }, []);
+
+  const retryBalance = useCallback(async () => {
+    if (!studentId.trim()) return;
+    setBalanceError(false);
+    try {
+      const balRes = await getStudentBalance(studentId);
+      setHasDeletedPayments(balRes?.data?.hasDeletedPayments === true);
+    } catch {
+      setBalanceError(true);
+    }
+  }, [studentId]);
 
   async function copy(text, key) {
     await navigator.clipboard.writeText(text).catch(() => {});
@@ -231,6 +245,22 @@ export default function PaymentForm() {
                 <div role="alert" className="alert alert-warning" style={{ marginBottom: "1rem", fontSize: "0.8125rem" }}>
                   <IconAlertTriangle size={14} />
                   This student has deleted payment records not included in the balance shown.
+                </div>
+              )}
+              {balanceError && (
+                <div role="alert" className="alert alert-warning" style={{ marginBottom: "1rem", fontSize: "0.8125rem", display: "flex", alignItems: "center", justifyContent: "space-between", gap: "0.75rem", flexWrap: "wrap" }}>
+                  <span style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                    <IconAlertTriangle size={14} />
+                    Balance information could not be loaded.
+                  </span>
+                  <button
+                    type="button"
+                    onClick={retryBalance}
+                    className="btn btn-sm btn-ghost"
+                    style={{ flexShrink: 0 }}
+                  >
+                    Retry
+                  </button>
                 </div>
               )}
 


### PR DESCRIPTION
## Summary

Closes #1222

`PaymentForm.jsx` called `getStudentBalance` inside `Promise.all` with a `.catch` that silently swallowed all non-abort errors and returned `null`. A failed balance fetch (network error, backend 5xx, timeout) produced no visible indication in the UI — the form rendered normally, leaving the user with no way to know that balance context was missing.

## Root Cause

```js
// Before — error silently discarded, UI shows nothing
getStudentBalance(id, { signal }).catch((err) => {
  if (err?.name === "CanceledError" || err?.code === "ERR_CANCELED") throw err;
  return null;  // swallowed — no state update, no warning
}),
```

## Changes

### `frontend/src/components/PaymentForm.jsx`

1. **Added `balanceError` state** — a boolean flag initialised to `false`, reset to `false` at the start of every new lookup, and set to `true` inside the balance `.catch()` when a non-abort error is caught.

2. **Updated the balance `.catch()`** — instead of silently returning `null`, it now calls `setBalanceError(true)` before returning `null`, so the rest of the `Promise.all` still resolves (student + instructions + payments still load normally).

3. **Added `retryBalance` callback** — a `useCallback` that re-fetches `getStudentBalance` for the current student ID, clearing and re-setting `balanceError` as appropriate, without re-running the full lookup.

4. **Added a visible warning banner** — rendered immediately below the `hasDeletedPayments` alert, inside the `student && instructions` block, using the existing `alert alert-warning` class and `IconAlertTriangle` icon consistent with other warnings in the component. Includes an inline "Retry" button wired to `retryBalance`.

```jsx
{balanceError && (
  <div role="alert" className="alert alert-warning" ...>
    <span>
      <IconAlertTriangle size={14} />
      Balance information could not be loaded.
    </span>
    <button type="button" onClick={retryBalance} className="btn btn-sm btn-ghost">
      Retry
    </button>
  </div>
)}
```

## Behaviour

- Normal flow (balance loads): no change — `balanceError` stays `false`, banner never renders.
- Balance fetch fails: warning banner appears immediately below any other alerts, above the student info rows. User can click Retry to re-fetch without re-entering their student ID.
- Abort (new lookup started): `balanceError` is cleared at the top of `lookupStudent`, so a stale warning from a previous lookup never persists into a new one.

## Acceptance Criteria (from issue)

- [x] A simulated balance-fetch failure results in a visible error indicator in the rendered form.
- [x] The error is not silent — the user is informed balance data could not be loaded.
- [x] A retry affordance is provided without requiring a full page reload or re-lookup.
- [x] The rest of the form (student info, payment instructions, QR code) continues to render normally when only the balance fetch fails.
