### PR TITLE
feat: Admin retry-queue

### DIFF
--- a/backend/src/controllers/retryQueueController.js
+++ b/backend/src/controllers/retryQueueController.js
@@ -1,28 +1,59 @@
 'use strict';
 
 const svc = require('../services/bullMQRetryService');
+const { asyncHandler } = require('../middleware/errorHandler');
 
-const wrap = (fn) => async (req, res) => {
-  try { res.json({ success: true, data: await fn(req) }); }
-  catch (err) { res.status(500).json({ success: false, error: err.message }); }
-};
+const getStats = asyncHandler(async (req, res) => {
+  const data = await svc.getRetryQueueStats();
+  res.json({ success: true, data });
+});
 
-const getStats    = wrap(() => svc.getRetryQueueStats());
-const getHealth   = async (req, res) => { try { const h = await svc.getHealthStatus(); res.status(h.healthy ? 200 : 503).json({ success: true, data: h }); } catch (err) { res.status(500).json({ success: false, error: err.message }); } };
-const getJob      = wrap((req) => svc.getJobDetails(req.params.jobId));
-const getJobs     = wrap((req) => svc.getJobsByState(req.params.state, parseInt(req.query.limit) || 50).then((jobs) => ({ state: req.params.state, count: jobs.length, jobs })));
-const manualRetry = wrap((req) => svc.retryJobImmediately(req.params.jobId));
-const deleteJob   = wrap((req) => svc.removeJob(req.params.jobId));
-const pause       = wrap(() => svc.pauseQueue());
-const resume      = wrap(() => svc.resumeQueue());
+const getHealth = asyncHandler(async (req, res) => {
+  const h = await svc.getHealthStatus();
+  res.status(h.healthy ? 200 : 503).json({ success: true, data: h });
+});
 
-async function queueTransaction(req, res) {
+const getJob = asyncHandler(async (req, res) => {
+  const data = await svc.getJobDetails(req.params.jobId);
+  res.json({ success: true, data });
+});
+
+const getJobs = asyncHandler(async (req, res) => {
+  const jobs = await svc.getJobsByState(req.params.state, parseInt(req.query.limit) || 50);
+  res.json({ success: true, data: { state: req.params.state, count: jobs.length, jobs } });
+});
+
+const manualRetry = asyncHandler(async (req, res) => {
+  const data = await svc.retryJobImmediately(req.params.jobId);
+  res.json({ success: true, data });
+});
+
+const deleteJob = asyncHandler(async (req, res) => {
+  const data = await svc.removeJob(req.params.jobId);
+  res.json({ success: true, data });
+});
+
+const pause = asyncHandler(async (req, res) => {
+  const data = await svc.pauseQueue();
+  res.json({ success: true, data });
+});
+
+const resume = asyncHandler(async (req, res) => {
+  const data = await svc.resumeQueue();
+  res.json({ success: true, data });
+});
+
+const queueTransaction = asyncHandler(async (req, res) => {
   const { transactionHash, studentId, memo, error, metadata } = req.body;
-  if (!transactionHash) return res.status(400).json({ success: false, error: 'transactionHash is required' });
-  try {
-    const data = await svc.queueFailedTransaction(transactionHash, { studentId, memo, error: error ? new Error(error.message) : null, metadata });
-    res.json({ success: true, data });
-  } catch (err) { res.status(500).json({ success: false, error: err.message }); }
-}
+  if (!transactionHash) {
+    const err = new Error('transactionHash is required');
+    err.code = 'VALIDATION_ERROR';
+    throw err;
+  }
+  const data = await svc.queueFailedTransaction(transactionHash, {
+    studentId, memo, error: error ? new Error(error.message) : null, metadata,
+  });
+  res.json({ success: true, data });
+});
 
 module.exports = { getStats, getHealth, getJob, getJobs, manualRetry, deleteJob, pause, resume, queueTransaction };

--- a/backend/src/services/bullMQRetryService.js
+++ b/backend/src/services/bullMQRetryService.js
@@ -182,7 +182,9 @@ async function getJobDetails(jobId) {
     const job = await queue.getJob(jobId);
 
     if (!job) {
-      return null;
+      const err = new Error(`Job ${jobId} not found`);
+      err.code = 'NOT_FOUND';
+      throw err;
     }
 
     const state = await job.getState();
@@ -267,12 +269,16 @@ async function retryJobImmediately(jobId) {
     const job = await queue.getJob(jobId);
 
     if (!job) {
-      throw new Error(`Job ${jobId} not found`);
+      const err = new Error(`Job ${jobId} not found`);
+      err.code = 'NOT_FOUND';
+      throw err;
     }
 
     const state = await job.getState();
     if (state !== 'failed') {
-      throw new Error(`Job ${jobId} is not in failed state (current: ${state})`);
+      const err = new Error(`Job ${jobId} is not in failed state (current: ${state})`);
+      err.code = 'VALIDATION_ERROR';
+      throw err;
     }
 
     await job.retry();
@@ -301,7 +307,9 @@ async function removeJob(jobId) {
     const job = await queue.getJob(jobId);
 
     if (!job) {
-      throw new Error(`Job ${jobId} not found`);
+      const err = new Error(`Job ${jobId} not found`);
+      err.code = 'NOT_FOUND';
+      throw err;
     }
 
     await job.remove();


### PR DESCRIPTION
Closes #1188 

 Here's a summary of every change made and the reasoning:               
                                                                               
  `backend/src/services/bullMQRetryService.js` — 3 locations                   
                                                                               
  - getJobDetails: was return null on a missing job → now throws { code:       
  'NOT_FOUND' }. The controller previously had to handle null silently; now the
  absence of a job is an explicit error that routes through the status map.    
  - retryJobImmediately: was throw new Error(...) (no .code) → now throws {    
  code: 'NOT_FOUND' }. Also added { code: 'VALIDATION_ERROR' } to the "wrong   
  state" branch, so retrying a non-failed job returns 400 instead of 500.      
  - removeJob: same as retryJobImmediately — plain Error → { code: 'NOT_FOUND' 
  }.                                                                           
                                                                               
  `backend/src/controllers/retryQueueController.js` — full rewrite             
                                                                               
  - Removed the local wrap() helper entirely.                                  
  - All handlers now use asyncHandler from errorHandler.js, which calls        
  next(err) on failure and lets globalErrorHandler pick the status from        
  ERROR_STATUS_MAP.                                                            
  - queueTransaction's inline 400 branch now throws { code: 'VALIDATION_ERROR' 
  } through the same path rather than responding directly.                     
  - getHealth now also goes through asyncHandler — it was the only handler that
  had its own inline try/catch outside of wrap().                              
                                                                               
  The result: GET /api/admin/retry-queue/jobs/:jobId for a nonexistent job now 
  returns 404, POST .../manualRetry and DELETE .../deleteJob for a missing job 
  ID return 404, and a retry attempt on a non-failed job returns 400 — all     
  consistent with every other resource-lookup endpoint in the codebase.