### PR TITLE
fix: resolve issues #1195, #1196, #1215, #1218

### DIFF
--- a/backend/src/services/consistencyService.js
+++ b/backend/src/services/consistencyService.js
@@ -149,7 +149,10 @@ async function checkStudentBalanceConsistency(schoolId) {
 async function checkConsistency() {
   const schools = await School.find({ isActive: true }).lean();
 
-  const schoolResults = await Promise.all(
+  // Use Promise.allSettled so a transient Horizon error for one school does not
+  // abort the entire consistency cycle — every other school's check still runs
+  // and records its results normally.
+  const settled = await Promise.allSettled(
     schools.map((school) =>
       checkSchoolConsistency({
         schoolId: school.schoolId,
@@ -157,6 +160,30 @@ async function checkConsistency() {
       })
     )
   );
+
+  const schoolResults = [];
+  for (let i = 0; i < settled.length; i++) {
+    const outcome = settled[i];
+    if (outcome.status === 'fulfilled') {
+      schoolResults.push(outcome.value);
+    } else {
+      // Log the per-school failure so operators know which tenant is affected,
+      // but don't let it silence the results from healthy schools.
+      const schoolId = schools[i]?.schoolId ?? `index-${i}`;
+      console.error(
+        `[consistencyService] checkSchoolConsistency failed for school ${schoolId}:`,
+        outcome.reason
+      );
+      schoolResults.push({
+        schoolId,
+        error: outcome.reason?.message ?? String(outcome.reason),
+        totalDbPayments: 0,
+        totalChainTxsScanned: 0,
+        mismatchCount: 0,
+        mismatches: [],
+      });
+    }
+  }
 
   const totalDbPayments = schoolResults.reduce((s, r) => s + r.totalDbPayments, 0);
   const totalChainTxsScanned = schoolResults.reduce((s, r) => s + r.totalChainTxsScanned, 0);

--- a/backend/src/services/receiptService.js
+++ b/backend/src/services/receiptService.js
@@ -21,7 +21,13 @@ function generateReceiptSignature(receipt) {
 function verifyReceiptSignature(receipt) {
   if (!receipt.signature) return false;
   const expectedSignature = generateReceiptSignature(receipt);
-  return crypto.timingSafeEqual(Buffer.from(receipt.signature), Buffer.from(expectedSignature));
+  const actual   = Buffer.from(receipt.signature);
+  const expected = Buffer.from(expectedSignature);
+  // crypto.timingSafeEqual throws a RangeError when the two buffers have
+  // different lengths.  A length mismatch is itself proof of a bad signature,
+  // so we treat it as verification failure rather than letting it propagate.
+  if (actual.length !== expected.length) return false;
+  return crypto.timingSafeEqual(actual, expected);
 }
 
 /**

--- a/frontend/src/components/PaymentForm.jsx
+++ b/frontend/src/components/PaymentForm.jsx
@@ -202,7 +202,16 @@ export default function PaymentForm() {
             Enter your student ID to get payment instructions.
           </p>
 
-          <form onSubmit={(e) => { e.preventDefault(); lookupStudent(studentId); }}>
+          <form onSubmit={(e) => {
+            e.preventDefault();
+            // #1215 — cancel any pending debounce timer so that submitting the
+            // form immediately after typing doesn't fire a duplicate lookup.
+            if (debounceRef.current) {
+              clearTimeout(debounceRef.current);
+              debounceRef.current = null;
+            }
+            lookupStudent(studentId);
+          }}>
             <label className="pf-section-label" htmlFor="sid">Student ID</label>
             <div className="pf-id-input-wrap">
               <span className="pf-search-icon"><IconSearch size={15} /></span>

--- a/frontend/src/hooks/useAdminAuth.js
+++ b/frontend/src/hooks/useAdminAuth.js
@@ -1,7 +1,49 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/router';
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000/api';
+
+// Maximum number of /auth/me retry attempts after the initial failure.
+const AUTH_ME_MAX_RETRIES = 3;
+// Base delay in ms for exponential backoff (1 s, 2 s, 4 s).
+const AUTH_ME_RETRY_BASE_MS = 1000;
+
+/**
+ * Fetch /auth/me with automatic exponential-backoff retry.
+ *
+ * Resolves with the parsed JSON on success, or rejects after all attempts
+ * have been exhausted.  A 401/403 response is treated as a permanent auth
+ * failure and is not retried (retrying would be pointless without fresh
+ * credentials).
+ *
+ * @param {number} [maxRetries]
+ * @returns {Promise<object>}
+ */
+async function fetchAuthMe(maxRetries = AUTH_ME_MAX_RETRIES) {
+  let lastError;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      // Exponential backoff: 1 s, 2 s, 4 s, …
+      await new Promise((resolve) =>
+        setTimeout(resolve, AUTH_ME_RETRY_BASE_MS * Math.pow(2, attempt - 1))
+      );
+    }
+    try {
+      const r = await fetch(`${API_URL}/auth/me`, { credentials: 'include' });
+      if (r.ok) return r.json();
+      // 401 / 403 → not authenticated; no point retrying.
+      if (r.status === 401 || r.status === 403) {
+        throw Object.assign(new Error('Not authenticated'), { permanent: true });
+      }
+      // 5xx or other transient errors — record and retry.
+      lastError = new Error(`/auth/me responded with ${r.status}`);
+    } catch (err) {
+      if (err.permanent) throw err;
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
 
 export function useAdminAuth() {
   const router = useRouter();
@@ -9,67 +51,86 @@ export function useAdminAuth() {
   const [schoolId, setSchoolId] = useState(null);
   const [userId, setUserId] = useState(null);
   const [checked, setChecked] = useState(false);
+  // #1218 — surfaces a recoverable auth-me failure so consuming pages can
+  // render a "Retry" affordance instead of silently breaking.
+  const [authMeError, setAuthMeError] = useState(false);
 
-  // Fetch user context from /auth/me — includes schoolId from authenticated session.
+  // Tracks whether the component is still mounted so async callbacks don't
+  // update state after unmount.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => { mountedRef.current = false; };
+  }, []);
+
+  /**
+   * Apply a successful /auth/me response to state and localStorage.
+   */
+  const applyAuthData = useCallback((data) => {
+    if (!mountedRef.current) return;
+    setIsAdmin(true);
+    setSchoolId(data.schoolId || null);
+    setUserId(data.userId || null);
+    setAuthMeError(false);
+    if (typeof window !== 'undefined') {
+      if (data.schoolId) localStorage.setItem('schoolId', data.schoolId);
+      if (data.userId)   localStorage.setItem('userId',   data.userId);
+    }
+  }, []);
+
+  // Fetch user context from /auth/me on mount — includes schoolId from authenticated session.
   // The HttpOnly cookie is sent automatically by the browser; we never touch it from JS.
   useEffect(() => {
-    fetch(`${API_URL}/auth/me`, { credentials: 'include' })
-      .then((r) => {
-        if (r.ok) {
-          return r.json();
-        }
-        throw new Error('Not authenticated');
-      })
+    fetchAuthMe()
       .then((data) => {
-        setIsAdmin(true);
-        setSchoolId(data.schoolId || null);
-        setUserId(data.userId || null);
-        // Store school context for API interceptor to use
-        if (typeof window !== 'undefined') {
-          if (data.schoolId) {
-            localStorage.setItem('schoolId', data.schoolId);
-          }
-          if (data.userId) {
-            localStorage.setItem('userId', data.userId);
-          }
-        }
+        applyAuthData(data);
       })
       .catch(() => {
+        if (!mountedRef.current) return;
         setIsAdmin(false);
         setSchoolId(null);
         setUserId(null);
       })
-      .finally(() => setChecked(true));
-  }, []);
+      .finally(() => {
+        if (mountedRef.current) setChecked(true);
+      });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const login = useCallback(() => {
     // Called after a successful POST /auth/login — the cookie is already set.
-    // Fetch user context to get the school ID
-    fetch(`${API_URL}/auth/me`, { credentials: 'include' })
-      .then((r) => r.ok ? r.json() : null)
+    // Fetch user context with retry so a transient network blip right after
+    // login doesn't permanently strand the admin with schoolId: null.
+    setAuthMeError(false);
+    fetchAuthMe()
       .then((data) => {
-        if (data) {
-          setSchoolId(data.schoolId || null);
-          setUserId(data.userId || null);
-          // Store school context for API interceptor to use
-          if (typeof window !== 'undefined') {
-            if (data.schoolId) {
-              localStorage.setItem('schoolId', data.schoolId);
-            }
-            if (data.userId) {
-              localStorage.setItem('userId', data.userId);
-            }
-          }
-        }
-        setIsAdmin(true);
+        applyAuthData(data);
       })
       .catch(() => {
+        if (!mountedRef.current) return;
+        // Mark admin as logged in (the login POST succeeded) but signal that
+        // /auth/me context could not be loaded so the UI can offer a retry.
         setIsAdmin(true);
-        // Fall back to no school ID if unable to fetch
         setSchoolId(null);
         setUserId(null);
+        setAuthMeError(true);
       });
-  }, []);
+  }, [applyAuthData]);
+
+  /**
+   * Manual retry for /auth/me — call this from a "Retry" button in any page
+   * that renders an error state when schoolId is null after login.
+   */
+  const retryAuth = useCallback(() => {
+    setAuthMeError(false);
+    fetchAuthMe()
+      .then((data) => {
+        applyAuthData(data);
+      })
+      .catch(() => {
+        if (!mountedRef.current) return;
+        setAuthMeError(true);
+      });
+  }, [applyAuthData]);
 
   const logout = useCallback(async () => {
     await fetch(`${API_URL}/auth/logout`, {
@@ -80,6 +141,7 @@ export function useAdminAuth() {
     setIsAdmin(false);
     setSchoolId(null);
     setUserId(null);
+    setAuthMeError(false);
     // Clear school context from storage
     if (typeof window !== 'undefined') {
       localStorage.removeItem('schoolId');
@@ -88,5 +150,5 @@ export function useAdminAuth() {
     router.push('/login');
   }, [router]);
 
-  return { isAdmin, checked, login, logout, schoolId, userId };
+  return { isAdmin, checked, login, logout, schoolId, userId, authMeError, retryAuth };
 }

--- a/tests/consistency.test.js
+++ b/tests/consistency.test.js
@@ -59,6 +59,62 @@ beforeEach(() => {
 });
 
 describe('checkConsistency — multi-school', () => {
+  test('a Horizon failure for one school does not prevent results from other schools — #1196', async () => {
+    // SCH-A will throw a simulated Horizon error; SCH-B should still complete.
+    mockSchoolFind.mockResolvedValue([
+      { schoolId: 'SCH-A', stellarAddress: 'GWALLET_A' },
+      { schoolId: 'SCH-B', stellarAddress: 'GWALLET_B' },
+    ]);
+
+    // GWALLET_A is NOT in mockChainTxsByWallet, so the Stellar mock returns [].
+    // We override the mock for GWALLET_A to throw instead.
+    const originalTransactions = jest.requireMock('../backend/src/config/stellarConfig').server.transactions;
+    jest.requireMock('../backend/src/config/stellarConfig').server.transactions = () => ({
+      forAccount: (wallet) => ({
+        order: () => ({
+          limit: () => ({
+            call: async () => {
+              if (wallet === 'GWALLET_A') throw new Error('Simulated Horizon timeout');
+              return { records: mockChainTxsByWallet[wallet] || [] };
+            },
+          }),
+        }),
+      }),
+    });
+
+    mockChainTxsByWallet['GWALLET_B'] = [makeChainTx('hashB1', 'STU002', 300, 'GWALLET_B')];
+
+    mockFind.mockImplementation(({ schoolId }) => {
+      if (schoolId === 'SCH-A') return Promise.resolve([{ txHash: 'hashA1', studentId: 'STU001', amount: 250 }]);
+      if (schoolId === 'SCH-B') return Promise.resolve([{ txHash: 'hashB1', studentId: 'STU002', amount: 300 }]);
+      return Promise.resolve([]);
+    });
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const report = await checkConsistency();
+
+    // Restore the original mock after this test.
+    jest.requireMock('../backend/src/config/stellarConfig').server.transactions = originalTransactions;
+    errorSpy.mockRestore();
+
+    // Both schools should appear in bySchool results.
+    expect(report.schoolsChecked).toBe(2);
+    expect(report.bySchool).toHaveLength(2);
+
+    const schA = report.bySchool.find((s) => s.schoolId === 'SCH-A');
+    const schB = report.bySchool.find((s) => s.schoolId === 'SCH-B');
+
+    // SCH-A failed — it should surface an error field, not crash the whole run.
+    expect(schA).toBeDefined();
+    expect(schA.error).toBeDefined();
+
+    // SCH-B succeeded and should have recorded its results normally.
+    expect(schB).toBeDefined();
+    expect(schB.mismatchCount).toBe(0);
+    expect(schB.totalDbPayments).toBe(1);
+  });
+
   test('checks each school wallet independently', async () => {
     mockSchoolFind.mockResolvedValue([
       { schoolId: 'SCH-A', stellarAddress: 'GWALLET_A' },

--- a/tests/issues-1215-1218.test.js
+++ b/tests/issues-1215-1218.test.js
@@ -1,0 +1,256 @@
+'use strict';
+
+/**
+ * Tests for:
+ *   #1215 — PaymentForm must cancel its debounce timer on submit so only one
+ *            student-lookup request fires, not two.
+ *   #1218 — useAdminAuth must retry /auth/me with backoff after a transient
+ *            failure and expose authMeError + retryAuth for manual recovery.
+ *
+ * These tests exercise the fix logic directly (without importing the full React
+ * components) so they run cleanly in the Node/Jest environment at the repo root
+ * where frontend dependencies (qrcode.react, next/router, …) are not installed.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #1215 — debounce-cancel-on-submit logic
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal re-implementation of the form's debounce + submit interaction so we
+ * can verify the fix without spinning up React.
+ *
+ * Before fix: onSubmit did NOT clear the timer.
+ * After fix:  onSubmit clears the timer before calling lookupStudent.
+ */
+function makeFormState() {
+  let debounceRef = null; // mirrors debounceRef.current
+  const calls = [];       // tracks every lookupStudent invocation
+
+  function lookupStudent(id) {
+    calls.push(id);
+  }
+
+  // Mirrors the onChange handler — schedules a debounced lookup.
+  function handleChange(value, ms = 420) {
+    if (debounceRef) clearTimeout(debounceRef);
+    debounceRef = setTimeout(() => lookupStudent(value), ms);
+  }
+
+  // After fix: cancel the debounce timer before invoking lookupStudent.
+  function handleSubmitFixed(value) {
+    if (debounceRef) {
+      clearTimeout(debounceRef);
+      debounceRef = null;
+    }
+    lookupStudent(value);
+  }
+
+  // Before fix: submit does NOT clear the debounce timer.
+  function handleSubmitBroken(value) {
+    lookupStudent(value);
+  }
+
+  return { calls, handleChange, handleSubmitFixed, handleSubmitBroken };
+}
+
+describe('#1215 — PaymentForm: submit cancels pending debounce timer', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test('FIXED: submitting immediately after typing triggers exactly one lookup', () => {
+    const { calls, handleChange, handleSubmitFixed } = makeFormState();
+
+    // User types — schedules a debounce timer.
+    handleChange('STU001', 420);
+
+    // User hits submit before the timer fires.
+    handleSubmitFixed('STU001');
+
+    // The timer fires 420 ms later — should NOT trigger a second lookup.
+    jest.advanceTimersByTime(500);
+
+    expect(calls).toEqual(['STU001']); // exactly one call
+    expect(calls).toHaveLength(1);
+  });
+
+  test('BROKEN (pre-fix): submitting without cancelling debounce triggers two lookups', () => {
+    const { calls, handleChange, handleSubmitBroken } = makeFormState();
+
+    // User types — schedules a debounce timer.
+    handleChange('STU001', 420);
+
+    // Submit fires WITHOUT cancelling the timer.
+    handleSubmitBroken('STU001');
+
+    // Debounce timer still fires → second lookup.
+    jest.advanceTimersByTime(500);
+
+    // This is the BUG the fix addresses — two calls instead of one.
+    expect(calls).toHaveLength(2);
+  });
+
+  test('FIXED: submitting when no debounce is pending still performs one lookup', () => {
+    const { calls, handleChange, handleSubmitFixed } = makeFormState();
+
+    // Type, let the debounce fire naturally.
+    handleChange('STU001', 420);
+    jest.advanceTimersByTime(500); // first lookup from debounce
+
+    // Now submit — should trigger a second independent lookup.
+    handleSubmitFixed('STU001');
+
+    expect(calls).toHaveLength(2); // debounce + submit
+  });
+
+  test('FIXED: debounceRef is null after submit clears it', () => {
+    let debounceRef = null;
+
+    function handleSubmitFixed() {
+      if (debounceRef) {
+        clearTimeout(debounceRef);
+        debounceRef = null; // #1215 fix: explicitly null the ref
+      }
+    }
+
+    debounceRef = setTimeout(() => {}, 420);
+    handleSubmitFixed();
+
+    expect(debounceRef).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #1218 — fetchAuthMe retry logic (pure logic, no React needed)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Re-implement fetchAuthMe exactly as written in useAdminAuth.js so we can
+ * test its retry/backoff contract in isolation.
+ */
+const AUTH_ME_MAX_RETRIES = 3;
+const AUTH_ME_RETRY_BASE_MS = 1000;
+
+async function fetchAuthMe(fetchFn, maxRetries = AUTH_ME_MAX_RETRIES) {
+  let lastError;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, AUTH_ME_RETRY_BASE_MS * Math.pow(2, attempt - 1))
+      );
+    }
+    try {
+      const r = await fetchFn();
+      if (r.ok) return r.json();
+      if (r.status === 401 || r.status === 403) {
+        throw Object.assign(new Error('Not authenticated'), { permanent: true });
+      }
+      lastError = new Error(`/auth/me responded with ${r.status}`);
+    } catch (err) {
+      if (err.permanent) throw err;
+      lastError = err;
+    }
+  }
+  throw lastError;
+}
+
+// Wrapper that replaces the real setTimeout with one that executes immediately,
+// so we can test the retry path without any real delays.  Returns a cleanup fn.
+function patchSetTimeoutImmediate(delayLog) {
+  const orig = global.setTimeout;
+  global.setTimeout = (fn, ms) => {
+    if (typeof ms === 'number' && delayLog) delayLog.push(ms);
+    return orig(fn, 0); // run immediately
+  };
+  return () => { global.setTimeout = orig; };
+}
+
+describe('#1218 — fetchAuthMe retry logic', () => {
+  test('resolves immediately on a successful first attempt', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ schoolId: 'SCH-001', userId: 'admin-1' }),
+    });
+
+    const result = await fetchAuthMe(fetchFn);
+
+    expect(result.schoolId).toBe('SCH-001');
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('retries on 500 and resolves when a later attempt succeeds', async () => {
+    const restore = patchSetTimeoutImmediate();
+    try {
+      const fetchFn = jest.fn()
+        .mockResolvedValueOnce({ ok: false, status: 500 }) // attempt 0 fails
+        .mockResolvedValueOnce({ ok: false, status: 500 }) // attempt 1 fails
+        .mockResolvedValue({                               // attempt 2 succeeds
+          ok: true,
+          json: async () => ({ schoolId: 'SCH-002' }),
+        });
+
+      const result = await fetchAuthMe(fetchFn);
+      expect(result.schoolId).toBe('SCH-002');
+      expect(fetchFn).toHaveBeenCalledTimes(3);
+    } finally {
+      restore();
+    }
+  });
+
+  test('rejects after exhausting all retries (no permanent error)', async () => {
+    const restore = patchSetTimeoutImmediate();
+    try {
+      const fetchFn = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+      await expect(fetchAuthMe(fetchFn)).rejects.toThrow('/auth/me responded with 503');
+      // 1 initial + 3 retries = 4 total calls.
+      expect(fetchFn).toHaveBeenCalledTimes(4);
+    } finally {
+      restore();
+    }
+  });
+
+  test('does NOT retry on 401 (permanent auth failure)', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    await expect(fetchAuthMe(fetchFn)).rejects.toThrow('Not authenticated');
+    // Only one attempt — 401 is permanent, no retry.
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('does NOT retry on 403 (permanent auth failure)', async () => {
+    const fetchFn = jest.fn().mockResolvedValue({ ok: false, status: 403 });
+    await expect(fetchAuthMe(fetchFn)).rejects.toThrow('Not authenticated');
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies exponential backoff: 1 s, 2 s, 4 s between retries', async () => {
+    const delays = [];
+    const restore = patchSetTimeoutImmediate(delays);
+    try {
+      const fetchFn = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+      try { await fetchAuthMe(fetchFn); } catch { /* expected */ }
+      // There should be exactly 3 backoff delays (between attempts 0→1, 1→2, 2→3).
+      const backoffDelays = delays.filter((d) => d >= 1000);
+      expect(backoffDelays).toEqual([1000, 2000, 4000]);
+    } finally {
+      restore();
+    }
+  });
+
+  test('a network error (fetch throws) is treated as retriable', async () => {
+    const restore = patchSetTimeoutImmediate();
+    try {
+      const fetchFn = jest.fn()
+        .mockRejectedValueOnce(new Error('Network error')) // attempt 0
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({ schoolId: 'SCH-NET' }),
+        });
+
+      const result = await fetchAuthMe(fetchFn);
+      expect(result.schoolId).toBe('SCH-NET');
+      expect(fetchFn).toHaveBeenCalledTimes(2);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/tests/receipts.test.js
+++ b/tests/receipts.test.js
@@ -114,6 +114,55 @@ describe('receiptService.createReceipt()', () => {
   });
 });
 
+// ── verifyReceiptSignature tests — issue #1195 ────────────────────────────────
+
+describe('receiptService.verifyReceiptSignature() — #1195 length-mismatch fix', () => {
+  const { generateReceiptSignature, verifyReceiptSignature } = require('../backend/src/services/receiptService');
+
+  const RECEIPT = {
+    txHash: 'abc123def456abc123def456abc123def456abc123def456abc123def456abc1',
+    studentId: 'STU001',
+    schoolId: 'SCH-001',
+    amount: 250,
+    assetCode: 'XLM',
+    confirmedAt: new Date('2026-03-24T10:00:00Z'),
+  };
+
+  test('returns true for a genuine (correct-length) signature', () => {
+    const receiptWithSig = { ...RECEIPT, signature: generateReceiptSignature(RECEIPT) };
+    expect(verifyReceiptSignature(receiptWithSig)).toBe(true);
+  });
+
+  test('returns false — not throw — for a truncated signature (shorter than expected)', () => {
+    const goodSig = generateReceiptSignature(RECEIPT);
+    const truncated = goodSig.slice(0, goodSig.length - 4); // 4 chars shorter
+    const receiptWithTruncated = { ...RECEIPT, signature: truncated };
+    expect(() => verifyReceiptSignature(receiptWithTruncated)).not.toThrow();
+    expect(verifyReceiptSignature(receiptWithTruncated)).toBe(false);
+  });
+
+  test('returns false — not throw — for an extended signature (longer than expected)', () => {
+    const goodSig = generateReceiptSignature(RECEIPT);
+    const extended = goodSig + 'deadbeef';
+    const receiptWithExtended = { ...RECEIPT, signature: extended };
+    expect(() => verifyReceiptSignature(receiptWithExtended)).not.toThrow();
+    expect(verifyReceiptSignature(receiptWithExtended)).toBe(false);
+  });
+
+  test('returns false for a same-length but tampered signature', () => {
+    const goodSig = generateReceiptSignature(RECEIPT);
+    // Flip the last two hex chars while keeping the same length.
+    const tampered = goodSig.slice(0, -2) + (goodSig.slice(-2) === 'ff' ? '00' : 'ff');
+    const receiptWithTampered = { ...RECEIPT, signature: tampered };
+    expect(verifyReceiptSignature(receiptWithTampered)).toBe(false);
+  });
+
+  test('returns false when signature is absent', () => {
+    expect(verifyReceiptSignature({ ...RECEIPT, signature: undefined })).toBe(false);
+    expect(verifyReceiptSignature({ ...RECEIPT, signature: '' })).toBe(false);
+  });
+});
+
 describe('receiptService.getReceiptByTxHash()', () => {
   test('queries by txHash and schoolId', async () => {
     const mockReceipt = { txHash: PAYMENT.txHash, schoolId: 'SCH-001' };


### PR DESCRIPTION
#1195 — receiptService: guard buffer length before timingSafeEqual crypto.timingSafeEqual throws RangeError when buffers differ in length. Add an explicit length check in verifyReceiptSignature() so a mismatched or tampered signature returns false instead of propagating an exception.

#1196 — consistencyService: use Promise.allSettled in checkConsistency Replace Promise.all with Promise.allSettled so a transient Horizon error for one school does not abort the entire consistency cycle.  Each failed school is logged individually and returns an error entry in bySchool[]; healthy schools complete and record results normally.

#1215 — PaymentForm: cancel debounce timer on submit The onSubmit handler now clears debounceRef.current before calling lookupStudent(), ensuring that submitting the form immediately after typing triggers exactly one student lookup rather than two.

#1218 — useAdminAuth: retry /auth/me with exponential backoff Introduce fetchAuthMe() with up to 3 retries and 1 s/2 s/4 s backoff. 401/403 responses short-circuit immediately (permanent failure). On exhausted retries, isAdmin is set true (login POST succeeded) and authMeError=true is exposed so consuming pages can render a Retry affordance.  retryAuth() callback allows manual recovery.

Tests:
- tests/receipts.test.js: 5 new verifyReceiptSignature tests (#1195)
- tests/consistency.test.js: 1 new Horizon-failure isolation test (#1196)
- tests/issues-1215-1218.test.js: 11 new tests (#1215 + #1218)

Closes #1195
Closes #1196
Closes #1215
Closes #1218 