### PR TITLE
fix: security hardening for #1179, #1180, #1181, #1182

### DIFF
--- a/backend/src/controllers/dispute.controller.js
+++ b/backend/src/controllers/dispute.controller.js
@@ -178,9 +178,17 @@ async function flagDispute(req, res, next) {
       return res.status(400).json({ error: 'txHash, studentId, raisedBy, and reason are all required.', code: 'VALIDATION_ERROR' });
     }
 
-    // Validate field lengths
-    const raisedByTrimmed = raisedBy.trim();
-    const reasonTrimmed = reason.trim();
+    // #1181 — Trim before validating length and presence so whitespace-only
+    // strings ('   ') are rejected rather than silently accepted.
+    const raisedByTrimmed = typeof raisedBy === 'string' ? raisedBy.trim() : '';
+    const reasonTrimmed   = typeof reason   === 'string' ? reason.trim()   : '';
+
+    if (!raisedByTrimmed) {
+      return res.status(400).json({ error: 'raisedBy must not be blank.', code: 'VALIDATION_ERROR' });
+    }
+    if (!reasonTrimmed) {
+      return res.status(400).json({ error: 'reason must not be blank.', code: 'VALIDATION_ERROR' });
+    }
 
     if (raisedByTrimmed.length > 200) {
       return res.status(400).json({ error: 'raisedBy must not exceed 200 characters.', code: 'VALIDATION_ERROR' });
@@ -300,7 +308,11 @@ async function resolveDispute(req, res, next) {
       return res.status(400).json({ error: 'resolutionNote is required.', code: 'VALIDATION_ERROR' });
     }
 
-    const resolutionNoteTrimmed = resolutionNote.trim();
+    // #1181 — Trim before validating so whitespace-only strings are rejected.
+    const resolutionNoteTrimmed = typeof resolutionNote === 'string' ? resolutionNote.trim() : '';
+    if (!resolutionNoteTrimmed) {
+      return res.status(400).json({ error: 'resolutionNote must not be blank.', code: 'VALIDATION_ERROR' });
+    }
     if (resolutionNoteTrimmed.length > 1000) {
       return res.status(400).json({ error: 'resolutionNote must not exceed 1000 characters.', code: 'VALIDATION_ERROR' });
     }

--- a/backend/src/controllers/mfaController.js
+++ b/backend/src/controllers/mfaController.js
@@ -99,6 +99,16 @@ async function setupMfa(req, res) {
       return res.status(404).json({ error: 'School not found.', code: 'SCHOOL_NOT_FOUND' });
     }
 
+    // #1180 — Refuse to overwrite credentials when MFA is already active.
+    // An authenticated admin must call /mfa/disable (with a valid TOTP code)
+    // before re-issuing a new secret, preventing silent credential overwrites.
+    if (school.mfaEnabled) {
+      return res.status(400).json({
+        error: 'MFA is already active for this school. Disable MFA before setting it up again.',
+        code: 'MFA_ALREADY_ACTIVE',
+      });
+    }
+
     const generated = speakeasy.generateSecret({
       name: `StellarEduPay (${school.name || slug})`,
       issuer: 'StellarEduPay',
@@ -113,6 +123,18 @@ async function setupMfa(req, res) {
     school.mfaSecret = encryptMfaSecret(totpSecret);
     school.mfaBackupCodes = backupCodes.map((c) => ({ hash: hashBackupCode(c), used: false }));
     await school.save();
+
+    // #1180 — Audit credential generation so every setup attempt is traceable.
+    await logAudit({
+      schoolId: school.schoolId || slug,
+      action: 'MFA_SECRET_GENERATED',
+      performedBy: req.admin?.username || req.user?.userId || req.admin?.email || req.user?.email || 'admin',
+      targetId: school._id?.toString() || slug,
+      targetType: 'school',
+      details: { slug },
+      result: 'success',
+      severity: 'high',
+    });
 
     return res.json({
       secret: totpSecret,

--- a/backend/src/controllers/webhookEndpointsController.js
+++ b/backend/src/controllers/webhookEndpointsController.js
@@ -103,9 +103,11 @@ async function listEndpoints(req, res, next) {
 async function getEndpoint(req, res, next) {
   try {
     const schoolId = _callerSchoolId(req);
-    const endpoint = await WebhookEndpoint.findById(req.params.id).lean();
+    // Scope the query to the caller's schoolId so cross-tenant IDs produce the
+    // same 404 as non-existent IDs — eliminating the existence side-channel
+    // that a prior 403 vs 404 divergence would reveal. (#1179)
+    const endpoint = await WebhookEndpoint.findOne({ _id: req.params.id, schoolId }).lean();
     if (!endpoint) return res.status(404).json({ error: 'Endpoint not found', code: 'NOT_FOUND' });
-    if (endpoint.schoolId !== schoolId) return res.status(403).json({ error: 'Forbidden', code: 'FORBIDDEN' });
     // secret is stripped by toJSON transform; lean() bypasses that — strip manually
     delete endpoint.secret;
     return res.json(endpoint);
@@ -118,9 +120,10 @@ async function getEndpoint(req, res, next) {
 async function updateEndpoint(req, res, next) {
   try {
     const schoolId = _callerSchoolId(req);
-    const endpoint = await WebhookEndpoint.findById(req.params.id);
+    // Scope the query to the caller's schoolId — cross-tenant IDs and missing
+    // IDs both return 404, removing the existence side-channel. (#1179)
+    const endpoint = await WebhookEndpoint.findOne({ _id: req.params.id, schoolId });
     if (!endpoint) return res.status(404).json({ error: 'Endpoint not found', code: 'NOT_FOUND' });
-    if (endpoint.schoolId !== schoolId) return res.status(403).json({ error: 'Forbidden', code: 'FORBIDDEN' });
 
     const { url, secret, subscribedEvents, isActive, description } = req.body;
 
@@ -167,9 +170,10 @@ async function updateEndpoint(req, res, next) {
 async function deleteEndpoint(req, res, next) {
   try {
     const schoolId = _callerSchoolId(req);
-    const endpoint = await WebhookEndpoint.findById(req.params.id);
+    // Scope the query to the caller's schoolId — cross-tenant IDs and missing
+    // IDs both return 404, removing the existence side-channel. (#1179)
+    const endpoint = await WebhookEndpoint.findOne({ _id: req.params.id, schoolId });
     if (!endpoint) return res.status(404).json({ error: 'Endpoint not found', code: 'NOT_FOUND' });
-    if (endpoint.schoolId !== schoolId) return res.status(403).json({ error: 'Forbidden', code: 'FORBIDDEN' });
 
     await WebhookEndpoint.deleteOne({ _id: endpoint._id });
 

--- a/backend/src/middleware/validateInboundWebhook.js
+++ b/backend/src/middleware/validateInboundWebhook.js
@@ -18,7 +18,7 @@
  */
 
 const crypto = require('crypto');
-const WebhookDelivery = require('../models/webhookDeliveryModel');
+const InboundWebhookNonce = require('../models/inboundWebhookNonceModel');
 const logger = require('../utils/logger').child('WebhookReplayProtection');
 
 const TOLERANCE_SECONDS = parseInt(process.env.WEBHOOK_TIMESTAMP_TOLERANCE_SECONDS, 10) || 300; // 5 min
@@ -72,9 +72,15 @@ function validateInboundWebhook(secretOrFn) {
       }
 
       // ── 3. Delivery-ID dedup ──────────────────────────────────────────────
+      // #1182 — Use InboundWebhookNonce (a minimal nonce store) rather than the
+      // outbound WebhookDelivery model.  WebhookDelivery has several required
+      // fields (endpointId, schoolId, event, success) that are not available in
+      // this inbound middleware, so calling WebhookDelivery.create({ deliveryId })
+      // threw a Mongoose validation error before MongoDB could produce a 11000
+      // duplicate-key error — meaning duplicate deliveries were never caught.
       if (deliveryId) {
         try {
-          await WebhookDelivery.create({ deliveryId });
+          await InboundWebhookNonce.create({ deliveryId });
         } catch (err) {
           if (err.code === 11000) {
             // Duplicate key — this delivery was already processed

--- a/backend/src/models/inboundWebhookNonceModel.js
+++ b/backend/src/models/inboundWebhookNonceModel.js
@@ -1,0 +1,48 @@
+'use strict';
+
+/**
+ * InboundWebhookNonce — lightweight replay-protection store for inbound webhooks.
+ *
+ * Each document records a delivery ID that has already been processed.
+ * Documents are auto-expired after WEBHOOK_NONCE_TTL_SECONDS (default: 24 hours)
+ * which exceeds the timestamp-skew tolerance (5 min) by a large margin, ensuring
+ * that any delivery replayed within the tolerance window is correctly rejected.
+ *
+ * A unique index on `deliveryId` guarantees that concurrent upserts produce a
+ * duplicate-key error (11000), which the validateInboundWebhook middleware uses
+ * to return a 409 response.
+ *
+ * This model is intentionally separate from WebhookDelivery (the outbound
+ * delivery log).  Inbound replay protection only needs a nonce store; there is
+ * no need to satisfy the outbound delivery schema's required fields.
+ */
+
+const mongoose = require('mongoose');
+
+const TTL_SECONDS = parseInt(process.env.WEBHOOK_NONCE_TTL_SECONDS, 10) || 86_400; // 24 h
+
+const inboundWebhookNonceSchema = new mongoose.Schema(
+  {
+    deliveryId: {
+      type: String,
+      required: true,
+      unique: true,   // produces 11000 on duplicate insert
+      index: true,
+    },
+    receivedAt: {
+      type: Date,
+      default: Date.now,
+    },
+  },
+  {
+    // No timestamps — receivedAt is the only time field needed.
+    timestamps: false,
+    // Minimal collection footprint.
+    collection: 'inbound_webhook_nonces',
+  }
+);
+
+// TTL index — MongoDB automatically removes nonces after the window expires.
+inboundWebhookNonceSchema.index({ receivedAt: 1 }, { expireAfterSeconds: TTL_SECONDS });
+
+module.exports = mongoose.model('InboundWebhookNonce', inboundWebhookNonceSchema);


### PR DESCRIPTION
#1179 — Eliminate multi-tenant endpoint existence side-channel Replace WebhookEndpoint.findById() + explicit schoolId mismatch check (403) with a scoped WebhookEndpoint.findOne({ _id, schoolId }) in getEndpoint, updateEndpoint, and deleteEndpoint.  Cross-tenant IDs and non-existent IDs now both return a uniform 404, removing the information leak that let an attacker enumerate endpoint IDs belonging to other tenants by comparing 403 vs 404 responses.

#1180 — Prevent unauthenticated MFA credential overwrites setupMfa now checks school.mfaEnabled before generating a new TOTP secret.  When MFA is already active the handler returns 400 MFA_ALREADY_ACTIVE, requiring the admin to call /mfa/disable (which demands a valid live TOTP token) before re-issuing credentials. logAudit is called with action MFA_SECRET_GENERATED on every successful setup so all credential-generation events are traceable in the audit log.

#1181 — Fix whitespace-only input validation bypass in disputes flagDispute and resolveDispute previously trimmed raisedBy, reason, and resolutionNote AFTER the !field truthiness guard, so a payload of
'   ' (spaces only) would pass validation and be stored as an empty
string.  Validation now trims first, checks for blank, then checks
length, rejecting whitespace-only values with 400 VALIDATION_ERROR.

#1182 — Repair inbound webhook deduplication
WebhookDelivery has required fields (endpointId, schoolId, event, success) that are unavailable in the inbound middleware context, so WebhookDelivery.create({ deliveryId }) was throwing a Mongoose validation error — never reaching MongoDB — meaning the 11000 duplicate- key check was dead code and replayed deliveries were never rejected. Fix: introduce InboundWebhookNonce, a purpose-built minimal model with a unique index on deliveryId and a TTL expiry (default 24 h, well beyond the 5-minute timestamp-skew window).  validateInboundWebhook now inserts into this collection; duplicate inserts correctly produce a 11000 error that is caught and returned as 409 DUPLICATE_DELIVERY.


closes #1182 
Closes #1179
 Closes #1180 
Closes #1181