### PR TITLE
feat: txHash fallback path

### DIFF
--- a/backend/src/services/underpaidReconciliationService.js
+++ b/backend/src/services/underpaidReconciliationService.js
@@ -9,6 +9,7 @@
  * - Documentation and audit trail of all reconciliation actions
  */
 
+const mongoose = require('mongoose');
 const Payment = require('../models/paymentModel');
 const Student = require('../models/studentModel');
 const logger = require('../utils/logger');
@@ -31,10 +32,14 @@ async function applyPartialCredit(paymentId, creditAmount, creditAppliedBy, scho
     throw new Error('creditAmount must be a positive number');
   }
 
-  // Find payment by ID or txHash
-  let payment = await Payment.findById(paymentId);
-  if (!payment && paymentId.length > 20) {
-    // Likely a txHash
+  // Find payment by ID or txHash.
+  // Guard with isValid() first: passing a non-ObjectId string (e.g. a 64-char
+  // Stellar txHash) to findById throws a CastError synchronously, bypassing
+  // the intended txHash fallback entirely.
+  let payment = mongoose.Types.ObjectId.isValid(paymentId)
+    ? await Payment.findById(paymentId)
+    : null;
+  if (!payment) {
     payment = await Payment.findOne({ txHash: paymentId, schoolId });
   }
 
@@ -134,10 +139,11 @@ async function applyPartialCredit(paymentId, creditAmount, creditAppliedBy, scho
  * @returns {Promise<object>} Updated payment document
  */
 async function initiateRefund(paymentId, refundInitiatedBy, schoolId, refundNote = null) {
-  // Find payment by ID or txHash
-  let payment = await Payment.findById(paymentId);
-  if (!payment && paymentId.length > 20) {
-    // Likely a txHash
+  // Find payment by ID or txHash (same isValid() guard as applyPartialCredit)
+  let payment = mongoose.Types.ObjectId.isValid(paymentId)
+    ? await Payment.findById(paymentId)
+    : null;
+  if (!payment) {
     payment = await Payment.findOne({ txHash: paymentId, schoolId });
   }
 
@@ -187,10 +193,11 @@ async function completeRefund(paymentId, refundTxHash) {
     throw new Error('refundTxHash is required to complete refund');
   }
 
-  // Find payment by ID or txHash
-  let payment = await Payment.findById(paymentId);
-  if (!payment && paymentId.length > 20) {
-    // Likely a txHash
+  // Find payment by ID or txHash (same isValid() guard as applyPartialCredit)
+  let payment = mongoose.Types.ObjectId.isValid(paymentId)
+    ? await Payment.findById(paymentId)
+    : null;
+  if (!payment) {
     payment = await Payment.findOne({ txHash: paymentId });
   }
 

--- a/backend/tests/underpaidReconciliationService.test.js
+++ b/backend/tests/underpaidReconciliationService.test.js
@@ -1,0 +1,287 @@
+'use strict';
+
+/**
+ * Tests for underpaidReconciliationService (Issue #1039 / CastError fix).
+ *
+ * Focus: all three exported mutating functions must reach the txHash-based
+ * lookup without throwing when the caller passes a 64-character Stellar
+ * transaction hash instead of a MongoDB ObjectId.
+ *
+ * Before the fix, passing a txHash to Payment.findById() threw a Mongoose
+ * CastError synchronously, which bypassed the txHash fallback entirely.
+ * After the fix, mongoose.Types.ObjectId.isValid() gates the findById call,
+ * so non-ObjectId identifiers fall straight through to findOne({ txHash }).
+ */
+
+// ── mongoose: mock isValid so the service doesn't need a real DB connection ───
+//
+// The service only uses mongoose.Types.ObjectId.isValid(id) to decide whether
+// to attempt findById. We expose a real implementation so the routing logic
+// (ObjectId string → findById, non-ObjectId string → findOne) is exercised
+// correctly without requiring mongoose to be installed in the test environment.
+jest.mock('mongoose', () => {
+  // Replicate the real ObjectId.isValid() rule: 12-byte buffer or
+  // 24-character hex string.  Everything else (including a 64-char txHash)
+  // returns false.
+  function isValid(id) {
+    if (id == null) return false;
+    const s = String(id);
+    return /^[0-9a-fA-F]{24}$/.test(s) || (Buffer.isBuffer(id) && id.length === 12);
+  }
+  return { Types: { ObjectId: { isValid } } };
+});
+
+// ── Suppress logger noise ─────────────────────────────────────────────────────
+jest.mock('../src/utils/logger', () => ({
+  info:  jest.fn(),
+  warn:  jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+  child: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() }),
+}));
+
+// ── Distributed lock: always succeeds, no-op release ─────────────────────────
+jest.mock('../src/services/distributedLock', () => ({
+  studentBalanceLockKey: (schoolId, studentId) => `lock:${schoolId}:${studentId}`,
+  acquire: jest.fn().mockResolvedValue({ token: 'mock-token', fencingToken: 1 }),
+  release: jest.fn().mockResolvedValue(true),
+}));
+
+// ── Payment model mock ────────────────────────────────────────────────────────
+const mockFindById  = jest.fn();
+const mockFindOne   = jest.fn();
+const mockSave      = jest.fn().mockResolvedValue();
+
+jest.mock('../src/models/paymentModel', () => ({
+  findById:  (...args) => mockFindById(...args),
+  findOne:   (...args) => mockFindOne(...args),
+}));
+
+// ── Student model mock ────────────────────────────────────────────────────────
+const mockStudentFindOne          = jest.fn();
+const mockStudentFindOneAndUpdate = jest.fn().mockResolvedValue({});
+
+jest.mock('../src/models/studentModel', () => ({
+  findOne:          (...args) => mockStudentFindOne(...args),
+  findOneAndUpdate: (...args) => mockStudentFindOneAndUpdate(...args),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** A valid 64-character hex Stellar transaction hash. */
+const STELLAR_TX_HASH = 'a'.repeat(64);
+
+/** A valid MongoDB ObjectId string. */
+const MONGO_ID = '507f1f77bcf86cd799439011';
+
+const SCHOOL_ID  = 'school-test';
+const STUDENT_ID = 'STU001';
+
+/**
+ * Build a minimal payment document that satisfies each function's validation.
+ */
+function makePayment(overrides = {}) {
+  const base = {
+    _id:                  MONGO_ID,
+    txHash:               STELLAR_TX_HASH,
+    schoolId:             SCHOOL_ID,
+    studentId:            STUDENT_ID,
+    amount:               100,
+    feeAmount:            200,
+    feeValidationStatus:  'underpaid',
+    underpaidReconciliation: {
+      status: 'pending',
+    },
+    save: mockSave,
+  };
+  return Object.assign({}, base, overrides);
+}
+
+/**
+ * Build a minimal student document for the balance lock path in applyPartialCredit.
+ */
+function makeStudent(overrides = {}) {
+  return Object.assign(
+    { studentId: STUDENT_ID, schoolId: SCHOOL_ID, feeAmount: 200, totalPaid: 0 },
+    overrides,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+const {
+  applyPartialCredit,
+  initiateRefund,
+  completeRefund,
+} = require('../src/services/underpaidReconciliationService');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSave.mockResolvedValue();
+  mockStudentFindOneAndUpdate.mockResolvedValue({});
+});
+
+// ── applyPartialCredit ────────────────────────────────────────────────────────
+
+describe('applyPartialCredit', () => {
+  it('does NOT call findById when passed a txHash, calls findOne({ txHash }) instead', async () => {
+    const payment = makePayment();
+    mockFindOne.mockResolvedValue(payment);
+    mockStudentFindOne.mockResolvedValue(makeStudent());
+
+    await applyPartialCredit(STELLAR_TX_HASH, 50, 'admin', SCHOOL_ID);
+
+    expect(mockFindById).not.toHaveBeenCalled();
+    expect(mockFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ txHash: STELLAR_TX_HASH, schoolId: SCHOOL_ID }),
+    );
+  });
+
+  it('calls findById when passed a valid ObjectId', async () => {
+    const payment = makePayment({ txHash: 'abc' });
+    mockFindById.mockResolvedValue(payment);
+    mockStudentFindOne.mockResolvedValue(makeStudent());
+
+    await applyPartialCredit(MONGO_ID, 50, 'admin', SCHOOL_ID);
+
+    expect(mockFindById).toHaveBeenCalledWith(MONGO_ID);
+    // findOne should NOT be called when findById succeeds
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+
+  it('falls through to findOne({ txHash }) when findById returns null for a valid ObjectId', async () => {
+    const payment = makePayment();
+    mockFindById.mockResolvedValue(null);
+    mockFindOne.mockResolvedValue(payment);
+    mockStudentFindOne.mockResolvedValue(makeStudent());
+
+    await applyPartialCredit(MONGO_ID, 50, 'admin', SCHOOL_ID);
+
+    expect(mockFindById).toHaveBeenCalledWith(MONGO_ID);
+    expect(mockFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ txHash: MONGO_ID, schoolId: SCHOOL_ID }),
+    );
+  });
+
+  it('throws Payment not found when neither lookup matches', async () => {
+    mockFindById.mockResolvedValue(null);
+    mockFindOne.mockResolvedValue(null);
+
+    await expect(
+      applyPartialCredit(STELLAR_TX_HASH, 50, 'admin', SCHOOL_ID),
+    ).rejects.toThrow(`Payment not found: ${STELLAR_TX_HASH}`);
+  });
+
+  it('throws when creditAmount is not positive', async () => {
+    await expect(
+      applyPartialCredit(STELLAR_TX_HASH, 0, 'admin', SCHOOL_ID),
+    ).rejects.toThrow('creditAmount must be a positive number');
+
+    // findById / findOne should never be reached
+    expect(mockFindById).not.toHaveBeenCalled();
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+});
+
+// ── initiateRefund ────────────────────────────────────────────────────────────
+
+describe('initiateRefund', () => {
+  it('does NOT call findById when passed a txHash, calls findOne({ txHash }) instead', async () => {
+    const payment = makePayment();
+    mockFindOne.mockResolvedValue(payment);
+
+    await initiateRefund(STELLAR_TX_HASH, 'admin', SCHOOL_ID);
+
+    expect(mockFindById).not.toHaveBeenCalled();
+    expect(mockFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ txHash: STELLAR_TX_HASH, schoolId: SCHOOL_ID }),
+    );
+  });
+
+  it('calls findById when passed a valid ObjectId', async () => {
+    const payment = makePayment();
+    mockFindById.mockResolvedValue(payment);
+
+    await initiateRefund(MONGO_ID, 'admin', SCHOOL_ID);
+
+    expect(mockFindById).toHaveBeenCalledWith(MONGO_ID);
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+
+  it('falls through to findOne({ txHash }) when findById returns null for a valid ObjectId', async () => {
+    const payment = makePayment();
+    mockFindById.mockResolvedValue(null);
+    mockFindOne.mockResolvedValue(payment);
+
+    await initiateRefund(MONGO_ID, 'admin', SCHOOL_ID);
+
+    expect(mockFindById).toHaveBeenCalledWith(MONGO_ID);
+    expect(mockFindOne).toHaveBeenCalledWith(
+      expect.objectContaining({ txHash: MONGO_ID, schoolId: SCHOOL_ID }),
+    );
+  });
+
+  it('throws Payment not found when neither lookup matches', async () => {
+    mockFindById.mockResolvedValue(null);
+    mockFindOne.mockResolvedValue(null);
+
+    await expect(
+      initiateRefund(STELLAR_TX_HASH, 'admin', SCHOOL_ID),
+    ).rejects.toThrow(`Payment not found: ${STELLAR_TX_HASH}`);
+  });
+});
+
+// ── completeRefund ────────────────────────────────────────────────────────────
+
+describe('completeRefund', () => {
+  const REFUND_TX_HASH = 'b'.repeat(64);
+
+  it('does NOT call findById when passed a txHash, calls findOne({ txHash }) instead', async () => {
+    const payment = makePayment();
+    mockFindOne.mockResolvedValue(payment);
+
+    await completeRefund(STELLAR_TX_HASH, REFUND_TX_HASH);
+
+    expect(mockFindById).not.toHaveBeenCalled();
+    expect(mockFindOne).toHaveBeenCalledWith({ txHash: STELLAR_TX_HASH });
+  });
+
+  it('calls findById when passed a valid ObjectId', async () => {
+    const payment = makePayment();
+    mockFindById.mockResolvedValue(payment);
+
+    await completeRefund(MONGO_ID, REFUND_TX_HASH);
+
+    expect(mockFindById).toHaveBeenCalledWith(MONGO_ID);
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+
+  it('falls through to findOne({ txHash }) when findById returns null for a valid ObjectId', async () => {
+    const payment = makePayment();
+    mockFindById.mockResolvedValue(null);
+    mockFindOne.mockResolvedValue(payment);
+
+    await completeRefund(MONGO_ID, REFUND_TX_HASH);
+
+    expect(mockFindById).toHaveBeenCalledWith(MONGO_ID);
+    expect(mockFindOne).toHaveBeenCalledWith({ txHash: MONGO_ID });
+  });
+
+  it('throws Payment not found when neither lookup matches', async () => {
+    mockFindById.mockResolvedValue(null);
+    mockFindOne.mockResolvedValue(null);
+
+    await expect(
+      completeRefund(STELLAR_TX_HASH, REFUND_TX_HASH),
+    ).rejects.toThrow(`Payment not found: ${STELLAR_TX_HASH}`);
+  });
+
+  it('throws when refundTxHash is missing', async () => {
+    await expect(
+      completeRefund(STELLAR_TX_HASH, undefined),
+    ).rejects.toThrow('refundTxHash is required');
+
+    expect(mockFindById).not.toHaveBeenCalled();
+    expect(mockFindOne).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #1192

All done. Here's a summary of every change made:                  
                                                                    
  ──────────────────────────────────────────────────────────────────
                                                                    
  `backend/src/services/underpaidReconciliationService.js`          
                                                                    
  Added require('mongoose') at the top. Replaced all three findById 
  / heuristic-fallback patterns with a correct guard:               
                                                                    
  // Before (broken)                                                
  let payment = await Payment.findById(paymentId);          //      
  throws CastError on txHash                                        
  if (!payment && paymentId.length > 20) {                  // never
  reached                                                           
    payment = await Payment.findOne({ txHash: paymentId }); // dead 
  code                                                              
  }                                                                 
                                                                    
  // After (fixed)                                                  
  let payment = mongoose.Types.ObjectId.isValid(paymentId)          
    ? await Payment.findById(paymentId)                             
    : null;                                                         
  if (!payment) {                                                   
    payment = await Payment.findOne({ txHash: paymentId, schoolId   
  });                                                               
  }                                                                 
  The length > 20 heuristic is gone — isValid() is the correct      
  predicate. The txHash fallback is now always reached when the     
  input isn't a 24-char ObjectId hex string.                        
                                                                    
  ──────────────────────────────────────────────────────────────────
                                                                    
  `backend/tests/underpaidReconciliationService.test.js` (new, 14   
  tests)                                                            
                                                                    
  Covers all three functions (applyPartialCredit, initiateRefund,   
  completeRefund) across four scenarios each:                       
                                                                    
  - txHash input → findById never called, findOne({ txHash }) called
  - ObjectId input → findById called, findOne skipped               
  - ObjectId input but findById returns null → falls through to     
  findOne                                                           
  - Neither lookup matches → throws Payment not found               
                                                                    
  Plus the two early-exit guards (creditAmount ≤ 0, missing         
  refundTxHash).                              