### PR TITLE
fix(#1216,#1217): single error-message source of truth + shared auth context

### DIFF
--- a/frontend/src/components/AppLayout.jsx
+++ b/frontend/src/components/AppLayout.jsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
-import { useAdminAuth } from "../hooks/useAdminAuth";
+import { useAdminAuthContext } from "../hooks/AdminAuthContext";
 import RequireAdmin from "./RequireAdmin";
 import {
   IconDashboard,
@@ -29,7 +29,7 @@ const ADMIN_NAV = [
 
 function AppLayoutInner({ children }) {
   const { pathname } = useRouter();
-  const { isAdmin } = useAdminAuth();
+  const { isAdmin } = useAdminAuthContext();
 
   return (
     <div className="app-layout">

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import TestnetBanner from "./TestnetBanner";
 import { useTheme } from "../pages/_app";
-import { useAdminAuth } from "../hooks/useAdminAuth";
+import { useAdminAuthContext } from "../hooks/AdminAuthContext";
 
 const PUBLIC_LINKS = [
   { href: "/pay-fees",  label: "Pay Fees" },
@@ -37,7 +37,7 @@ export default function Navbar() {
   const { pathname } = useRouter();
   const [open, setOpen] = useState(false);
   const { dark, toggle } = useTheme();
-  const { isAdmin, logout } = useAdminAuth();
+  const { isAdmin, logout } = useAdminAuthContext();
   const links = isAdmin ? [...PUBLIC_LINKS, ...ADMIN_LINKS] : PUBLIC_LINKS;
 
   useEffect(() => { setOpen(false); }, [pathname]);

--- a/frontend/src/components/RequireAdmin.jsx
+++ b/frontend/src/components/RequireAdmin.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
-import { useAdminAuth } from "../hooks/useAdminAuth";
+import { useAdminAuthContext } from "../hooks/AdminAuthContext";
 
 /**
  * RequireAdmin
@@ -29,7 +29,7 @@ import { useAdminAuth } from "../hooks/useAdminAuth";
  */
 export default function RequireAdmin({ children }) {
   const router = useRouter();
-  const { isAdmin, checked } = useAdminAuth();
+  const { isAdmin, checked } = useAdminAuthContext();
 
   useEffect(() => {
     // Only act once the /auth/me round-trip has completed.

--- a/frontend/src/hooks/AdminAuthContext.jsx
+++ b/frontend/src/hooks/AdminAuthContext.jsx
@@ -1,0 +1,61 @@
+/**
+ * AdminAuthContext — #1217
+ *
+ * Provides a single shared instance of useAdminAuth so every component on a
+ * given page reads from the same in-memory state and the browser fires exactly
+ * one /auth/me request per page load, regardless of how many components call
+ * useAdminAuthContext().
+ *
+ * Usage
+ * -----
+ * 1. Mount <AdminAuthProvider> once near the root (in _app.jsx).
+ * 2. Replace every `useAdminAuth()` call-site with `useAdminAuthContext()`.
+ *    The returned shape is identical to useAdminAuth(), so it's a drop-in swap.
+ *
+ * login.jsx is the only page that needs the `login` callback — it still
+ * receives it through context just like all other fields.
+ *
+ * Implementation note: React.createElement is used instead of JSX so this
+ * file parses correctly under the project's existing Babel config
+ * (@babel/preset-env only, no @babel/preset-react).
+ */
+
+import React, { createContext, useContext } from "react";
+import { useAdminAuth } from "./useAdminAuth";
+
+// The context holds the full return value of useAdminAuth().
+// Initialised to null so we can detect if a consumer is used outside the provider.
+const AdminAuthContext = createContext(null);
+
+/**
+ * Mount this once at the top of the component tree (e.g. in _app.jsx).
+ * It instantiates useAdminAuth exactly once and publishes the result to all
+ * descendants via context.
+ */
+export function AdminAuthProvider({ children }) {
+  const auth = useAdminAuth();
+  return React.createElement(
+    AdminAuthContext.Provider,
+    { value: auth },
+    children
+  );
+}
+
+/**
+ * Drop-in replacement for the standalone `useAdminAuth()` call.
+ * Returns the same shape: { isAdmin, checked, login, logout, schoolId, userId,
+ * authMeError, retryAuth }.
+ *
+ * Throws a clear error when used outside <AdminAuthProvider> so misconfiguration
+ * surfaces immediately in development rather than silently producing bad state.
+ */
+export function useAdminAuthContext() {
+  const ctx = useContext(AdminAuthContext);
+  if (ctx === null) {
+    throw new Error(
+      "useAdminAuthContext must be used inside <AdminAuthProvider>. " +
+      "Make sure AdminAuthProvider is mounted in _app.jsx."
+    );
+  }
+  return ctx;
+}

--- a/frontend/src/hooks/__tests__/AdminAuthContext.test.js
+++ b/frontend/src/hooks/__tests__/AdminAuthContext.test.js
@@ -1,0 +1,176 @@
+/**
+ * Tests for AdminAuthContext — #1217
+ *
+ * Strategy: Jest runs in a node environment without a real DOM or React
+ * renderer. We test the contract of AdminAuthContext by mocking React's
+ * useContext so we can control what value the context provides, and by mocking
+ * useAdminAuth so we can count how many times it is instantiated.
+ *
+ * Key guarantees tested:
+ *  1. useAdminAuth is called exactly once when AdminAuthProvider mounts —
+ *     regardless of how many consumers call useAdminAuthContext().
+ *  2. useAdminAuthContext returns the same object that useAdminAuth returned.
+ *  3. useAdminAuthContext throws a descriptive error when used outside the provider.
+ *  4. AdminAuthContext module exports the expected symbols.
+ */
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────
+
+// We need to control what useContext returns so we can simulate:
+//   a) the provider case  → useContext returns a real auth value
+//   b) the no-provider case → useContext returns null (the context default)
+let mockContextValue = null;
+
+jest.mock("react", () => {
+  const actual = jest.requireActual("react");
+  return {
+    ...actual,
+    // Replace useContext with a version that returns whatever mockContextValue
+    // is set to for AdminAuthContext and delegates everything else to React.
+    useContext: jest.fn((ctx) => {
+      // We intercept calls from useAdminAuthContext; all other useContext calls
+      // (e.g. from useAdminAuth itself) pass through to the real implementation.
+      return mockContextValue;
+    }),
+    // createContext is needed for the module to initialise; keep the real one.
+    createContext: actual.createContext,
+  };
+});
+
+// Track how many times useAdminAuth is called so we can assert it is only
+// instantiated once regardless of consumer count.
+let useAdminAuthCallCount = 0;
+const MOCK_AUTH_VALUE = {
+  isAdmin:    false,
+  checked:    false,
+  login:      jest.fn(),
+  logout:     jest.fn(),
+  schoolId:   "school-abc",
+  userId:     "user-123",
+  authMeError: false,
+  retryAuth:  jest.fn(),
+};
+
+jest.mock("../useAdminAuth", () => ({
+  useAdminAuth: jest.fn(() => {
+    useAdminAuthCallCount += 1;
+    return MOCK_AUTH_VALUE;
+  }),
+}));
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+const { useAdminAuthContext } = require("../AdminAuthContext");
+
+describe("AdminAuthContext — #1217", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useAdminAuthCallCount = 0;
+    mockContextValue = null;
+  });
+
+  describe("module shape", () => {
+    it("exports AdminAuthProvider as a function", () => {
+      const { AdminAuthProvider } = require("../AdminAuthContext");
+      expect(typeof AdminAuthProvider).toBe("function");
+    });
+
+    it("exports useAdminAuthContext as a function", () => {
+      expect(typeof useAdminAuthContext).toBe("function");
+    });
+  });
+
+  describe("useAdminAuthContext — guard", () => {
+    it("throws a descriptive error when context value is null (used outside provider)", () => {
+      // mockContextValue is null → simulates missing provider.
+      mockContextValue = null;
+      expect(() => useAdminAuthContext()).toThrow(
+        "useAdminAuthContext must be used inside <AdminAuthProvider>"
+      );
+    });
+
+    it("error message mentions AdminAuthProvider", () => {
+      mockContextValue = null;
+      expect(() => useAdminAuthContext()).toThrow("AdminAuthProvider");
+    });
+  });
+
+  describe("useAdminAuthContext — passthrough", () => {
+    it("returns the value provided by the context", () => {
+      mockContextValue = MOCK_AUTH_VALUE;
+      const result = useAdminAuthContext();
+      expect(result).toBe(MOCK_AUTH_VALUE);
+    });
+
+    it("exposes isAdmin from context", () => {
+      mockContextValue = { ...MOCK_AUTH_VALUE, isAdmin: true };
+      expect(useAdminAuthContext().isAdmin).toBe(true);
+    });
+
+    it("exposes schoolId from context", () => {
+      mockContextValue = { ...MOCK_AUTH_VALUE, schoolId: "sch-xyz" };
+      expect(useAdminAuthContext().schoolId).toBe("sch-xyz");
+    });
+
+    it("exposes login callback from context", () => {
+      const loginFn = jest.fn();
+      mockContextValue = { ...MOCK_AUTH_VALUE, login: loginFn };
+      expect(useAdminAuthContext().login).toBe(loginFn);
+    });
+
+    it("exposes logout callback from context", () => {
+      const logoutFn = jest.fn();
+      mockContextValue = { ...MOCK_AUTH_VALUE, logout: logoutFn };
+      expect(useAdminAuthContext().logout).toBe(logoutFn);
+    });
+
+    it("exposes all required auth fields", () => {
+      mockContextValue = MOCK_AUTH_VALUE;
+      const result = useAdminAuthContext();
+      const requiredFields = [
+        "isAdmin", "checked", "login", "logout",
+        "schoolId", "userId", "authMeError", "retryAuth",
+      ];
+      for (const field of requiredFields) {
+        expect(result).toHaveProperty(field);
+      }
+    });
+  });
+
+  describe("AdminAuthProvider — single useAdminAuth instantiation", () => {
+    it("AdminAuthProvider calls useAdminAuth exactly once", () => {
+      // Simulate AdminAuthProvider rendering: it calls useAdminAuth() once
+      // to get the value to publish through context.
+      const { AdminAuthProvider } = require("../AdminAuthContext");
+      const { useAdminAuth } = require("../useAdminAuth");
+
+      // Simulate what React does when rendering a function component — call
+      // the provider as a function and check its output (children passthrough).
+      // We only care that useAdminAuth was invoked exactly once.
+      const children = "child content";
+
+      // Call it as a plain function (simulating a single render pass).
+      AdminAuthProvider({ children });
+
+      expect(useAdminAuth).toHaveBeenCalledTimes(1);
+    });
+
+    it("multiple useAdminAuthContext calls share one auth instance", () => {
+      // Set the shared value in context (as AdminAuthProvider would do).
+      mockContextValue = MOCK_AUTH_VALUE;
+
+      // Each consumer call reads from the same context — not from useAdminAuth.
+      const r1 = useAdminAuthContext();
+      const r2 = useAdminAuthContext();
+      const r3 = useAdminAuthContext();
+
+      // All three consumers received the same object.
+      expect(r1).toBe(MOCK_AUTH_VALUE);
+      expect(r2).toBe(MOCK_AUTH_VALUE);
+      expect(r3).toBe(MOCK_AUTH_VALUE);
+
+      // useAdminAuth was never called by the consumers — only by the provider.
+      expect(useAdminAuthCallCount).toBe(0);
+    });
+  });
+});

--- a/frontend/src/pages/_app.jsx
+++ b/frontend/src/pages/_app.jsx
@@ -6,6 +6,7 @@ import "../styles/redesign.css";
 import Navbar from "../components/Navbar";
 import AppLayout from "../components/AppLayout";
 import ErrorBoundary from "../components/ErrorBoundary";
+import { AdminAuthProvider } from "../hooks/AdminAuthContext";
 
 export const ThemeContext = createContext({ dark: false, toggle: () => {} });
 export const useTheme = () => useContext(ThemeContext);
@@ -47,20 +48,22 @@ export default function MyApp({ Component, pageProps }) {
   const useAppLayout = APP_LAYOUT_ROUTES.includes(pathname);
 
   return (
-    <ThemeContext.Provider value={{ dark, toggle: () => setDark((d) => !d) }}>
-      <Head>
-        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-      </Head>
-      <Navbar />
-      <ErrorBoundary>
-        {useAppLayout ? (
-          <AppLayout>
+    <AdminAuthProvider>
+      <ThemeContext.Provider value={{ dark, toggle: () => setDark((d) => !d) }}>
+        <Head>
+          <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+        </Head>
+        <Navbar />
+        <ErrorBoundary>
+          {useAppLayout ? (
+            <AppLayout>
+              <Component {...pageProps} />
+            </AppLayout>
+          ) : (
             <Component {...pageProps} />
-          </AppLayout>
-        ) : (
-          <Component {...pageProps} />
-        )}
-      </ErrorBoundary>
-    </ThemeContext.Provider>
+          )}
+        </ErrorBoundary>
+      </ThemeContext.Provider>
+    </AdminAuthProvider>
   );
 }

--- a/frontend/src/pages/fee-adjustments.jsx
+++ b/frontend/src/pages/fee-adjustments.jsx
@@ -9,7 +9,7 @@ import { getErrorMessage } from "../utils/errorMessages";
 import { validateStellarAmount } from "../utils/stellarAmount";
 import { IconAlertTriangle, IconCheck } from "../components/Icons";
 import PageHero from "../components/PageHero";
-import { useAdminAuth } from "../hooks/useAdminAuth";
+import { useAdminAuthContext } from "../hooks/AdminAuthContext";
 
 const RULE_TYPES = [
   { value: "discount_percentage", label: "Discount %" },
@@ -51,7 +51,7 @@ function RuleTypePill({ type }) {
 }
 
 export default function FeeAdjustments() {
-  const { schoolId } = useAdminAuth();
+  const { schoolId } = useAdminAuthContext();
   const [rules, setRules]           = useState([]);
   const [loading, setLoading]       = useState(true);
   const [error, setError]           = useState(null);

--- a/frontend/src/pages/login.jsx
+++ b/frontend/src/pages/login.jsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
-import { useAdminAuth } from '../hooks/useAdminAuth';
+import { useAdminAuthContext } from '../hooks/AdminAuthContext';
 import { getErrorMessage } from '../utils/errorMessages';
 import api from '../services/api';
 
@@ -16,7 +16,7 @@ function safeReturnTo(returnTo) {
 
 export default function LoginPage() {
   const router = useRouter();
-  const { login } = useAdminAuth();
+  const { login } = useAdminAuthContext();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');

--- a/frontend/src/utils/__tests__/errorMessages.test.js
+++ b/frontend/src/utils/__tests__/errorMessages.test.js
@@ -1,4 +1,5 @@
 import ERROR_MESSAGES, { getErrorMessage } from "../../utils/errorMessages";
+import { parseStellarError } from "../../utils/stellarErrors";
 
 describe("errorMessages — issue #612", () => {
   it("maps DUPLICATE_STUDENT to human-readable message", () => {
@@ -58,5 +59,109 @@ describe("errorMessages — issue #612", () => {
   it("exports a non-empty ERROR_MESSAGES object", () => {
     expect(typeof ERROR_MESSAGES).toBe("object");
     expect(Object.keys(ERROR_MESSAGES).length).toBeGreaterThan(0);
+  });
+});
+
+// #1216 — Stellar-specific codes must resolve through the single source of
+// truth in errorMessages.js so every form shows identical text for the same
+// backend error.
+describe("errorMessages — #1216 Stellar / Horizon codes", () => {
+  it("maps STELLAR_NETWORK_ERROR", () => {
+    expect(getErrorMessage("STELLAR_NETWORK_ERROR")).toBe(
+      "The Stellar network is currently unavailable. Please try again later."
+    );
+  });
+
+  it("maps HORIZON_UNREACHABLE", () => {
+    expect(getErrorMessage("HORIZON_UNREACHABLE")).toBe(
+      "The Stellar network is temporarily unavailable. Please check the network status and try again later."
+    );
+  });
+
+  it("maps HORIZON_UNAVAILABLE to the same text as HORIZON_UNREACHABLE", () => {
+    // Both codes represent the same failure from the user's perspective.
+    expect(getErrorMessage("HORIZON_UNAVAILABLE")).toBe(
+      getErrorMessage("HORIZON_UNREACHABLE")
+    );
+  });
+
+  it("maps tx_insufficient_fee (Stellar SDK result code)", () => {
+    const msg = getErrorMessage("tx_insufficient_fee");
+    expect(msg).toContain("congested");
+    expect(msg).toContain("fee");
+  });
+
+  it("maps op_underfunded (Stellar SDK result code)", () => {
+    const msg = getErrorMessage("op_underfunded");
+    expect(msg).toContain("XLM");
+    expect(msg).toContain("balance");
+  });
+
+  // Verify parseStellarError delegates to errorMessages.js and the returned
+  // messages are identical to a direct getErrorMessage() call — this is the
+  // contract that closes the divergence reported in #1216.
+  describe("parseStellarError delegates to errorMessages.js", () => {
+    function makeAxiosErr(code, error) {
+      return { response: { data: { code, error } } };
+    }
+
+    it("STELLAR_NETWORK_ERROR: parseStellarError message === getErrorMessage(code)", () => {
+      const result = parseStellarError(makeAxiosErr("STELLAR_NETWORK_ERROR", ""));
+      expect(result).not.toBeNull();
+      expect(result.message).toBe(getErrorMessage("STELLAR_NETWORK_ERROR"));
+    });
+
+    it("HORIZON_UNREACHABLE: parseStellarError message === getErrorMessage(code)", () => {
+      const result = parseStellarError(makeAxiosErr("HORIZON_UNREACHABLE", ""));
+      expect(result).not.toBeNull();
+      expect(result.message).toBe(getErrorMessage("HORIZON_UNREACHABLE"));
+    });
+
+    it("HORIZON_UNAVAILABLE: parseStellarError message === getErrorMessage(code)", () => {
+      const result = parseStellarError(makeAxiosErr("HORIZON_UNAVAILABLE", ""));
+      expect(result).not.toBeNull();
+      expect(result.message).toBe(getErrorMessage("HORIZON_UNAVAILABLE"));
+    });
+
+    it("tx_insufficient_fee: parseStellarError message === getErrorMessage(code)", () => {
+      const result = parseStellarError(makeAxiosErr("tx_insufficient_fee", ""));
+      expect(result).not.toBeNull();
+      expect(result.message).toBe(getErrorMessage("tx_insufficient_fee"));
+    });
+
+    it("op_underfunded: parseStellarError message === getErrorMessage(code)", () => {
+      const result = parseStellarError(makeAxiosErr("op_underfunded", ""));
+      expect(result).not.toBeNull();
+      expect(result.message).toBe(getErrorMessage("op_underfunded"));
+    });
+
+    it("returns null for a non-Stellar error code", () => {
+      const result = parseStellarError(makeAxiosErr("VALIDATION_ERROR", "bad input"));
+      expect(result).toBeNull();
+    });
+
+    it("surfaces stellarStatusUrl for STELLAR_NETWORK_ERROR", () => {
+      const result = parseStellarError(makeAxiosErr("STELLAR_NETWORK_ERROR", ""));
+      expect(result.stellarStatusUrl).toBe("https://status.stellar.org");
+    });
+
+    it("does not surface stellarStatusUrl for op_underfunded", () => {
+      const result = parseStellarError(makeAxiosErr("op_underfunded", ""));
+      expect(result.stellarStatusUrl).toBeNull();
+    });
+
+    it("keyword fallback: 'horizon' in message resolves to HORIZON_UNREACHABLE text", () => {
+      const err = { response: { data: { code: "", error: "horizon is down" } } };
+      const result = parseStellarError(err);
+      expect(result).not.toBeNull();
+      expect(result.message).toBe(getErrorMessage("HORIZON_UNREACHABLE"));
+    });
+
+    it("keyword fallback: 'tx_insufficient_fee' in message resolves correctly", () => {
+      const err = { response: { data: { code: "", error: "tx_insufficient_fee encountered" } } };
+      const result = parseStellarError(err);
+      expect(result).not.toBeNull();
+      expect(result.message).toBe(getErrorMessage("tx_insufficient_fee"));
+    });
   });
 });

--- a/frontend/src/utils/errorMessages.js
+++ b/frontend/src/utils/errorMessages.js
@@ -25,7 +25,6 @@ const ERROR_MESSAGES = {
   AMOUNT_TOO_LOW:              "Payment amount is below the minimum allowed.",
   AMOUNT_TOO_HIGH:             "Payment amount exceeds the maximum allowed.",
   UNDERPAID:                   "Payment amount is less than the required fee.",
-  STELLAR_NETWORK_ERROR:       "The Stellar network is currently unavailable. Please try again later.",
   PAYMENT_LOCKED:              "This payment is currently being processed. Please wait.",
   INTENT_EXPIRED:              "The payment session has expired. Please start again.",
   INVALID_FEE_CATEGORY:        "Invalid fee category specified.",
@@ -70,6 +69,17 @@ const ERROR_MESSAGES = {
   CSV_INVALID_FORMAT:          "The CSV file format is not valid.",
   CSV_TOO_MANY_ROWS:           "The CSV file contains too many rows.",
   CSV_TOO_LARGE:               "The CSV file is too large to process.",
+
+  // Stellar / Horizon errors
+  // These codes are surfaced by the backend or by parseStellarError() in
+  // stellarErrors.js — all user-facing text for Stellar failures lives here so
+  // every component shows identical wording for the same underlying failure.
+  STELLAR_NETWORK_ERROR:       "The Stellar network is currently unavailable. Please try again later.",
+  HORIZON_UNREACHABLE:         "The Stellar network is temporarily unavailable. Please check the network status and try again later.",
+  HORIZON_UNAVAILABLE:         "The Stellar network is temporarily unavailable. Please check the network status and try again later.",
+  // Horizon result codes (lowercase, as returned by the Stellar SDK)
+  tx_insufficient_fee:         "The Stellar network is congested and rejected the transaction fee. Please try again in a few minutes or use a higher transaction fee.",
+  op_underfunded:              "Insufficient XLM balance. Please fund your wallet with enough XLM to cover the payment and transaction fee.",
 
   // Rate limiting / system errors
   RATE_LIMIT_EXCEEDED:         "Too many requests. Please slow down and try again.",

--- a/frontend/src/utils/stellarErrors.js
+++ b/frontend/src/utils/stellarErrors.js
@@ -1,40 +1,27 @@
-// Maps Stellar / Horizon error codes to user-facing messages.
-// The backend may surface Stellar SDK codes (lowercase, e.g. "tx_insufficient_fee")
-// or custom backend codes (uppercase, e.g. "HORIZON_UNREACHABLE").
+// Parses Stellar / Horizon errors from Axios error objects and maps them to
+// user-facing messages.  All message text is owned by errorMessages.js — this
+// module handles the *detection* logic (code lookup, keyword fallback) only,
+// so every form displays identical wording for the same underlying failure.
+// See #1216.
+
+import { getErrorMessage } from "./errorMessages";
 
 const STELLAR_STATUS_URL = "https://status.stellar.org";
 
-const CODE_MAP = {
-  // Stellar SDK result codes (Horizon envelope errors)
-  tx_insufficient_fee: {
-    message:
-      "The Stellar network is congested and rejected the transaction fee. Please try again in a few minutes or use a higher transaction fee.",
-    showStatus: true,
-  },
-  op_underfunded: {
-    message:
-      "Insufficient XLM balance. Please fund your wallet with enough XLM to cover the payment and transaction fee.",
-    showStatus: false,
-  },
-  // Backend-defined codes
-  HORIZON_UNREACHABLE: {
-    message:
-      "The Stellar network is temporarily unavailable. Please check the network status and try again later.",
-    showStatus: true,
-  },
-  HORIZON_UNAVAILABLE: {
-    message:
-      "The Stellar network is temporarily unavailable. Please check the network status and try again later.",
-    showStatus: true,
-  },
-  STELLAR_NETWORK_ERROR: {
-    message:
-      "A Stellar network error occurred. Please try again in a few minutes.",
-    showStatus: true,
-  },
+// Maps an error code (either a Stellar SDK result code like "tx_insufficient_fee"
+// or a backend-defined code like "HORIZON_UNREACHABLE") to whether we should
+// surface the Stellar status-page URL alongside the message.
+const CODE_SHOW_STATUS = {
+  tx_insufficient_fee: true,
+  op_underfunded:      false,
+  HORIZON_UNREACHABLE: true,
+  HORIZON_UNAVAILABLE: true,
+  STELLAR_NETWORK_ERROR: true,
 };
 
-// Fallback: search the error message string for known keywords when the code field is absent.
+// Fallback: search the error message string for known keywords when the code
+// field is absent.  Each entry maps a keyword to a canonical code whose
+// message lives in errorMessages.js.
 const KEYWORD_MAP = [
   { keyword: "tx_insufficient_fee", ref: "tx_insufficient_fee" },
   { keyword: "op_underfunded",      ref: "op_underfunded" },
@@ -45,28 +32,33 @@ const KEYWORD_MAP = [
 
 /**
  * Attempts to extract a Stellar-specific error from an Axios error.
- * Returns { message, stellarStatusUrl } if the error is Stellar-related,
- * or null if the caller should fall back to a generic message.
+ *
+ * Returns `{ message, stellarStatusUrl }` when the error is Stellar-related,
+ * or `null` when the caller should fall back to a generic message via
+ * `getErrorMessage()` from errorMessages.js.
+ *
+ * @param {Error} err - An Axios error (or any error with a `.response` shape).
+ * @returns {{ message: string, stellarStatusUrl: string|null } | null}
  */
 export function parseStellarError(err) {
-  const code    = err?.response?.data?.code    || "";
-  const message = err?.response?.data?.error   || err?.message || "";
+  const code    = err?.response?.data?.code  || "";
+  const message = err?.response?.data?.error || err?.message || "";
 
-  const entry = CODE_MAP[code];
-  if (entry) {
+  // Direct code match
+  if (code && Object.prototype.hasOwnProperty.call(CODE_SHOW_STATUS, code)) {
     return {
-      message: entry.message,
-      stellarStatusUrl: entry.showStatus ? STELLAR_STATUS_URL : null,
+      message:         getErrorMessage(code),
+      stellarStatusUrl: CODE_SHOW_STATUS[code] ? STELLAR_STATUS_URL : null,
     };
   }
 
+  // Keyword fallback when the response has no structured code
   const lower = message.toLowerCase();
   for (const { keyword, ref } of KEYWORD_MAP) {
     if (lower.includes(keyword)) {
-      const fallback = CODE_MAP[ref];
       return {
-        message: fallback.message,
-        stellarStatusUrl: fallback.showStatus ? STELLAR_STATUS_URL : null,
+        message:         getErrorMessage(ref),
+        stellarStatusUrl: CODE_SHOW_STATUS[ref] ? STELLAR_STATUS_URL : null,
       };
     }
   }


### PR DESCRIPTION
## Summary

Closes #1216 and #1217.

---

## #1216 — `STELLAR_NETWORK_ERROR` inconsistency across forms

**Problem:** `errorMessages.js` and `stellarErrors.js` each independently defined a user-facing string for `STELLAR_NETWORK_ERROR` with different wording. A parent hitting a Stellar network error in `VerifyPayment` saw different text than one hitting the same error in `PaymentForm` or `DisputeForm`.

**Fix:**
- `errorMessages.js` is now the single source of truth. Added `STELLAR_NETWORK_ERROR`, `HORIZON_UNREACHABLE`, `HORIZON_UNAVAILABLE`, `tx_insufficient_fee`, `op_underfunded`.
- `stellarErrors.js` rewritten: `parseStellarError()` retains all detection logic (code lookup + keyword fallback + status-URL flag) but calls `getErrorMessage(code)` for every user-facing string — zero inline literals.
- `errorMessages.test.js` extended: dedicated `#1216` suite with mapping tests for all five new Stellar codes plus an integration block asserting `parseStellarError().message === getErrorMessage(code)` for each — the divergence can never silently reappear.

---

## #1217 — Redundant `/auth/me` fetches on fee-adjustments page

**Problem:** `useAdminAuth` is a regular hook — every call site gets its own `useEffect` and `fetch`. On `/fee-adjustments` the render tree was `Navbar → AppLayout → RequireAdmin → AppLayoutInner → FeeAdjustments` (4 independent hook instances = 4 concurrent `/auth/me` requests).

**Fix:**
- New `hooks/AdminAuthContext.jsx`: `AdminAuthProvider` runs `useAdminAuth()` **exactly once** and publishes the result via React Context. `useAdminAuthContext()` is the consumer hook — reads from context, zero additional fetches, throws a descriptive error if used outside the provider.
- `_app.jsx`: `AdminAuthProvider` wraps the entire app at the root.
- All five consumers (`Navbar`, `AppLayout`, `RequireAdmin`, `fee-adjustments`, `login`) migrated from `useAdminAuth()` to `useAdminAuthContext()`. Drop-in swap — identical destructuring.
- `useAdminAuth.js` is **untouched** — still the implementation; only `AdminAuthContext.jsx` imports it.
- New `hooks/__tests__/AdminAuthContext.test.js` (12 tests): guard throws, all auth fields exposed, `useAdminAuth` called exactly once from `AdminAuthProvider`, multiple consumers share one object without triggering additional fetches.

---

## Tests

```
Test Suites: 6 passed, 6 total
Tests:       92 passed, 92 total
```
closes #1216 
closes #1217 