### PR TITLE
fix: resolve request queue jam caused by never-invoked req.queueDone

### DIFF
--- a/backend/src/middleware/concurrentRequestHandler.js
+++ b/backend/src/middleware/concurrentRequestHandler.js
@@ -406,6 +406,8 @@ function createConcurrentRequestMiddleware(options = {}) {
           await requestQueue.enqueue(async () => {
             return new Promise((resolve) => {
               req.queueDone = resolve;
+              res.on('finish', resolve);
+              res.on('close', resolve);
               next();
             });
           }, priority, timeoutMs);


### PR DESCRIPTION
## Summary

The \equestQueue\ middleware wraps each request in a promise that only resolves when \eq.queueDone()\ is called, but nothing in the codebase ever invokes it. This causes \RequestQueue.processing\ to only ever increment — never decrement — permanently jamming the queue after \maxConcurrent\ (50) requests have been processed since process start.

## Fix

Added \es.on('finish', resolve)\ and \es.on('close', resolve)\ handlers so the queue slot is released when the response completes, not left dangling on an unresolved promise. The \eq.queueDone\ reference is preserved for backward compatibility.

Closes #1173